### PR TITLE
STS cross-account access

### DIFF
--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -100,7 +100,7 @@ class AwsLimitChecker(object):
         self.account_role = account_role
         self.region = region
         self.services = {}
-        self.ta = TrustedAdvisor()
+        self.ta = TrustedAdvisor(account_id=self.account_id, account_role=self.account_role, region=self.region)
         for sname, cls in _services.items():
             self.services[sname] = cls(warning_threshold, critical_threshold,
                                        account_id, account_role, region)

--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -48,7 +48,8 @@ logger = logging.getLogger(__name__)
 
 class AwsLimitChecker(object):
 
-    def __init__(self, warning_threshold=80, critical_threshold=99, account_id=None, account_role=None, region=None):
+    def __init__(self, warning_threshold=80, critical_threshold=99,
+                 account_id=None, account_role=None, region=None):
         """
         Main AwsLimitChecker class - this should be the only externally-used
         portion of awslimitchecker.
@@ -101,7 +102,8 @@ class AwsLimitChecker(object):
         self.services = {}
         self.ta = TrustedAdvisor()
         for sname, cls in _services.items():
-            self.services[sname] = cls(warning_threshold, critical_threshold, account_id, account_role, region)
+            self.services[sname] = cls(warning_threshold, critical_threshold,
+                                       account_id, account_role, region)
 
     def get_version(self):
         """

--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 class AwsLimitChecker(object):
 
-    def __init__(self, warning_threshold=80, critical_threshold=99):
+    def __init__(self, warning_threshold=80, critical_threshold=99, account_id=None, account_role=None, region=None):
         """
         Main AwsLimitChecker class - this should be the only externally-used
         portion of awslimitchecker.
@@ -65,6 +65,10 @@ class AwsLimitChecker(object):
           integer percentage, for any limits without a specifically-set
           threshold.
         :type critical_threshold: int
+        :param account_id: connect via STS to this AWS account
+        :type account_id: str
+        :param account_role: connect via STS as this IAM role
+        :type account_role: str
         """
         # ###### IMPORTANT license notice ##########
         # Pursuant to Sections 5(b) and 13 of the GNU Affero General Public
@@ -91,10 +95,13 @@ class AwsLimitChecker(object):
         )
         self.warning_threshold = warning_threshold
         self.critical_threshold = critical_threshold
+        self.account_id = account_id
+        self.account_role = account_role
+        self.region = region
         self.services = {}
         self.ta = TrustedAdvisor()
         for sname, cls in _services.items():
-            self.services[sname] = cls(warning_threshold, critical_threshold)
+            self.services[sname] = cls(warning_threshold, critical_threshold, account_id, account_role, region)
 
     def get_version(self):
         """

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -128,12 +128,15 @@ class Runner(object):
                        type=int, default=99,
                        help='default critical threshold (percentage of '
                        'limit); default: 99')
-        p.add_argument('-A', '--sts-account-id', action='store', type=str,
-                       default=None)
-        p.add_argument('-R', '--sts-account-role', action='store', type=str,
-                       default=None)
-        p.add_argument('-r', '--region', action='store', type=str,
-                       default=None)
+        p.add_argument('-A', '--sts-account-id', action='store',
+                       type=str, default=None,
+                       help='the AWS account to control')
+        p.add_argument('-R', '--sts-account-role', action='store',
+                       type=str, default=None,
+                       help='the IAM role to assume')
+        p.add_argument('-r', '--region', action='store',
+                       type=str, default=None,
+                       help='connect to this AWS region; required for STS')
         p.add_argument('--skip-ta', action='store_true', default=False,
                        help='do not attempt to pull *any* information on limits'
                        ' from Trusted Advisor')

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -128,6 +128,12 @@ class Runner(object):
                        type=int, default=99,
                        help='default critical threshold (percentage of '
                        'limit); default: 99')
+        p.add_argument('-A', '--sts-account-id', action='store', type=str,
+                       default=None)
+        p.add_argument('-R', '--sts-account-role', action='store', type=str,
+                       default=None)
+        p.add_argument('-r', '--region', action='store', type=str,
+                       default=None)
         p.add_argument('--skip-ta', action='store_true', default=False,
                        help='do not attempt to pull *any* information on limits'
                        ' from Trusted Advisor')
@@ -281,7 +287,10 @@ class Runner(object):
         # the rest of these actually use the checker
         self.checker = AwsLimitChecker(
             warning_threshold=args.warning_threshold,
-            critical_threshold=args.critical_threshold
+            critical_threshold=args.critical_threshold,
+            account_id=args.sts_account_id,
+            account_role=args.sts_account_role,
+            region=args.region
         )
 
         if args.version:

--- a/awslimitchecker/services/autoscaling.py
+++ b/awslimitchecker/services/autoscaling.py
@@ -53,9 +53,7 @@ class _AutoscalingService(_AwsService):
     service_name = 'AutoScaling'
 
     def connect(self):
-        """
-        Connect to API if not already connected; set self.conn.
-        """
+        """Connect to API if not already connected; set self.conn."""
         if self.conn is not None:
             return
         elif self.region:

--- a/awslimitchecker/services/autoscaling.py
+++ b/awslimitchecker/services/autoscaling.py
@@ -57,7 +57,7 @@ class _AutoscalingService(_AwsService):
         if self.conn is not None:
             return
         elif self.region:
-            self.conn = self.connect_via(boto.ec2.autoscale)
+            self.conn = self.connect_via(boto.ec2.autoscale.connect_to_region)
         else:
             self.conn = boto.connect_autoscale()
 

--- a/awslimitchecker/services/autoscaling.py
+++ b/awslimitchecker/services/autoscaling.py
@@ -39,6 +39,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 
 import abc  # noqa
 import boto
+import boto.ec2.autoscale
 import logging
 
 from .base import _AwsService
@@ -52,11 +53,15 @@ class _AutoscalingService(_AwsService):
     service_name = 'AutoScaling'
 
     def connect(self):
-        """connect to API if not already connected; set self.conn"""
-        if self.conn is None:
-            logger.debug("Connecting to %s", self.service_name)
+        """
+        Connect to API if not already connected; set self.conn.
+        """
+        if self.conn is not None:
+            return
+        elif self.region:
+            self.conn = self.connect_via(boto.ec2.autoscale)
+        else:
             self.conn = boto.connect_autoscale()
-            logger.info("Connected to %s", self.service_name)
 
     def find_usage(self):
         """

--- a/awslimitchecker/services/base.py
+++ b/awslimitchecker/services/base.py
@@ -150,6 +150,9 @@ class _AwsService(object):
         """
         Connect to API if not already connected; set self.conn.
         Use STS to assume a role as another user if self.account_id has been set.
+
+        :param driver: the Boto sub-module to use to call connect_to_region() 
+        :type driver: module
         """
         if(self.account_id):
             logger.debug("Connecting to %s for account %s", self.service_name, self.account_id)

--- a/awslimitchecker/services/base.py
+++ b/awslimitchecker/services/base.py
@@ -153,14 +153,15 @@ class _AwsService(object):
         Connect to API if not already connected; set self.conn
         Use STS to assume a role as another user if self.account_id has been set
 
-        :param driver: the Boto sub-module to use to call connect_to_region()
-        :type driver: module
+        :param driver: the connect_to_region() function of the boto
+          submodule to use to create this connection
+        :type driver: function
         """
         if(self.account_id):
             logger.debug("Connecting to %s for account %s", self.service_name,
                          self.account_id)
             self.credentials = self._get_sts_token()
-            conn = driver.connect_to_region(
+            conn = driver(
                 self.region,
                 aws_access_key_id=self.credentials.access_key,
                 aws_secret_access_key=self.credentials.secret_key,

--- a/awslimitchecker/services/base.py
+++ b/awslimitchecker/services/base.py
@@ -172,9 +172,7 @@ class _AwsService(object):
         return conn
 
     def _get_sts_token(self):
-        """
-        Attempt to get STS token, exit if fail.
-        """
+        """Attempt to get STS token, exit if fail."""
         sts = boto.sts.connect_to_region(self.region)
         arn = "arn:aws:iam::%s:role/%s" % (self.account_id, self.account_role)
         role = sts.assume_role(arn, "awslimitchecker")

--- a/awslimitchecker/services/base.py
+++ b/awslimitchecker/services/base.py
@@ -49,7 +49,8 @@ class _AwsService(object):
 
     service_name = 'baseclass'
 
-    def __init__(self, warning_threshold, critical_threshold, account_id=None, account_role=None, region=None):
+    def __init__(self, warning_threshold, critical_threshold, account_id=None,
+                 account_role=None, region=None):
         """
         Describes an AWS service and its limits, and provides methods to
         query current utilization.
@@ -149,20 +150,21 @@ class _AwsService(object):
 
     def connect_via(self, driver):
         """
-        Connect to API if not already connected; set self.conn.
-        Use STS to assume a role as another user if self.account_id has been set.
+        Connect to API if not already connected; set self.conn
+        Use STS to assume a role as another user if self.account_id has been set
 
         :param driver: the Boto sub-module to use to call connect_to_region()
         :type driver: module
         """
         if(self.account_id):
-            logger.debug("Connecting to %s for account %s", self.service_name, self.account_id)
+            logger.debug("Connecting to %s for account %s", self.service_name,
+                         self.account_id)
             self.credentials = self._get_sts_token()
-            conn = driver.connect_to_region(self.region,
-                aws_access_key_id = self.credentials.access_key,
-                aws_secret_access_key = self.credentials.secret_key,
-                security_token = self.credentials.session_token
-            )
+            conn = driver.connect_to_region(
+                self.region,
+                aws_access_key_id=self.credentials.access_key,
+                aws_secret_access_key=self.credentials.secret_key,
+                security_token=self.credentials.session_token)
         else:
             logger.debug("Connecting to %s", self.service_name)
             conn = driver.connect_to_region(self.region)

--- a/awslimitchecker/services/base.py
+++ b/awslimitchecker/services/base.py
@@ -39,9 +39,10 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 
 import abc
 import logging
+import boto.sts
+
 logger = logging.getLogger(__name__)
 
-import boto.sts
 
 class _AwsService(object):
     __metaclass__ = abc.ABCMeta
@@ -145,13 +146,13 @@ class _AwsService(object):
         :rtype: list
         """
         raise NotImplementedError('abstract base class')
-    
+
     def connect_via(self, driver):
         """
         Connect to API if not already connected; set self.conn.
         Use STS to assume a role as another user if self.account_id has been set.
 
-        :param driver: the Boto sub-module to use to call connect_to_region() 
+        :param driver: the Boto sub-module to use to call connect_to_region()
         :type driver: module
         """
         if(self.account_id):
@@ -167,7 +168,7 @@ class _AwsService(object):
             conn = driver.connect_to_region(self.region)
         logger.info("Connected to %s", self.service_name)
         return conn
-    
+
     def _get_sts_token(self):
         """
         Attempt to get STS token, exit if fail.
@@ -176,7 +177,7 @@ class _AwsService(object):
         arn = "arn:aws:iam::%s:role/%s" % (self.account_id, self.account_role)
         role = sts.assume_role(arn, "awslimitchecker")
         return role.credentials
-    
+
     def set_limit_override(self, limit_name, value, override_ta=True):
         """
         Set a new limit ``value`` for the specified limit, overriding

--- a/awslimitchecker/services/base.py
+++ b/awslimitchecker/services/base.py
@@ -155,7 +155,7 @@ class _AwsService(object):
 
         :param driver: the connect_to_region() function of the boto
           submodule to use to create this connection
-        :type driver: function
+        :type driver: :py:func:
         """
         if(self.account_id):
             logger.debug("Connecting to %s for account %s", self.service_name,

--- a/awslimitchecker/services/ebs.py
+++ b/awslimitchecker/services/ebs.py
@@ -39,6 +39,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 
 import abc  # noqa
 import boto
+import boto.ec2
 import logging
 from .base import _AwsService
 from ..limit import AwsLimit
@@ -50,11 +51,15 @@ class _EbsService(_AwsService):
     service_name = 'EBS'
 
     def connect(self):
-        """connect to API if not already connected; set self.conn"""
-        if self.conn is None:
-            logger.debug("Connecting to %s", self.service_name)
+        """
+        Connect to API if not already connected; set self.conn.
+        """
+        if self.conn is not None:
+            return
+        elif self.region:
+            self.conn = self.connect_via(boto.ec2)
+        else:
             self.conn = boto.connect_ec2()
-            logger.info("Connected to %s", self.service_name)
 
     def find_usage(self):
         """

--- a/awslimitchecker/services/ebs.py
+++ b/awslimitchecker/services/ebs.py
@@ -51,9 +51,7 @@ class _EbsService(_AwsService):
     service_name = 'EBS'
 
     def connect(self):
-        """
-        Connect to API if not already connected; set self.conn.
-        """
+        """Connect to API if not already connected; set self.conn."""
         if self.conn is not None:
             return
         elif self.region:

--- a/awslimitchecker/services/ebs.py
+++ b/awslimitchecker/services/ebs.py
@@ -55,7 +55,7 @@ class _EbsService(_AwsService):
         if self.conn is not None:
             return
         elif self.region:
-            self.conn = self.connect_via(boto.ec2)
+            self.conn = self.connect_via(boto.ec2.connect_to_region)
         else:
             self.conn = boto.connect_ec2()
 

--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -57,7 +57,7 @@ class _Ec2Service(_AwsService):
         if self.conn is not None:
             return
         elif self.region:
-            self.conn = self.connect_via(boto.ec2)
+            self.conn = self.connect_via(boto.ec2.connect_to_region)
         else:
             self.conn = boto.connect_ec2()
 

--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -53,9 +53,7 @@ class _Ec2Service(_AwsService):
     service_name = 'EC2'
 
     def connect(self):
-        """
-        Connect to API if not already connected; set self.conn.
-        """
+        """Connect to API if not already connected; set self.conn."""
         if self.conn is not None:
             return
         elif self.region:

--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -39,6 +39,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 
 import abc  # noqa
 import boto
+import boto.ec2
 import logging
 from collections import defaultdict
 from copy import deepcopy
@@ -52,11 +53,15 @@ class _Ec2Service(_AwsService):
     service_name = 'EC2'
 
     def connect(self):
-        """connect to API if not already connected; set self.conn"""
-        if self.conn is None:
-            logger.debug("Connecting to %s", self.service_name)
+        """
+        Connect to API if not already connected; set self.conn.
+        """
+        if self.conn is not None:
+            return
+        elif self.region:
+            self.conn = self.connect_via(boto.ec2)
+        else:
             self.conn = boto.connect_ec2()
-            logger.info("Connected to %s", self.service_name)
 
     def find_usage(self):
         """

--- a/awslimitchecker/services/elasticache.py
+++ b/awslimitchecker/services/elasticache.py
@@ -38,6 +38,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 """
 
 import abc  # noqa
+import boto.elasticache
 from boto.elasticache.layer1 import ElastiCacheConnection
 from boto.exception import BotoServerError
 import logging
@@ -53,10 +54,15 @@ class _ElastiCacheService(_AwsService):
     service_name = 'ElastiCache'
 
     def connect(self):
-        if self.conn is None:
-            logger.debug("Connecting to %s", self.service_name)
+        """
+        Connect to API if not already connected; set self.conn.
+        """
+        if self.conn is not None:
+            return
+        elif self.region:
+            self.conn = self.connect_via(boto.elasticache)
+        else:
             self.conn = ElastiCacheConnection()
-            logger.info("Connected to %s", self.service_name)
 
     def find_usage(self):
         """

--- a/awslimitchecker/services/elasticache.py
+++ b/awslimitchecker/services/elasticache.py
@@ -54,9 +54,7 @@ class _ElastiCacheService(_AwsService):
     service_name = 'ElastiCache'
 
     def connect(self):
-        """
-        Connect to API if not already connected; set self.conn.
-        """
+        """Connect to API if not already connected; set self.conn."""
         if self.conn is not None:
             return
         elif self.region:

--- a/awslimitchecker/services/elasticache.py
+++ b/awslimitchecker/services/elasticache.py
@@ -58,7 +58,7 @@ class _ElastiCacheService(_AwsService):
         if self.conn is not None:
             return
         elif self.region:
-            self.conn = self.connect_via(boto.elasticache)
+            self.conn = self.connect_via(boto.elasticache.connect_to_region)
         else:
             self.conn = ElastiCacheConnection()
 

--- a/awslimitchecker/services/elb.py
+++ b/awslimitchecker/services/elb.py
@@ -53,9 +53,7 @@ class _ElbService(_AwsService):
     service_name = 'ELB'
 
     def connect(self):
-        """
-        Connect to API if not already connected; set self.conn.
-        """
+        """Connect to API if not already connected; set self.conn."""
         if self.conn is not None:
             return
         elif self.region:

--- a/awslimitchecker/services/elb.py
+++ b/awslimitchecker/services/elb.py
@@ -39,6 +39,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 
 import abc  # noqa
 import boto
+import boto.ec2.elb
 import logging
 
 from .base import _AwsService
@@ -52,10 +53,15 @@ class _ElbService(_AwsService):
     service_name = 'ELB'
 
     def connect(self):
-        if self.conn is None:
-            logger.debug("Connecting to %s", self.service_name)
+        """
+        Connect to API if not already connected; set self.conn.
+        """
+        if self.conn is not None:
+            return
+        elif self.region:
+            self.conn = self.connect_via(boto.ec2.elb)
+        else:
             self.conn = boto.connect_elb()
-            logger.info("Connected to %s", self.service_name)
 
     def find_usage(self):
         """

--- a/awslimitchecker/services/elb.py
+++ b/awslimitchecker/services/elb.py
@@ -57,7 +57,7 @@ class _ElbService(_AwsService):
         if self.conn is not None:
             return
         elif self.region:
-            self.conn = self.connect_via(boto.ec2.elb)
+            self.conn = self.connect_via(boto.ec2.elb.connect_to_region)
         else:
             self.conn = boto.connect_elb()
 

--- a/awslimitchecker/services/newservice.py.example
+++ b/awslimitchecker/services/newservice.py.example
@@ -58,7 +58,7 @@ class _XXNewServiceXXService(_AwsService):
         # TODO: set this to the correct connection methods:
         elif self.region:
             import boto.XXnewserviceXX
-            self.conn = self.connect_via(boto.XXnewserviceXX)
+            self.conn = self.connect_via(boto.XXnewserviceXX.connect_to_region)
         else:
             self.conn = boto.connect_XXnewserviceXX()
 

--- a/awslimitchecker/services/newservice.py.example
+++ b/awslimitchecker/services/newservice.py.example
@@ -52,11 +52,17 @@ class _XXNewServiceXXService(_AwsService):
     service_name = 'XXNewServiceXX'
 
     def connect(self):
-        if self.conn is None:
-            logger.debug("Connecting to %s", self.service_name)
-            # TODO: set this to the correct connection method:
+        """
+        Connect to API if not already connected; set self.conn.
+        """
+        if self.conn is not None:
+            return
+        # TODO: set this to the correct connection methods:
+        elif self.region:
+            import boto.XXnewserviceXX
+            self.conn = self.connect_via(boto.XXnewserviceXX)
+        else:
             self.conn = boto.connect_XXnewserviceXX()
-            logger.info("Connected to %s", self.service_name)
 
     def find_usage(self):
         """

--- a/awslimitchecker/services/newservice.py.example
+++ b/awslimitchecker/services/newservice.py.example
@@ -52,9 +52,7 @@ class _XXNewServiceXXService(_AwsService):
     service_name = 'XXNewServiceXX'
 
     def connect(self):
-        """
-        Connect to API if not already connected; set self.conn.
-        """
+        """Connect to API if not already connected; set self.conn."""
         if self.conn is not None:
             return
         # TODO: set this to the correct connection methods:

--- a/awslimitchecker/services/rds.py
+++ b/awslimitchecker/services/rds.py
@@ -53,9 +53,7 @@ class _RDSService(_AwsService):
     service_name = 'RDS'
 
     def connect(self):
-        """
-        Connect to API if not already connected; set self.conn.
-        """
+        """Connect to API if not already connected; set self.conn."""
         if self.conn is not None:
             return
         elif self.region:

--- a/awslimitchecker/services/rds.py
+++ b/awslimitchecker/services/rds.py
@@ -57,7 +57,7 @@ class _RDSService(_AwsService):
         if self.conn is not None:
             return
         elif self.region:
-            self.conn = self.connect_via(boto.rds2)
+            self.conn = self.connect_via(boto.rds2.connect_to_region)
         else:
             self.conn = boto.connect_rds2()
 

--- a/awslimitchecker/services/rds.py
+++ b/awslimitchecker/services/rds.py
@@ -39,6 +39,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 
 import abc  # noqa
 import boto
+import boto.rds2
 import logging
 
 from .base import _AwsService
@@ -52,11 +53,15 @@ class _RDSService(_AwsService):
     service_name = 'RDS'
 
     def connect(self):
-        if self.conn is None:
-            logger.debug("Connecting to %s", self.service_name)
-            # TODO: set this to the correct connection method:
+        """
+        Connect to API if not already connected; set self.conn.
+        """
+        if self.conn is not None:
+            return
+        elif self.region:
+            self.conn = self.connect_via(boto.rds2)
+        else:
             self.conn = boto.connect_rds2()
-            logger.info("Connected to %s", self.service_name)
 
     def find_usage(self):
         """

--- a/awslimitchecker/services/vpc.py
+++ b/awslimitchecker/services/vpc.py
@@ -54,9 +54,7 @@ class _VpcService(_AwsService):
     service_name = 'VPC'
 
     def connect(self):
-        """
-        Connect to API if not already connected; set self.conn.
-        """
+        """Connect to API if not already connected; set self.conn."""
         if self.conn is not None:
             return
         elif self.region:

--- a/awslimitchecker/services/vpc.py
+++ b/awslimitchecker/services/vpc.py
@@ -58,7 +58,7 @@ class _VpcService(_AwsService):
         if self.conn is not None:
             return
         elif self.region:
-            self.conn = self.connect_via(boto.vpc)
+            self.conn = self.connect_via(boto.vpc.connect_to_region)
         else:
             self.conn = boto.connect_vpc()
 

--- a/awslimitchecker/services/vpc.py
+++ b/awslimitchecker/services/vpc.py
@@ -39,6 +39,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 
 import abc  # noqa
 import boto
+import boto.vpc
 import logging
 from collections import defaultdict
 
@@ -53,11 +54,15 @@ class _VpcService(_AwsService):
     service_name = 'VPC'
 
     def connect(self):
-        """connect to API if not already connected; set self.conn"""
-        if self.conn is None:
-            logger.debug("Connecting to %s", self.service_name)
+        """
+        Connect to API if not already connected; set self.conn.
+        """
+        if self.conn is not None:
+            return
+        elif self.region:
+            self.conn = self.connect_via(boto.vpc)
+        else:
             self.conn = boto.connect_vpc()
-            logger.info("Connected to %s", self.service_name)
 
     def find_usage(self):
         """

--- a/awslimitchecker/tests/test_checker.py
+++ b/awslimitchecker/tests/test_checker.py
@@ -99,8 +99,8 @@ class TestAwsLimitChecker(object):
             'SvcBar': self.mock_svc2
         }
         # _AwsService instances should exist, but have no other calls
-        assert self.mock_foo.mock_calls == [call(80, 99)]
-        assert self.mock_bar.mock_calls == [call(80, 99)]
+        assert self.mock_foo.mock_calls == [call(80, 99, None, None, None)]
+        assert self.mock_bar.mock_calls == [call(80, 99, None, None, None)]
         assert self.mock_svc1.mock_calls == []
         assert self.mock_svc2.mock_calls == []
         assert self.cls.ta == self.mock_ta
@@ -151,8 +151,8 @@ class TestAwsLimitChecker(object):
             'SvcBar': mock_svc2
         }
         # _AwsService instances should exist, but have no other calls
-        assert mock_foo.mock_calls == [call(5, 22)]
-        assert mock_bar.mock_calls == [call(5, 22)]
+        assert mock_foo.mock_calls == [call(5, 22, None, None, None)]
+        assert mock_bar.mock_calls == [call(5, 22, None, None, None)]
         assert mock_svc1.mock_calls == []
         assert mock_svc2.mock_calls == []
         assert self.mock_version.mock_calls == [call()]

--- a/awslimitchecker/tests/test_runner.py
+++ b/awslimitchecker/tests/test_runner.py
@@ -157,6 +157,15 @@ class TestAwsLimitCheckerRunner(object):
                                 type=int, default=99,
                                 help='default critical threshold (percentage '
                                 'of limit); default: 99'),
+            call().add_argument('-A', '--sts-account-id', action='store',
+                                type=str, default=None,
+                                help='the AWS account to control'),
+            call().add_argument('-R', '--sts-account-role', action='store',
+                                type=str, default=None,
+                                help='the IAM role to assume'),
+            call().add_argument('-r', '--region', action='store',
+                                type=str, default=None,
+                                help='connect to this AWS region; required for STS'),
             call().add_argument('--skip-ta', action='store_true', default=False,
                                 help='do not attempt to pull *any* information '
                                 'on limits from Trusted Advisor'),
@@ -192,6 +201,9 @@ class TestAwsLimitCheckerRunner(object):
             call(
                 warning_threshold=80,
                 critical_threshold=99,
+                account_id=None,
+                account_role=None,
+                region=None
             ),
             call().get_project_url(),
             call().get_version()
@@ -560,7 +572,7 @@ class TestAwsLimitCheckerRunner(object):
                         self.cls.console_entry_point()
         assert excinfo.value.code == 8
         assert mock_alc.mock_calls == [
-            call(warning_threshold=50, critical_threshold=99)
+            call(warning_threshold=50, critical_threshold=99, account_id=None, account_role=None, region=None)
         ]
 
     def test_entry_critical(self):
@@ -574,7 +586,7 @@ class TestAwsLimitCheckerRunner(object):
                         self.cls.console_entry_point()
         assert excinfo.value.code == 9
         assert mock_alc.mock_calls == [
-            call(warning_threshold=80, critical_threshold=95)
+            call(warning_threshold=80, critical_threshold=95, account_id=None, account_role=None, region=None)
         ]
 
     def test_entry_check_thresholds(self):

--- a/awslimitchecker/tests/test_runner.py
+++ b/awslimitchecker/tests/test_runner.py
@@ -165,7 +165,8 @@ class TestAwsLimitCheckerRunner(object):
                                 help='the IAM role to assume'),
             call().add_argument('-r', '--region', action='store',
                                 type=str, default=None,
-                                help='connect to this AWS region; required for STS'),
+                                help='connect to this AWS region; '
+                                'required for STS'),
             call().add_argument('--skip-ta', action='store_true', default=False,
                                 help='do not attempt to pull *any* information '
                                 'on limits from Trusted Advisor'),
@@ -572,7 +573,8 @@ class TestAwsLimitCheckerRunner(object):
                         self.cls.console_entry_point()
         assert excinfo.value.code == 8
         assert mock_alc.mock_calls == [
-            call(warning_threshold=50, critical_threshold=99, account_id=None, account_role=None, region=None)
+            call(warning_threshold=50, critical_threshold=99, account_id=None,
+                 account_role=None, region=None)
         ]
 
     def test_entry_critical(self):
@@ -586,7 +588,8 @@ class TestAwsLimitCheckerRunner(object):
                         self.cls.console_entry_point()
         assert excinfo.value.code == 9
         assert mock_alc.mock_calls == [
-            call(warning_threshold=80, critical_threshold=95, account_id=None, account_role=None, region=None)
+            call(warning_threshold=80, critical_threshold=95, account_id=None,
+                 account_role=None, region=None)
         ]
 
     def test_entry_check_thresholds(self):


### PR DESCRIPTION
At [Logicworks](http://logicworks.net) we had a crucial need to look up service limits across many different client accounts, and this tool was the perfect fit. The only thing missing was a more practical way to query multiple accounts than specifying access keys via environment variables.

I was able to fairly trivially implement [STS AssumeRole](http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) support, allowing you to setup your environment variables with a IAM user [that has `sts:AssumeRole` privileges](http://docs.aws.amazon.com/IAM/latest/UserGuide/roles-usingrole-configuringuser.html). The primary change was a switch to using the `connect_to_region()` function to connect to the API, which accepts the access keys and security token you get from STS.

To use this in code, you should already have created an IAM account with `sts:AssumeRole`, and set your environment up up using the normal methods (env variables, config file, what have you). Then you simply pass the `region`, an `account_id` ([a 12 digit string](http://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html)), and `account_role`, the name of an IAM Role defined in the destination account. Alternatively, you can use the new `-r`, `-A` and `-R` flags to pass those things in at the CLI.

I fixed the tests it broke, but I haven't yet been able to write any tests. I'm not entirely sure how. All that has changed is a line or two in the connect() methods, and there has been the addition of two methods to the _AwsService base class, `connect_via()` and `_get_sts_token()`, but I'm not clear how to add tests for them without requiring use of an actual AWS account.

This is a pretty useful patch, though, so I wanted to at least make it available.
