### PR TITLE
Fixes #73

### DIFF
--- a/awslimitchecker/tests/test_versioncheck.py
+++ b/awslimitchecker/tests/test_versioncheck.py
@@ -502,7 +502,10 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = True
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'git+https://foo',
@@ -513,6 +516,7 @@ class Test_AGPLVersionChecker(object):
         assert mocks['_find_git_info'].mock_calls == [call(cls)]
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_git_notag_dirty(self):
         cls = AGPLVersionChecker()
@@ -537,7 +541,10 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = True
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'git+https://foo',
@@ -548,6 +555,7 @@ class Test_AGPLVersionChecker(object):
         assert mocks['_find_git_info'].mock_calls == [call(cls)]
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_git_tag(self):
         cls = AGPLVersionChecker()
@@ -572,7 +580,10 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = True
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'git+https://foo',
@@ -583,6 +594,7 @@ class Test_AGPLVersionChecker(object):
         assert mocks['_find_git_info'].mock_calls == [call(cls)]
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_git_tag_dirty(self):
         cls = AGPLVersionChecker()
@@ -607,7 +619,10 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = True
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'git+https://foo',
@@ -618,6 +633,7 @@ class Test_AGPLVersionChecker(object):
         assert mocks['_find_git_info'].mock_calls == [call(cls)]
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_pkg_res_exception(self):
         cls = AGPLVersionChecker()
@@ -643,7 +659,10 @@ class Test_AGPLVersionChecker(object):
                 'url': 'http://my.package.url/pip'
             }
             mocks['_find_pkg_info'].side_effect = se_exception
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = False
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'git+https://foo',
@@ -651,9 +670,10 @@ class Test_AGPLVersionChecker(object):
             'commit': '12345678',
             'dirty': False,
         }
-        assert mocks['_find_git_info'].mock_calls == [call(cls)]
+        assert mocks['_find_git_info'].mock_calls == []
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_pip_exception(self):
         cls = AGPLVersionChecker()
@@ -679,7 +699,10 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = False
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'git+https://foo',
@@ -690,6 +713,7 @@ class Test_AGPLVersionChecker(object):
         assert mocks['_find_git_info'].mock_calls == [call(cls)]
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_no_git(self):
         cls = AGPLVersionChecker()
@@ -715,16 +739,20 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = False
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'http://my.package.url/pip',
             'tag': None,
             'commit': None,
         }
-        assert mocks['_find_git_info'].mock_calls == [call(cls)]
+        assert mocks['_find_git_info'].mock_calls == []
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_no_git_no_pip(self):
         cls = AGPLVersionChecker()
@@ -750,16 +778,20 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = False
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'http://my.package.url/pkg_resources',
             'tag': None,
             'commit': None,
         }
-        assert mocks['_find_git_info'].mock_calls == [call(cls)]
+        assert mocks['_find_git_info'].mock_calls == []
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_debug(self):
         mock_pip_logger = Mock(spec_set=logging.Logger)
@@ -792,13 +824,13 @@ class Test_AGPLVersionChecker(object):
                     with patch('%s.logger' % self.mpb,
                                spec_set=logging.Logger) as mock_mod_logger:
                         mock_logging.getLogger.return_value = mock_pip_logger
-                        cls.find_package_version()
+                        with patch('%s._is_git_clone' % self.pb,
+                                   new_callable=PropertyMock) as mock_is_git:
+                            mock_is_git.return_value = False
+                            cls.find_package_version()
         assert mock_logging.mock_calls == []
         assert mock_pip_logger.mock_calls == []
         assert mock_mod_logger.mock_calls == [
-            call.debug('Git info: %s',
-                       {'url': None, 'commit': None, 'tag': None,
-                        'dirty': None}),
             call.debug('pip info: %s', {'url': 'http://my.package.url/pip',
                                         'version': '1.2.3'}),
             call.debug('pkg_resources info: %s',
@@ -808,6 +840,7 @@ class Test_AGPLVersionChecker(object):
                        {'url': 'http://my.package.url/pip', 'commit': None,
                         'version': '1.2.3', 'tag': None})
         ]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_no_debug(self):
         mock_pip_logger = Mock()
@@ -841,7 +874,10 @@ class Test_AGPLVersionChecker(object):
                     }
                     with patch('%s.logger' % self.mpb,
                                spec_set=logging.Logger) as mock_mod_logger:
-                        cls.find_package_version()
+                        with patch('%s._is_git_clone' % self.pb,
+                                   new_callable=PropertyMock) as mock_is_git:
+                            mock_is_git.return_value = False
+                            cls.find_package_version()
         assert mock_logging.mock_calls == [
             call.getLogger("pip"),
             call.getLogger().setLevel(mock_logging.WARNING)
@@ -851,9 +887,6 @@ class Test_AGPLVersionChecker(object):
         ]
         assert mock_mod_logger.mock_calls == [
             call.setLevel(mock_logging.WARNING),
-            call.debug('Git info: %s',
-                       {'url': None, 'commit': None, 'tag': None,
-                        'dirty': None}),
             call.debug('pip info: %s', {'url': 'http://my.package.url/pip',
                                         'version': '1.2.3'}),
             call.debug('pkg_resources info: %s',
@@ -863,6 +896,7 @@ class Test_AGPLVersionChecker(object):
                        {'url': 'http://my.package.url/pip', 'commit': None,
                         'version': '1.2.3', 'tag': None})
         ]
+        assert mock_is_git.mock_calls == [call()]
 
 
 class Test_VersionCheck_Funcs(object):

--- a/awslimitchecker/tests/test_versioncheck.py
+++ b/awslimitchecker/tests/test_versioncheck.py
@@ -1171,8 +1171,8 @@ class Test_AGPLVersionChecker_Acceptance(object):
         except subprocess.CalledProcessError:
             pass
 
-    def _set_git_config(self):
-        if os.environ.get('TRAVIS', '') != 'true':
+    def _set_git_config(self, set_in_travis=False):
+        if not set_in_travis and os.environ.get('TRAVIS', '') != 'true':
             print("not running in Travis; not setting git config")
             return
         try:
@@ -1647,7 +1647,8 @@ class Test_AGPLVersionChecker_Acceptance(object):
         """regression test for issue #73"""
         path = str(tmpdir)
         # setup a git repo in tmpdir
-        repo_commit = self._make_git_repo(path)
+        self._set_git_config(set_in_travis=True)
+        self._make_git_repo(path)
         # make the venv
         self._make_venv(path)
         # build the sdist

--- a/awslimitchecker/tests/test_versioncheck.py
+++ b/awslimitchecker/tests/test_versioncheck.py
@@ -1301,6 +1301,7 @@ class Test_AGPLVersionChecker_Acceptance(object):
             fh.write('foo')
         res = subprocess.call(['git', 'add', 'foo'])
         assert res == 0
+        self._set_git_config(set_in_travis=True)
         res = subprocess.call(['git', 'commit', '-m', 'foo'])
         assert res == 0
         commit = _get_git_commit()
@@ -1647,7 +1648,6 @@ class Test_AGPLVersionChecker_Acceptance(object):
         """regression test for issue #73"""
         path = str(tmpdir)
         # setup a git repo in tmpdir
-        self._set_git_config(set_in_travis=True)
         self._make_git_repo(path)
         # make the venv
         self._make_venv(path)

--- a/awslimitchecker/tests/test_versioncheck.py
+++ b/awslimitchecker/tests/test_versioncheck.py
@@ -61,9 +61,9 @@ if (
         sys.version_info[0] < 3 or
         sys.version_info[0] == 3 and sys.version_info[1] < 4
 ):
-    from mock import patch, call, DEFAULT, Mock
+    from mock import patch, call, DEFAULT, Mock, PropertyMock
 else:
-    from unittest.mock import patch, call, DEFAULT, Mock
+    from unittest.mock import patch, call, DEFAULT, Mock, PropertyMock
 
 
 class Test_AGPLVersionChecker(object):
@@ -661,7 +661,7 @@ class Test_AGPLVersionChecker(object):
             mocks['_find_pkg_info'].side_effect = se_exception
             with patch('%s._is_git_clone' % self.pb,
                        new_callable=PropertyMock) as mock_is_git:
-                mock_is_git.return_value = False
+                mock_is_git.return_value = True
                 res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
@@ -670,7 +670,7 @@ class Test_AGPLVersionChecker(object):
             'commit': '12345678',
             'dirty': False,
         }
-        assert mocks['_find_git_info'].mock_calls == []
+        assert mocks['_find_git_info'].mock_calls == [call(cls)]
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
         assert mock_is_git.mock_calls == [call()]
@@ -701,7 +701,7 @@ class Test_AGPLVersionChecker(object):
             }
             with patch('%s._is_git_clone' % self.pb,
                        new_callable=PropertyMock) as mock_is_git:
-                mock_is_git.return_value = False
+                mock_is_git.return_value = True
                 res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
@@ -831,6 +831,7 @@ class Test_AGPLVersionChecker(object):
         assert mock_logging.mock_calls == []
         assert mock_pip_logger.mock_calls == []
         assert mock_mod_logger.mock_calls == [
+            call.debug('Install does not appear to be a git clone'),
             call.debug('pip info: %s', {'url': 'http://my.package.url/pip',
                                         'version': '1.2.3'}),
             call.debug('pkg_resources info: %s',
@@ -887,6 +888,7 @@ class Test_AGPLVersionChecker(object):
         ]
         assert mock_mod_logger.mock_calls == [
             call.setLevel(mock_logging.WARNING),
+            call.debug('Install does not appear to be a git clone'),
             call.debug('pip info: %s', {'url': 'http://my.package.url/pip',
                                         'version': '1.2.3'}),
             call.debug('pkg_resources info: %s',

--- a/awslimitchecker/tests/test_versioncheck.py
+++ b/awslimitchecker/tests/test_versioncheck.py
@@ -900,6 +900,42 @@ class Test_AGPLVersionChecker(object):
         ]
         assert mock_is_git.mock_calls == [call()]
 
+    def test_is_git_clone_true(self):
+        foo_path = '/foo/bar/awslimitchecker/awslimitchecker/versioncheck.pyc'
+
+        with patch.multiple(
+                '%s.os.path' % self.mpb,
+                abspath=DEFAULT,
+                exists=DEFAULT,
+        ) as mocks:
+            mocks['abspath'].return_value = foo_path
+            mocks['exists'].return_value = True
+            cls = AGPLVersionChecker()
+            res = cls._is_git_clone
+        assert res is True
+        assert mocks['abspath'].call_count == 1
+        assert mocks['exists'].mock_calls == [
+            call('/foo/bar/awslimitchecker/.git')
+        ]
+
+    def test_is_git_clone_false(self):
+        foo_path = '/foo/bar/awslimitchecker/awslimitchecker/versioncheck.pyc'
+
+        with patch.multiple(
+                '%s.os.path' % self.mpb,
+                abspath=DEFAULT,
+                exists=DEFAULT,
+        ) as mocks:
+            mocks['abspath'].return_value = foo_path
+            mocks['exists'].return_value = False
+            cls = AGPLVersionChecker()
+            res = cls._is_git_clone
+        assert res is False
+        assert mocks['abspath'].call_count == 1
+        assert mocks['exists'].mock_calls == [
+            call('/foo/bar/awslimitchecker/.git')
+        ]
+
 
 class Test_VersionCheck_Funcs(object):
     """

--- a/awslimitchecker/versioncheck.py
+++ b/awslimitchecker/versioncheck.py
@@ -104,15 +104,18 @@ class AGPLVersionChecker(object):
             'tag': None,
             'commit': None
         }
-        git_info = self._find_git_info()
-        logger.debug("Git info: %s", git_info)
-        for k, v in git_info.items():
-            if v is not None:
-                res[k] = v
-        if git_info['dirty'] and res['tag'] is not None:
-            res['tag'] += '*'
-        if git_info['dirty'] and res['commit'] is not None:
-            res['commit'] += '*'
+        if self._is_git_clone:
+            git_info = self._find_git_info()
+            logger.debug("Git info: %s", git_info)
+            for k, v in git_info.items():
+                if v is not None:
+                    res[k] = v
+            if git_info['dirty'] and res['tag'] is not None:
+                res['tag'] += '*'
+            if git_info['dirty'] and res['commit'] is not None:
+                res['commit'] += '*'
+        else:
+            logger.debug("Install does not appear to be a git clone")
         try:
             pip_info = self._find_pip_info()
         except Exception:
@@ -134,6 +137,16 @@ class AGPLVersionChecker(object):
             res['url'] = pkg_info['url']
         logger.debug("Final package info: %s", res)
         return res
+
+    @property
+    def is_git_clone(self):
+        """
+        Attempt to determine whether this package is installed via git or not.
+
+        :rtype: bool
+        :returns: True if installed via git, False otherwise
+        """
+        return True
 
     def _find_pkg_info(self):
         """

--- a/awslimitchecker/versioncheck.py
+++ b/awslimitchecker/versioncheck.py
@@ -139,7 +139,7 @@ class AGPLVersionChecker(object):
         return res
 
     @property
-    def is_git_clone(self):
+    def _is_git_clone(self):
         """
         Attempt to determine whether this package is installed via git or not.
 

--- a/awslimitchecker/versioncheck.py
+++ b/awslimitchecker/versioncheck.py
@@ -146,7 +146,14 @@ class AGPLVersionChecker(object):
         :rtype: bool
         :returns: True if installed via git, False otherwise
         """
-        return True
+        distpath = os.path.normpath(
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                '../'
+            )
+        )
+        gitpath = os.path.join(distpath, '.git')
+        return os.path.exists(gitpath)
 
     def _find_pkg_info(self):
         """


### PR DESCRIPTION
This fixes a bug in versioncheck where it would incorrectly report git information if awslimitchecker was installed in a virtualenv within a git clone/repo.