### PR TITLE
Fixes #40 - pagination of API responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ cache:
   directories:
   - "$HOME/.pip-cache/"
 env:
+- TOXENV=py26-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py27-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py32-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py33-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py34-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=pypy-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=pypy3-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
+- TOXENV=py26-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py27-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py32-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py33-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
 - TOXENV=pypy-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=pypy3-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=docs PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
-- TOXENV=cov PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 install:
 - git config --global user.email "travisci@jasonantman.com"
 - git config --global user.name "travisci"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Pre-release (develop branch)
 * Fix `#87 <https://github.com/jantman/awslimitchecker/issues/87>`_ run coverage in all unit test Tox environments, not a dedicated env
 * Fix `#75 <https://github.com/jantman/awslimitchecker/issues/75>`_ re-enable py26 Travis builds now that `pytest-dev/pytest#1035 <https://github.com/pytest-dev/pytest/issues/1035`_ is fixed (pytest >= 2.8.3)
 * Fix `#13 <https://github.com/jantman/awslimitchecker/issues/13>`_ re-enable Sphinx documentation linkcheck
+* Fix `#40 <https://github.com/jantman/awslimitchecker/issues/40>`_ add support for pagination of API responses (to get all results) and handle pagination for all current services
 
 0.1.3 (2015-10-04)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Pre-release (develop branch)
 * Fix `#73 <https://github.com/jantman/awslimitchecker/issues/73>`_ versioncheck.py reports incorrect information when package is installed in a virtualenv inside a git repository
 * Fix `#87 <https://github.com/jantman/awslimitchecker/issues/87>`_ run coverage in all unit test Tox environments, not a dedicated env
 * Fix `#75 <https://github.com/jantman/awslimitchecker/issues/75>`_ re-enable py26 Travis builds now that `pytest-dev/pytest#1035 <https://github.com/pytest-dev/pytest/issues/1035`_ is fixed (pytest >= 2.8.3)
+* Fix `#13 <https://github.com/jantman/awslimitchecker/issues/13>`_ re-enable Sphinx documentation linkcheck
 
 0.1.3 (2015-10-04)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Pre-release (develop branch)
 
 * `#86 <https://github.com/jantman/awslimitchecker/issues/86>`_ wrap all AWS API queries in ``awslimitchecker.utils.boto_query_wrapper`` to retry queries with an exponential backoff when API request throttling/rate limiting is encountered
 * Attempt at fixing `#47 <https://github.com/jantman/awslimitchecker/issues/47>`_ where versioncheck acceptance tests fail under TravisCI, when testing master after a tagged release (when there's a tag for the current commit)
+* Fix `#73 <https://github.com/jantman/awslimitchecker/issues/73>`_ versioncheck.py reports incorrect information when package is installed in a virtualenv inside a git repository
 
 0.1.3 (2015-10-04)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Pre-release (develop branch)
 ----------------------------
 
 * `#86 <https://github.com/jantman/awslimitchecker/issues/86>`_ wrap all AWS API queries in ``awslimitchecker.utils.boto_query_wrapper`` to retry queries with an exponential backoff when API request throttling/rate limiting is encountered
+* Attempt at fixing `#47 <https://github.com/jantman/awslimitchecker/issues/47>`_ where versioncheck acceptance tests fail under TravisCI, when testing master after a tagged release (when there's a tag for the current commit)
 
 0.1.3 (2015-10-04)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 Pre-release (develop branch)
 ----------------------------
 
+* `#86 <https://github.com/jantman/awslimitchecker/issues/86>`_ wrap all AWS API queries in ``awslimitchecker.utils.boto_query_wrapper`` to retry queries with an exponential backoff when API request throttling/rate limiting is encountered
 
 0.1.3 (2015-10-04)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Pre-release (develop branch)
 * `#86 <https://github.com/jantman/awslimitchecker/issues/86>`_ wrap all AWS API queries in ``awslimitchecker.utils.boto_query_wrapper`` to retry queries with an exponential backoff when API request throttling/rate limiting is encountered
 * Attempt at fixing `#47 <https://github.com/jantman/awslimitchecker/issues/47>`_ where versioncheck acceptance tests fail under TravisCI, when testing master after a tagged release (when there's a tag for the current commit)
 * Fix `#73 <https://github.com/jantman/awslimitchecker/issues/73>`_ versioncheck.py reports incorrect information when package is installed in a virtualenv inside a git repository
+* Fix `#87 <https://github.com/jantman/awslimitchecker/issues/87>`_ run coverage in all unit test Tox environments, not a dedicated env
 
 0.1.3 (2015-10-04)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Pre-release (develop branch)
 * Attempt at fixing `#47 <https://github.com/jantman/awslimitchecker/issues/47>`_ where versioncheck acceptance tests fail under TravisCI, when testing master after a tagged release (when there's a tag for the current commit)
 * Fix `#73 <https://github.com/jantman/awslimitchecker/issues/73>`_ versioncheck.py reports incorrect information when package is installed in a virtualenv inside a git repository
 * Fix `#87 <https://github.com/jantman/awslimitchecker/issues/87>`_ run coverage in all unit test Tox environments, not a dedicated env
+* Fix `#75 <https://github.com/jantman/awslimitchecker/issues/75>`_ re-enable py26 Travis builds now that `pytest-dev/pytest#1035 <https://github.com/pytest-dev/pytest/issues/1035`_ is fixed (pytest >= 2.8.3)
 
 0.1.3 (2015-10-04)
 ------------------

--- a/awslimitchecker/services/autoscaling.py
+++ b/awslimitchecker/services/autoscaling.py
@@ -74,12 +74,19 @@ class _AutoscalingService(_AwsService):
             lim._reset_usage()
 
         self.limits['Auto Scaling groups']._add_current_usage(
-            len(boto_query_wrapper(self.conn.get_all_groups)),
+            len(
+                boto_query_wrapper(self.conn.get_all_groups, alc_paginate=True)
+            ),
             aws_type='AWS::AutoScaling::AutoScalingGroup',
         )
 
         self.limits['Launch configurations']._add_current_usage(
-            len(boto_query_wrapper(self.conn.get_all_launch_configurations)),
+            len(
+                boto_query_wrapper(
+                    self.conn.get_all_launch_configurations,
+                    alc_paginate=True
+                )
+            ),
             aws_type='AWS::AutoScaling::LaunchConfiguration',
         )
         self._have_usage = True

--- a/awslimitchecker/services/autoscaling.py
+++ b/awslimitchecker/services/autoscaling.py
@@ -75,7 +75,7 @@ class _AutoscalingService(_AwsService):
 
         self.limits['Auto Scaling groups']._add_current_usage(
             len(
-                boto_query_wrapper(self.conn.get_all_groups, alc_paginate=True)
+                boto_query_wrapper(self.conn.get_all_groups)
             ),
             aws_type='AWS::AutoScaling::AutoScalingGroup',
         )
@@ -83,8 +83,7 @@ class _AutoscalingService(_AwsService):
         self.limits['Launch configurations']._add_current_usage(
             len(
                 boto_query_wrapper(
-                    self.conn.get_all_launch_configurations,
-                    alc_paginate=True
+                    self.conn.get_all_launch_configurations
                 )
             ),
             aws_type='AWS::AutoScaling::LaunchConfiguration',

--- a/awslimitchecker/services/autoscaling.py
+++ b/awslimitchecker/services/autoscaling.py
@@ -44,6 +44,7 @@ import logging
 
 from .base import _AwsService
 from ..limit import AwsLimit
+from ..utils import boto_query_wrapper
 
 logger = logging.getLogger(__name__)
 
@@ -73,12 +74,12 @@ class _AutoscalingService(_AwsService):
             lim._reset_usage()
 
         self.limits['Auto Scaling groups']._add_current_usage(
-            len(self.conn.get_all_groups()),
+            len(boto_query_wrapper(self.conn.get_all_groups)),
             aws_type='AWS::AutoScaling::AutoScalingGroup',
         )
 
         self.limits['Launch configurations']._add_current_usage(
-            len(self.conn.get_all_launch_configurations()),
+            len(boto_query_wrapper(self.conn.get_all_launch_configurations)),
             aws_type='AWS::AutoScaling::LaunchConfiguration',
         )
         self._have_usage = True

--- a/awslimitchecker/services/base.py
+++ b/awslimitchecker/services/base.py
@@ -123,13 +123,15 @@ class _AwsService(Connectable):
         and update the ``current_usage`` property of each corresponding
         :py:class:`~.AwsLimit` instance.
 
-        This method must set ``self._have_usage = True``
+        This method MUST set ``self._have_usage = True``.
+        This method MUST make all API calls through
+        :py:func:`~awslimitchecker.utils.boto_query_wrapper`.
         """
         """
         logger.debug("Checking usage for service {n}".format(
             n=self.service_name))
         self.connect()
-        # find usage here
+        usage = boto_query_wrapper(self.conn.method_to_get_usage)
         logger.debug("Done checking usage.")
         self._have_usage = True
         """

--- a/awslimitchecker/services/ebs.py
+++ b/awslimitchecker/services/ebs.py
@@ -41,8 +41,11 @@ import abc  # noqa
 import boto
 import boto.ec2
 import logging
+
 from .base import _AwsService
 from ..limit import AwsLimit
+from ..utils import boto_query_wrapper
+
 logger = logging.getLogger(__name__)
 
 
@@ -82,7 +85,7 @@ class _EbsService(_AwsService):
         gp_gb = 0
         mag_gb = 0
         logger.debug("Getting usage for EBS volumes")
-        for vol in self.conn.get_all_volumes():
+        for vol in boto_query_wrapper(self.conn.get_all_volumes):
             vols += 1
             if vol.type == 'io1':
                 piops_gb += vol.size
@@ -124,7 +127,7 @@ class _EbsService(_AwsService):
     def _find_usage_snapshots(self):
         """find snapshot usage"""
         logger.debug("Getting usage for EBS snapshots")
-        snaps = self.conn.get_all_snapshots(owner='self')
+        snaps = boto_query_wrapper(self.conn.get_all_snapshots, owner='self')
         self.limits['Active snapshots']._add_current_usage(
             len(snaps),
             aws_type='AWS::EC2::VolumeSnapshot'

--- a/awslimitchecker/services/elasticache.py
+++ b/awslimitchecker/services/elasticache.py
@@ -83,8 +83,21 @@ class _ElastiCacheService(_AwsService):
     def _find_usage_nodes(self):
         """find usage for cache nodes"""
         nodes = 0
-        clusters = boto_query_wrapper(self.conn.describe_cache_clusters,
-                                      show_cache_node_info=True)[
+        clusters = boto_query_wrapper(
+            self.conn.describe_cache_clusters,
+            show_cache_node_info=True,
+            alc_marker_path=[
+                'DescribeCacheClustersResponse',
+                'DescribeCacheClustersResult',
+                'Marker'
+            ],
+            alc_data_path=[
+                'DescribeCacheClustersResponse',
+                'DescribeCacheClustersResult',
+                'CacheClusters'
+            ],
+            alc_marker_param='marker'
+        )[
             'DescribeCacheClustersResponse']['DescribeCacheClustersResult'][
                 'CacheClusters']
         for cluster in clusters:
@@ -113,7 +126,20 @@ class _ElastiCacheService(_AwsService):
 
     def _find_usage_subnet_groups(self):
         """find usage for elasticache subnet groups"""
-        groups = boto_query_wrapper(self.conn.describe_cache_subnet_groups)[
+        groups = boto_query_wrapper(
+            self.conn.describe_cache_subnet_groups,
+            alc_marker_path=[
+                'DescribeCacheSubnetGroupsResponse',
+                'DescribeCacheSubnetGroupsResult',
+                'Marker'
+            ],
+            alc_data_path=[
+                'DescribeCacheSubnetGroupsResponse',
+                'DescribeCacheSubnetGroupsResult',
+                'CacheSubnetGroups'
+            ],
+            alc_marker_param='marker'
+        )[
             'DescribeCacheSubnetGroupsResponse'][
             'DescribeCacheSubnetGroupsResult'][
             'CacheSubnetGroups']
@@ -124,7 +150,20 @@ class _ElastiCacheService(_AwsService):
 
     def _find_usage_parameter_groups(self):
         """find usage for elasticache parameter groups"""
-        groups = boto_query_wrapper(self.conn.describe_cache_parameter_groups)[
+        groups = boto_query_wrapper(
+            self.conn.describe_cache_parameter_groups,
+            alc_marker_path=[
+                'DescribeCacheParameterGroupsResponse',
+                'DescribeCacheParameterGroupsResult',
+                'Marker'
+            ],
+            alc_data_path=[
+                'DescribeCacheParameterGroupsResponse',
+                'DescribeCacheParameterGroupsResult',
+                'CacheParameterGroups'
+            ],
+            alc_marker_param='marker'
+        )[
             'DescribeCacheParameterGroupsResponse'][
             'DescribeCacheParameterGroupsResult'][
             'CacheParameterGroups']
@@ -143,7 +182,19 @@ class _ElastiCacheService(_AwsService):
             #             this API version for your account."
             #   Type:    "Sender"
             groups = boto_query_wrapper(
-                self.conn.describe_cache_security_groups)[
+                self.conn.describe_cache_security_groups,
+                alc_marker_path=[
+                    'DescribeCacheSecurityGroupsResponse',
+                    'DescribeCacheSecurityGroupsResult',
+                    'Marker'
+                ],
+                alc_data_path=[
+                    'DescribeCacheSecurityGroupsResponse',
+                    'DescribeCacheSecurityGroupsResult',
+                    'CacheSecurityGroups'
+                ],
+                alc_marker_param='marker'
+            )[
                 'DescribeCacheSecurityGroupsResponse'][
                 'DescribeCacheSecurityGroupsResult'][
                 'CacheSecurityGroups']

--- a/awslimitchecker/services/elasticache.py
+++ b/awslimitchecker/services/elasticache.py
@@ -45,6 +45,7 @@ import logging
 
 from .base import _AwsService
 from ..limit import AwsLimit
+from ..utils import boto_query_wrapper
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,8 @@ class _ElastiCacheService(_AwsService):
     def _find_usage_nodes(self):
         """find usage for cache nodes"""
         nodes = 0
-        clusters = self.conn.describe_cache_clusters(show_cache_node_info=True)[
+        clusters = boto_query_wrapper(self.conn.describe_cache_clusters,
+                                      show_cache_node_info=True)[
             'DescribeCacheClustersResponse']['DescribeCacheClustersResult'][
                 'CacheClusters']
         for cluster in clusters:
@@ -111,7 +113,7 @@ class _ElastiCacheService(_AwsService):
 
     def _find_usage_subnet_groups(self):
         """find usage for elasticache subnet groups"""
-        groups = self.conn.describe_cache_subnet_groups()[
+        groups = boto_query_wrapper(self.conn.describe_cache_subnet_groups)[
             'DescribeCacheSubnetGroupsResponse'][
             'DescribeCacheSubnetGroupsResult'][
             'CacheSubnetGroups']
@@ -122,7 +124,7 @@ class _ElastiCacheService(_AwsService):
 
     def _find_usage_parameter_groups(self):
         """find usage for elasticache parameter groups"""
-        groups = self.conn.describe_cache_parameter_groups()[
+        groups = boto_query_wrapper(self.conn.describe_cache_parameter_groups)[
             'DescribeCacheParameterGroupsResponse'][
             'DescribeCacheParameterGroupsResult'][
             'CacheParameterGroups']
@@ -140,7 +142,8 @@ class _ElastiCacheService(_AwsService):
             #   Message: "Use of cache security groups is not permitted in
             #             this API version for your account."
             #   Type:    "Sender"
-            groups = self.conn.describe_cache_security_groups()[
+            groups = boto_query_wrapper(
+                self.conn.describe_cache_security_groups)[
                 'DescribeCacheSecurityGroupsResponse'][
                 'DescribeCacheSecurityGroupsResult'][
                 'CacheSecurityGroups']

--- a/awslimitchecker/services/elb.py
+++ b/awslimitchecker/services/elb.py
@@ -44,6 +44,7 @@ import logging
 
 from .base import _AwsService
 from ..limit import AwsLimit
+from ..utils import boto_query_wrapper
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +72,7 @@ class _ElbService(_AwsService):
         self.connect()
         for lim in self.limits.values():
             lim._reset_usage()
-        lbs = self.conn.get_all_load_balancers()
+        lbs = boto_query_wrapper(self.conn.get_all_load_balancers)
         self.limits['Active load balancers']._add_current_usage(
             len(lbs),
             aws_type='AWS::ElasticLoadBalancing::LoadBalancer',

--- a/awslimitchecker/services/newservice.py.example
+++ b/awslimitchecker/services/newservice.py.example
@@ -43,6 +43,7 @@ import logging
 
 from .base import _AwsService
 from ..limit import AwsLimit
+from ..utils import boto_query_wrapper
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +77,7 @@ class _XXNewServiceXXService(_AwsService):
             lim._reset_usage()
         # TODO: update your usage here, i.e.:
         """
-        u = (count of something, from boto)
+        u = boto_query_wrapper(self.conn.some_method)  # count of something, from boto
         u_id = (resource id from AWS)
         self.limits['Number of u']._add_current_usage(u, aws_type='U', id=u_id)
         """

--- a/awslimitchecker/services/rds.py
+++ b/awslimitchecker/services/rds.py
@@ -86,7 +86,21 @@ class _RDSService(_AwsService):
     def _find_usage_instances(self):
         """find usage for DB Instances and related limits"""
         # instance count
-        instances = boto_query_wrapper(self.conn.describe_db_instances)[
+        instances = boto_query_wrapper(
+            self.conn.describe_db_instances,
+            alc_marker_path=[
+                'DescribeDBInstancesResponse',
+                'DescribeDBInstancesResult',
+                'Marker'
+            ],
+            alc_data_path=[
+                'DescribeDBInstancesResponse',
+                'DescribeDBInstancesResult',
+                'DBInstances'
+            ],
+            alc_marker_param='marker'
+        )
+        instances = instances[
             'DescribeDBInstancesResponse'][
                 'DescribeDBInstancesResult']['DBInstances']
         self.limits['DB instances']._add_current_usage(
@@ -112,7 +126,20 @@ class _RDSService(_AwsService):
 
     def _find_usage_reserved_instances(self):
         """find usage for reserved instances"""
-        reserved = boto_query_wrapper(self.conn.describe_reserved_db_instances)[
+        reserved = boto_query_wrapper(
+            self.conn.describe_reserved_db_instances,
+            alc_marker_path=[
+                'DescribeReservedDBInstancesResponse',
+                'DescribeReservedDBInstancesResult',
+                "Marker"
+            ],
+            alc_data_path=[
+                'DescribeReservedDBInstancesResponse',
+                'DescribeReservedDBInstancesResult',
+                'ReservedDBInstances'
+            ],
+            alc_marker_param='marker'
+        )[
             'DescribeReservedDBInstancesResponse'][
             'DescribeReservedDBInstancesResult'][
             'ReservedDBInstances']
@@ -123,7 +150,21 @@ class _RDSService(_AwsService):
 
     def _find_usage_snapshots(self):
         """find usage for (manual) DB snapshots"""
-        snaps = boto_query_wrapper(self.conn.describe_db_snapshots)[
+        snaps = boto_query_wrapper(
+            self.conn.describe_db_snapshots,
+            alc_marker_path=[
+                "DescribeDBSnapshotsResponse",
+                "DescribeDBSnapshotsResult",
+                'Marker'
+            ],
+            alc_data_path=[
+                "DescribeDBSnapshotsResponse",
+                "DescribeDBSnapshotsResult",
+                "DBSnapshots"
+            ],
+            alc_marker_param='marker'
+        )
+        snaps = snaps[
             "DescribeDBSnapshotsResponse"]["DescribeDBSnapshotsResult"][
                 "DBSnapshots"]
         num_manual_snaps = 0
@@ -137,7 +178,21 @@ class _RDSService(_AwsService):
 
     def _find_usage_param_groups(self):
         """find usage for parameter groups"""
-        params = boto_query_wrapper(self.conn.describe_db_parameter_groups)[
+        params = boto_query_wrapper(
+            self.conn.describe_db_parameter_groups,
+            alc_marker_path=[
+                "DescribeDBParameterGroupsResponse",
+                "DescribeDBParameterGroupsResult",
+                'Marker'
+            ],
+            alc_data_path=[
+                "DescribeDBParameterGroupsResponse",
+                "DescribeDBParameterGroupsResult",
+                "DBParameterGroups"
+            ],
+            alc_marker_param='marker'
+        )
+        params = params[
             "DescribeDBParameterGroupsResponse"][
                 "DescribeDBParameterGroupsResult"][
                     "DBParameterGroups"]
@@ -148,7 +203,20 @@ class _RDSService(_AwsService):
 
     def _find_usage_subnet_groups(self):
         """find usage for subnet groups"""
-        groups = boto_query_wrapper(self.conn.describe_db_subnet_groups)[
+        groups = boto_query_wrapper(
+            self.conn.describe_db_subnet_groups,
+            alc_marker_path=[
+                "DescribeDBSubnetGroupsResponse",
+                "DescribeDBSubnetGroupsResult",
+                "Marker"
+            ],
+            alc_data_path=[
+                "DescribeDBSubnetGroupsResponse",
+                "DescribeDBSubnetGroupsResult",
+                "DBSubnetGroups"
+            ],
+            alc_marker_param='marker'
+        )[
             "DescribeDBSubnetGroupsResponse"][
                 "DescribeDBSubnetGroupsResult"][
                     "DBSubnetGroups"]
@@ -167,7 +235,20 @@ class _RDSService(_AwsService):
 
     def _find_usage_option_groups(self):
         """find usage for option groups"""
-        groups = boto_query_wrapper(self.conn.describe_option_groups)[
+        groups = boto_query_wrapper(
+            self.conn.describe_option_groups,
+            alc_marker_path=[
+                "DescribeOptionGroupsResponse",
+                "DescribeOptionGroupsResult",
+                "Marker"
+            ],
+            alc_data_path=[
+                "DescribeOptionGroupsResponse",
+                "DescribeOptionGroupsResult",
+                "OptionGroupsList"
+            ],
+            alc_marker_param='marker'
+        )[
             "DescribeOptionGroupsResponse"][
                 "DescribeOptionGroupsResult"]["OptionGroupsList"]
         self.limits['Option Groups']._add_current_usage(
@@ -177,7 +258,20 @@ class _RDSService(_AwsService):
 
     def _find_usage_event_subscriptions(self):
         """find usage for event subscriptions"""
-        subs = boto_query_wrapper(self.conn.describe_event_subscriptions)[
+        subs = boto_query_wrapper(
+            self.conn.describe_event_subscriptions,
+            alc_marker_path=[
+                "DescribeEventSubscriptionsResponse",
+                "DescribeEventSubscriptionsResult",
+                "Marker"
+            ],
+            alc_data_path=[
+                "DescribeEventSubscriptionsResponse",
+                "DescribeEventSubscriptionsResult",
+                "EventSubscriptionsList"
+            ],
+            alc_marker_param='marker'
+        )[
             "DescribeEventSubscriptionsResponse"][
             "DescribeEventSubscriptionsResult"][
             "EventSubscriptionsList"]
@@ -188,7 +282,20 @@ class _RDSService(_AwsService):
 
     def _find_usage_security_groups(self):
         """find usage for security groups"""
-        groups = boto_query_wrapper(self.conn.describe_db_security_groups)[
+        groups = boto_query_wrapper(
+            self.conn.describe_db_security_groups,
+            alc_marker_path=[
+                "DescribeDBSecurityGroupsResponse",
+                "DescribeDBSecurityGroupsResult",
+                "Marker"
+            ],
+            alc_data_path=[
+                "DescribeDBSecurityGroupsResponse",
+                "DescribeDBSecurityGroupsResult",
+                "DBSecurityGroups"
+            ],
+            alc_marker_param='marker'
+        )[
             "DescribeDBSecurityGroupsResponse"][
             "DescribeDBSecurityGroupsResult"][
             "DBSecurityGroups"]

--- a/awslimitchecker/services/rds.py
+++ b/awslimitchecker/services/rds.py
@@ -44,6 +44,7 @@ import logging
 
 from .base import _AwsService
 from ..limit import AwsLimit
+from ..utils import boto_query_wrapper
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +86,7 @@ class _RDSService(_AwsService):
     def _find_usage_instances(self):
         """find usage for DB Instances and related limits"""
         # instance count
-        instances = self.conn.describe_db_instances()[
+        instances = boto_query_wrapper(self.conn.describe_db_instances)[
             'DescribeDBInstancesResponse'][
                 'DescribeDBInstancesResult']['DBInstances']
         self.limits['DB instances']._add_current_usage(
@@ -111,7 +112,7 @@ class _RDSService(_AwsService):
 
     def _find_usage_reserved_instances(self):
         """find usage for reserved instances"""
-        reserved = self.conn.describe_reserved_db_instances()[
+        reserved = boto_query_wrapper(self.conn.describe_reserved_db_instances)[
             'DescribeReservedDBInstancesResponse'][
             'DescribeReservedDBInstancesResult'][
             'ReservedDBInstances']
@@ -122,7 +123,7 @@ class _RDSService(_AwsService):
 
     def _find_usage_snapshots(self):
         """find usage for (manual) DB snapshots"""
-        snaps = self.conn.describe_db_snapshots()[
+        snaps = boto_query_wrapper(self.conn.describe_db_snapshots)[
             "DescribeDBSnapshotsResponse"]["DescribeDBSnapshotsResult"][
                 "DBSnapshots"]
         num_manual_snaps = 0
@@ -136,7 +137,7 @@ class _RDSService(_AwsService):
 
     def _find_usage_param_groups(self):
         """find usage for parameter groups"""
-        params = self.conn.describe_db_parameter_groups()[
+        params = boto_query_wrapper(self.conn.describe_db_parameter_groups)[
             "DescribeDBParameterGroupsResponse"][
                 "DescribeDBParameterGroupsResult"][
                     "DBParameterGroups"]
@@ -147,7 +148,7 @@ class _RDSService(_AwsService):
 
     def _find_usage_subnet_groups(self):
         """find usage for subnet groups"""
-        groups = self.conn.describe_db_subnet_groups()[
+        groups = boto_query_wrapper(self.conn.describe_db_subnet_groups)[
             "DescribeDBSubnetGroupsResponse"][
                 "DescribeDBSubnetGroupsResult"][
                     "DBSubnetGroups"]
@@ -166,7 +167,7 @@ class _RDSService(_AwsService):
 
     def _find_usage_option_groups(self):
         """find usage for option groups"""
-        groups = self.conn.describe_option_groups()[
+        groups = boto_query_wrapper(self.conn.describe_option_groups)[
             "DescribeOptionGroupsResponse"][
                 "DescribeOptionGroupsResult"]["OptionGroupsList"]
         self.limits['Option Groups']._add_current_usage(
@@ -176,7 +177,7 @@ class _RDSService(_AwsService):
 
     def _find_usage_event_subscriptions(self):
         """find usage for event subscriptions"""
-        subs = self.conn.describe_event_subscriptions()[
+        subs = boto_query_wrapper(self.conn.describe_event_subscriptions)[
             "DescribeEventSubscriptionsResponse"][
             "DescribeEventSubscriptionsResult"][
             "EventSubscriptionsList"]
@@ -187,7 +188,7 @@ class _RDSService(_AwsService):
 
     def _find_usage_security_groups(self):
         """find usage for security groups"""
-        groups = self.conn.describe_db_security_groups()[
+        groups = boto_query_wrapper(self.conn.describe_db_security_groups)[
             "DescribeDBSecurityGroupsResponse"][
             "DescribeDBSecurityGroupsResult"][
             "DBSecurityGroups"]

--- a/awslimitchecker/services/vpc.py
+++ b/awslimitchecker/services/vpc.py
@@ -45,6 +45,7 @@ from collections import defaultdict
 
 from .base import _AwsService
 from ..limit import AwsLimit
+from ..utils import boto_query_wrapper
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ class _VpcService(_AwsService):
     def _find_usage_vpcs(self):
         """find usage for VPCs"""
         # overall number of VPCs
-        vpcs = self.conn.get_all_vpcs()
+        vpcs = boto_query_wrapper(self.conn.get_all_vpcs)
         self.limits['VPCs']._add_current_usage(
             len(vpcs),
             aws_type='AWS::EC2::VPC'
@@ -93,7 +94,7 @@ class _VpcService(_AwsService):
         """find usage for Subnets"""
         # subnets per VPC
         subnets = defaultdict(int)
-        for subnet in self.conn.get_all_subnets():
+        for subnet in boto_query_wrapper(self.conn.get_all_subnets):
             # boto.vpc.subnet.Subnet
             subnets[subnet.vpc_id] += 1
         for vpc_id in subnets:
@@ -107,7 +108,7 @@ class _VpcService(_AwsService):
         """find usage for ACLs"""
         # Network ACLs per VPC
         acls = defaultdict(int)
-        for acl in self.conn.get_all_network_acls():
+        for acl in boto_query_wrapper(self.conn.get_all_network_acls):
             # boto.vpc.networkacl.NetworkAcl
             acls[acl.vpc_id] += 1
             # Rules per network ACL
@@ -127,7 +128,7 @@ class _VpcService(_AwsService):
         """find usage for route tables"""
         # Route tables per VPC
         tables = defaultdict(int)
-        for table in self.conn.get_all_route_tables():
+        for table in boto_query_wrapper(self.conn.get_all_route_tables):
             # boto.vpc.routetable.RouteTable
             tables[table.vpc_id] += 1
             # Entries per route table
@@ -146,7 +147,7 @@ class _VpcService(_AwsService):
     def _find_usage_gateways(self):
         """find usage for Internet Gateways"""
         # Internet gateways
-        gws = self.conn.get_all_internet_gateways()
+        gws = boto_query_wrapper(self.conn.get_all_internet_gateways)
         self.limits['Internet gateways']._add_current_usage(
             len(gws),
             aws_type='AWS::EC2::InternetGateway',

--- a/awslimitchecker/tests/services/test_autoscaling.py
+++ b/awslimitchecker/tests/services/test_autoscaling.py
@@ -151,8 +151,8 @@ class Test_AutoscalingService(object):
         assert mock_connect.mock_calls == [call()]
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.get_all_groups),
-            call(mock_conn.get_all_launch_configurations)
+            call(mock_conn.get_all_groups, alc_paginate=True),
+            call(mock_conn.get_all_launch_configurations, alc_paginate=True)
         ]
         assert cls._have_usage is True
         asgs = sorted(cls.limits['Auto Scaling groups'].get_current_usage())

--- a/awslimitchecker/tests/services/test_autoscaling.py
+++ b/awslimitchecker/tests/services/test_autoscaling.py
@@ -151,8 +151,8 @@ class Test_AutoscalingService(object):
         assert mock_connect.mock_calls == [call()]
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.get_all_groups, alc_paginate=True),
-            call(mock_conn.get_all_launch_configurations, alc_paginate=True)
+            call(mock_conn.get_all_groups),
+            call(mock_conn.get_all_launch_configurations)
         ]
         assert cls._have_usage is True
         asgs = sorted(cls.limits['Auto Scaling groups'].get_current_usage())

--- a/awslimitchecker/tests/services/test_elasticache.py
+++ b/awslimitchecker/tests/services/test_elasticache.py
@@ -347,7 +347,21 @@ class TestElastiCacheService(object):
 
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.describe_cache_clusters, show_cache_node_info=True)
+            call(
+                mock_conn.describe_cache_clusters,
+                show_cache_node_info=True,
+                alc_marker_path=[
+                    'DescribeCacheClustersResponse',
+                    'DescribeCacheClustersResult',
+                    'Marker'
+                ],
+                alc_data_path=[
+                    'DescribeCacheClustersResponse',
+                    'DescribeCacheClustersResult',
+                    'CacheClusters'
+                ],
+                alc_marker_param='marker'
+            )
         ]
 
     def test_find_usage_subnet_groups(self):
@@ -437,7 +451,20 @@ class TestElastiCacheService(object):
 
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.describe_cache_subnet_groups)
+            call(
+                mock_conn.describe_cache_subnet_groups,
+                alc_marker_path=[
+                    'DescribeCacheSubnetGroupsResponse',
+                    'DescribeCacheSubnetGroupsResult',
+                    'Marker'
+                ],
+                alc_data_path=[
+                    'DescribeCacheSubnetGroupsResponse',
+                    'DescribeCacheSubnetGroupsResult',
+                    'CacheSubnetGroups'
+                ],
+                alc_marker_param='marker'
+            )
         ]
 
         usage = cls.limits['Subnet Groups'].get_current_usage()
@@ -483,7 +510,20 @@ class TestElastiCacheService(object):
 
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.describe_cache_parameter_groups)
+            call(
+                mock_conn.describe_cache_parameter_groups,
+                alc_marker_path=[
+                    'DescribeCacheParameterGroupsResponse',
+                    'DescribeCacheParameterGroupsResult',
+                    'Marker'
+                ],
+                alc_data_path=[
+                    'DescribeCacheParameterGroupsResponse',
+                    'DescribeCacheParameterGroupsResult',
+                    'CacheParameterGroups'
+                ],
+                alc_marker_param='marker'
+            )
         ]
 
         usage = cls.limits['Parameter Groups'].get_current_usage()
@@ -533,7 +573,20 @@ class TestElastiCacheService(object):
 
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.describe_cache_security_groups)
+            call(
+                mock_conn.describe_cache_security_groups,
+                alc_marker_path=[
+                    'DescribeCacheSecurityGroupsResponse',
+                    'DescribeCacheSecurityGroupsResult',
+                    'Marker'
+                ],
+                alc_data_path=[
+                    'DescribeCacheSecurityGroupsResponse',
+                    'DescribeCacheSecurityGroupsResult',
+                    'CacheSecurityGroups'
+                ],
+                alc_marker_param='marker'
+            )
         ]
 
         usage = cls.limits['Security Groups'].get_current_usage()
@@ -542,7 +595,7 @@ class TestElastiCacheService(object):
 
     def test_find_usage_security_groups_exception(self):
         """test find usage for security groups"""
-        def se_exc(*args):
+        def se_exc(*args, **kwargs):
             raise BotoServerError(None, None, None)
 
         mock_conn = Mock(spec_set=ElastiCacheConnection)
@@ -556,7 +609,20 @@ class TestElastiCacheService(object):
 
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.describe_cache_security_groups)
+            call(
+                mock_conn.describe_cache_security_groups,
+                alc_marker_path=[
+                    'DescribeCacheSecurityGroupsResponse',
+                    'DescribeCacheSecurityGroupsResult',
+                    'Marker'
+                ],
+                alc_data_path=[
+                    'DescribeCacheSecurityGroupsResponse',
+                    'DescribeCacheSecurityGroupsResult',
+                    'CacheSecurityGroups'
+                ],
+                alc_marker_param='marker'
+            )
         ]
 
         usage = cls.limits['Security Groups'].get_current_usage()

--- a/awslimitchecker/tests/services/test_elasticache.py
+++ b/awslimitchecker/tests/services/test_elasticache.py
@@ -322,10 +322,11 @@ class TestElastiCacheService(object):
         }
 
         mock_conn = Mock(spec_set=ElastiCacheConnection)
-        mock_conn.describe_cache_clusters.return_value = resp
         cls = _ElastiCacheService(21, 43)
         cls.conn = mock_conn
-        cls._find_usage_nodes()
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = resp
+            cls._find_usage_nodes()
 
         usage = cls.limits['Nodes'].get_current_usage()
         assert len(usage) == 1
@@ -344,8 +345,9 @@ class TestElastiCacheService(object):
         assert usage[2].get_value() == 4
         assert usage[2].resource_id == 'redis2'
 
-        assert mock_conn.mock_calls == [
-            call.describe_cache_clusters(show_cache_node_info=True),
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.describe_cache_clusters, show_cache_node_info=True)
         ]
 
     def test_find_usage_subnet_groups(self):
@@ -426,13 +428,16 @@ class TestElastiCacheService(object):
         }
 
         mock_conn = Mock(spec_set=ElastiCacheConnection)
-        mock_conn.describe_cache_subnet_groups.return_value = data
         cls = _ElastiCacheService(21, 43)
         cls.conn = mock_conn
-        cls._find_usage_subnet_groups()
 
-        assert mock_conn.mock_calls == [
-            call.describe_cache_subnet_groups(),
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = data
+            cls._find_usage_subnet_groups()
+
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.describe_cache_subnet_groups)
         ]
 
         usage = cls.limits['Subnet Groups'].get_current_usage()
@@ -470,13 +475,15 @@ class TestElastiCacheService(object):
         }
 
         mock_conn = Mock(spec_set=ElastiCacheConnection)
-        mock_conn.describe_cache_parameter_groups.return_value = data
         cls = _ElastiCacheService(21, 43)
         cls.conn = mock_conn
-        cls._find_usage_parameter_groups()
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = data
+            cls._find_usage_parameter_groups()
 
-        assert mock_conn.mock_calls == [
-            call.describe_cache_parameter_groups(),
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.describe_cache_parameter_groups)
         ]
 
         usage = cls.limits['Parameter Groups'].get_current_usage()
@@ -517,13 +524,16 @@ class TestElastiCacheService(object):
         }
 
         mock_conn = Mock(spec_set=ElastiCacheConnection)
-        mock_conn.describe_cache_security_groups.return_value = data
         cls = _ElastiCacheService(21, 43)
         cls.conn = mock_conn
-        cls._find_usage_security_groups()
 
-        assert mock_conn.mock_calls == [
-            call.describe_cache_security_groups(),
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = data
+            cls._find_usage_security_groups()
+
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.describe_cache_security_groups)
         ]
 
         usage = cls.limits['Security Groups'].get_current_usage()
@@ -532,17 +542,21 @@ class TestElastiCacheService(object):
 
     def test_find_usage_security_groups_exception(self):
         """test find usage for security groups"""
-        def se_exc():
+        def se_exc(*args):
             raise BotoServerError(None, None, None)
 
         mock_conn = Mock(spec_set=ElastiCacheConnection)
         mock_conn.describe_cache_security_groups.side_effect = se_exc
         cls = _ElastiCacheService(21, 43)
         cls.conn = mock_conn
-        cls._find_usage_security_groups()
 
-        assert mock_conn.mock_calls == [
-            call.describe_cache_security_groups(),
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.side_effect = se_exc
+            cls._find_usage_security_groups()
+
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.describe_cache_security_groups)
         ]
 
         usage = cls.limits['Security Groups'].get_current_usage()

--- a/awslimitchecker/tests/services/test_newservice.py.example
+++ b/awslimitchecker/tests/services/test_newservice.py.example
@@ -110,14 +110,17 @@ class Test_XXNewServiceXXService(object):
     def test_find_usage(self):
         mock_conn = Mock(spec_set=XXNewServiceXXConnection)
         with patch('%s.connect' % self.pb) as mock_connect:
-            cls = _XXNewServiceXXService(21, 43)
-            cls.conn = mock_conn
-            assert cls._have_usage is False
-            cls.find_usage()
+            with patch('%s.boto_service_wrapper' % self.pbm) as mock_wrapper:
+                cls = _XXNewServiceXXService(21, 43)
+                cls.conn = mock_conn
+                mock_wrapper.return_value =  # some logical return value
+                assert cls._have_usage is False
+                cls.find_usage()
         assert mock_connect.mock_calls == [call()]
         assert cls._have_usage is True
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [call(mock_conn.some_method)]
         # TODO - assert about usage
-
 
     def test_required_iam_permissions(self):
         cls = _XXNewServiceXXService(21, 43)

--- a/awslimitchecker/tests/services/test_rds.py
+++ b/awslimitchecker/tests/services/test_rds.py
@@ -378,7 +378,7 @@ class Test_RDSService(object):
                 'DBInstanceIdentifier': 'baz'
             }
         ]
-        mock_conn.describe_db_instances.return_value = {
+        return_value = {
             'DescribeDBInstancesResponse': {
                 'DescribeDBInstancesResult': {
                     'DBInstances': instances
@@ -386,10 +386,13 @@ class Test_RDSService(object):
             }
         }
 
-        cls._find_usage_instances()
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = return_value
+            cls._find_usage_instances()
 
-        assert mock_conn.mock_calls == [
-            call.describe_db_instances()
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.describe_db_instances)
         ]
 
         usage = sorted(cls.limits['DB instances'].get_current_usage())
@@ -491,14 +494,16 @@ class Test_RDSService(object):
         }
 
         mock_conn = Mock(spec_set=RDSConnection)
-        mock_conn.describe_db_snapshots.return_value = data
         cls = _RDSService(21, 43)
         cls.conn = mock_conn
 
-        cls._find_usage_snapshots()
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = data
+            cls._find_usage_snapshots()
 
-        assert mock_conn.mock_calls == [
-            call.describe_db_snapshots()
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.describe_db_snapshots)
         ]
 
         usage = sorted(cls.limits['DB snapshots per user'].get_current_usage())
@@ -533,14 +538,16 @@ class Test_RDSService(object):
         }
 
         mock_conn = Mock(spec_set=RDSConnection)
-        mock_conn.describe_db_parameter_groups.return_value = data
         cls = _RDSService(21, 43)
         cls.conn = mock_conn
 
-        cls._find_usage_param_groups()
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = data
+            cls._find_usage_param_groups()
 
-        assert mock_conn.mock_calls == [
-            call.describe_db_parameter_groups()
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.describe_db_parameter_groups)
         ]
 
         usage = sorted(cls.limits['Parameter Groups'].get_current_usage())
@@ -640,14 +647,16 @@ class Test_RDSService(object):
         }
 
         mock_conn = Mock(spec_set=RDSConnection)
-        mock_conn.describe_db_subnet_groups.return_value = data
         cls = _RDSService(21, 43)
         cls.conn = mock_conn
 
-        cls._find_usage_subnet_groups()
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = data
+            cls._find_usage_subnet_groups()
 
-        assert mock_conn.mock_calls == [
-            call.describe_db_subnet_groups()
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.describe_db_subnet_groups)
         ]
 
         usage = sorted(cls.limits['Subnet Groups'].get_current_usage())
@@ -703,14 +712,16 @@ class Test_RDSService(object):
         }
 
         mock_conn = Mock(spec_set=RDSConnection)
-        mock_conn.describe_option_groups.return_value = data
         cls = _RDSService(21, 43)
         cls.conn = mock_conn
 
-        cls._find_usage_option_groups()
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = data
+            cls._find_usage_option_groups()
 
-        assert mock_conn.mock_calls == [
-            call.describe_option_groups()
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.describe_option_groups)
         ]
 
         usage = sorted(cls.limits['Option Groups'].get_current_usage())
@@ -733,14 +744,16 @@ class Test_RDSService(object):
         }
 
         mock_conn = Mock(spec_set=RDSConnection)
-        mock_conn.describe_event_subscriptions.return_value = data
         cls = _RDSService(21, 43)
         cls.conn = mock_conn
 
-        cls._find_usage_event_subscriptions()
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = data
+            cls._find_usage_event_subscriptions()
 
-        assert mock_conn.mock_calls == [
-            call.describe_event_subscriptions()
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.describe_event_subscriptions)
         ]
 
         usage = sorted(cls.limits['Event Subscriptions'].get_current_usage())
@@ -834,14 +847,16 @@ class Test_RDSService(object):
         }
 
         mock_conn = Mock(spec_set=RDSConnection)
-        mock_conn.describe_db_security_groups.return_value = data
         cls = _RDSService(21, 43)
         cls.conn = mock_conn
 
-        cls._find_usage_security_groups()
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = data
+            cls._find_usage_security_groups()
 
-        assert mock_conn.mock_calls == [
-            call.describe_db_security_groups()
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.describe_db_security_groups)
         ]
 
         usage = sorted(cls.limits['DB security groups'].get_current_usage())
@@ -885,14 +900,16 @@ class Test_RDSService(object):
         }
 
         mock_conn = Mock(spec_set=RDSConnection)
-        mock_conn.describe_reserved_db_instances.return_value = data
         cls = _RDSService(21, 43)
         cls.conn = mock_conn
 
-        cls._find_usage_reserved_instances()
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = data
+            cls._find_usage_reserved_instances()
 
-        assert mock_conn.mock_calls == [
-            call.describe_reserved_db_instances()
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.describe_reserved_db_instances)
         ]
 
         usage = sorted(cls.limits['Reserved Instances'].get_current_usage())

--- a/awslimitchecker/tests/services/test_rds.py
+++ b/awslimitchecker/tests/services/test_rds.py
@@ -392,7 +392,20 @@ class Test_RDSService(object):
 
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.describe_db_instances)
+            call(
+                mock_conn.describe_db_instances,
+                alc_marker_path=[
+                    'DescribeDBInstancesResponse',
+                    'DescribeDBInstancesResult',
+                    'Marker'
+                ],
+                alc_data_path=[
+                    'DescribeDBInstancesResponse',
+                    'DescribeDBInstancesResult',
+                    'DBInstances'
+                ],
+                alc_marker_param='marker'
+            )
         ]
 
         usage = sorted(cls.limits['DB instances'].get_current_usage())
@@ -503,7 +516,20 @@ class Test_RDSService(object):
 
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.describe_db_snapshots)
+            call(
+                mock_conn.describe_db_snapshots,
+                alc_marker_path=[
+                    "DescribeDBSnapshotsResponse",
+                    "DescribeDBSnapshotsResult",
+                    'Marker'
+                ],
+                alc_data_path=[
+                    "DescribeDBSnapshotsResponse",
+                    "DescribeDBSnapshotsResult",
+                    "DBSnapshots"
+                ],
+                alc_marker_param='marker'
+            )
         ]
 
         usage = sorted(cls.limits['DB snapshots per user'].get_current_usage())
@@ -547,7 +573,20 @@ class Test_RDSService(object):
 
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.describe_db_parameter_groups)
+            call(
+                mock_conn.describe_db_parameter_groups,
+                alc_marker_path=[
+                    "DescribeDBParameterGroupsResponse",
+                    "DescribeDBParameterGroupsResult",
+                    'Marker'
+                ],
+                alc_data_path=[
+                    "DescribeDBParameterGroupsResponse",
+                    "DescribeDBParameterGroupsResult",
+                    "DBParameterGroups"
+                ],
+                alc_marker_param='marker'
+            )
         ]
 
         usage = sorted(cls.limits['Parameter Groups'].get_current_usage())
@@ -656,7 +695,20 @@ class Test_RDSService(object):
 
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.describe_db_subnet_groups)
+            call(
+                mock_conn.describe_db_subnet_groups,
+                alc_marker_path=[
+                    "DescribeDBSubnetGroupsResponse",
+                    "DescribeDBSubnetGroupsResult",
+                    "Marker"
+                ],
+                alc_data_path=[
+                    "DescribeDBSubnetGroupsResponse",
+                    "DescribeDBSubnetGroupsResult",
+                    "DBSubnetGroups"
+                ],
+                alc_marker_param='marker'
+            )
         ]
 
         usage = sorted(cls.limits['Subnet Groups'].get_current_usage())
@@ -721,7 +773,20 @@ class Test_RDSService(object):
 
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.describe_option_groups)
+            call(
+                mock_conn.describe_option_groups,
+                alc_marker_path=[
+                    "DescribeOptionGroupsResponse",
+                    "DescribeOptionGroupsResult",
+                    "Marker"
+                ],
+                alc_data_path=[
+                    "DescribeOptionGroupsResponse",
+                    "DescribeOptionGroupsResult",
+                    "OptionGroupsList"
+                ],
+                alc_marker_param='marker'
+            )
         ]
 
         usage = sorted(cls.limits['Option Groups'].get_current_usage())
@@ -753,7 +818,20 @@ class Test_RDSService(object):
 
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.describe_event_subscriptions)
+            call(
+                mock_conn.describe_event_subscriptions,
+                alc_marker_path=[
+                    "DescribeEventSubscriptionsResponse",
+                    "DescribeEventSubscriptionsResult",
+                    "Marker"
+                ],
+                alc_data_path=[
+                    "DescribeEventSubscriptionsResponse",
+                    "DescribeEventSubscriptionsResult",
+                    "EventSubscriptionsList"
+                ],
+                alc_marker_param='marker'
+            )
         ]
 
         usage = sorted(cls.limits['Event Subscriptions'].get_current_usage())
@@ -856,7 +934,20 @@ class Test_RDSService(object):
 
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.describe_db_security_groups)
+            call(
+                mock_conn.describe_db_security_groups,
+                alc_marker_path=[
+                    "DescribeDBSecurityGroupsResponse",
+                    "DescribeDBSecurityGroupsResult",
+                    "Marker"
+                ],
+                alc_data_path=[
+                    "DescribeDBSecurityGroupsResponse",
+                    "DescribeDBSecurityGroupsResult",
+                    "DBSecurityGroups"
+                ],
+                alc_marker_param='marker'
+            )
         ]
 
         usage = sorted(cls.limits['DB security groups'].get_current_usage())
@@ -909,7 +1000,20 @@ class Test_RDSService(object):
 
         assert mock_conn.mock_calls == []
         assert mock_wrapper.mock_calls == [
-            call(mock_conn.describe_reserved_db_instances)
+            call(
+                mock_conn.describe_reserved_db_instances,
+                alc_marker_path=[
+                    'DescribeReservedDBInstancesResponse',
+                    'DescribeReservedDBInstancesResult',
+                    "Marker"
+                ],
+                alc_data_path=[
+                    'DescribeReservedDBInstancesResponse',
+                    'DescribeReservedDBInstancesResult',
+                    'ReservedDBInstances'
+                ],
+                alc_marker_param='marker'
+            )
         ]
 
         usage = sorted(cls.limits['Reserved Instances'].get_current_usage())

--- a/awslimitchecker/tests/services/test_vpc.py
+++ b/awslimitchecker/tests/services/test_vpc.py
@@ -184,15 +184,19 @@ class Test_VpcService(object):
         vpcs = [mock1, mock2]
 
         mock_conn = Mock(spec_set=VPCConnection)
-        mock_conn.get_all_vpcs.return_value = vpcs
 
         cls = _VpcService(21, 43)
         cls.conn = mock_conn
-        cls._find_usage_vpcs()
+
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = vpcs
+            cls._find_usage_vpcs()
+
         assert len(cls.limits['VPCs'].get_current_usage()) == 1
         assert cls.limits['VPCs'].get_current_usage()[0].get_value() == 2
-        assert mock_conn.mock_calls == [
-            call.get_all_vpcs(),
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.get_all_vpcs)
         ]
 
     def test_find_usage_subnets(self):
@@ -205,18 +209,22 @@ class Test_VpcService(object):
 
         subnets = [mock1, mock2, mock3]
         mock_conn = Mock(spec_set=VPCConnection)
-        mock_conn.get_all_subnets.return_value = subnets
         cls = _VpcService(21, 43)
         cls.conn = mock_conn
-        cls._find_usage_subnets()
+
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = subnets
+            cls._find_usage_subnets()
+
         usage = sorted(cls.limits['Subnets per VPC'].get_current_usage())
         assert len(usage) == 2
         assert usage[0].get_value() == 1
         assert usage[0].resource_id == 'vpc-2'
         assert usage[1].get_value() == 2
         assert usage[1].resource_id == 'vpc-1'
-        assert mock_conn.mock_calls == [
-            call.get_all_subnets(),
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.get_all_subnets)
         ]
 
     def test_find_usage_acls(self):
@@ -235,11 +243,14 @@ class Test_VpcService(object):
 
         acls = [mock1, mock2, mock3]
         mock_conn = Mock(spec_set=VPCConnection)
-        mock_conn.get_all_network_acls.return_value = acls
 
         cls = _VpcService(21, 43)
         cls.conn = mock_conn
-        cls._find_usage_ACLs()
+
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = acls
+            cls._find_usage_ACLs()
+
         usage = sorted(cls.limits['Network ACLs per VPC'].get_current_usage())
         assert len(usage) == 2
         assert usage[0].get_value() == 1
@@ -255,8 +266,9 @@ class Test_VpcService(object):
         assert entries[1].get_value() == 3
         assert entries[2].resource_id == 'acl-3'
         assert entries[2].get_value() == 5
-        assert mock_conn.mock_calls == [
-            call.get_all_network_acls(),
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.get_all_network_acls)
         ]
 
     def test_find_usage_route_tables(self):
@@ -276,11 +288,14 @@ class Test_VpcService(object):
         tables = [mock1, mock2, mock3]
 
         mock_conn = Mock(spec_set=VPCConnection)
-        mock_conn.get_all_route_tables.return_value = tables
 
         cls = _VpcService(21, 43)
         cls.conn = mock_conn
-        cls._find_usage_route_tables()
+
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = tables
+            cls._find_usage_route_tables()
+
         usage = sorted(cls.limits['Route tables per VPC'].get_current_usage())
         assert len(usage) == 2
         assert usage[0].get_value() == 1
@@ -296,8 +311,9 @@ class Test_VpcService(object):
         assert entries[1].get_value() == 3
         assert entries[2].resource_id == 'rt-3'
         assert entries[2].get_value() == 5
-        assert mock_conn.mock_calls == [
-            call.get_all_route_tables(),
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.get_all_route_tables)
         ]
 
     def test_find_usage_internet_gateways(self):
@@ -309,16 +325,20 @@ class Test_VpcService(object):
         gateways = [mock1, mock2]
 
         mock_conn = Mock(spec_set=VPCConnection)
-        mock_conn.get_all_internet_gateways.return_value = gateways
 
         cls = _VpcService(21, 43)
         cls.conn = mock_conn
-        cls._find_usage_gateways()
+
+        with patch('%s.boto_query_wrapper' % self.pbm) as mock_wrapper:
+            mock_wrapper.return_value = gateways
+            cls._find_usage_gateways()
+
         assert len(cls.limits['Internet gateways'].get_current_usage()) == 1
         assert cls.limits['Internet gateways'].get_current_usage()[
             0].get_value() == 2
-        assert mock_conn.mock_calls == [
-            call.get_all_internet_gateways(),
+        assert mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [
+            call(mock_conn.get_all_internet_gateways)
         ]
 
     def test_required_iam_permissions(self):

--- a/awslimitchecker/tests/test_trustedadvisor.py
+++ b/awslimitchecker/tests/test_trustedadvisor.py
@@ -57,7 +57,8 @@ else:
     from unittest.mock import patch, call, Mock
 
 
-pb = 'awslimitchecker.trustedadvisor.TrustedAdvisor'
+pbm = 'awslimitchecker.trustedadvisor'
+pb = '%s.TrustedAdvisor' % pbm
 
 
 class Test_TrustedAdvisor(object):
@@ -179,8 +180,9 @@ class Test_TrustedAdvisor(object):
                 },
             ]
         }
-        self.mock_conn.describe_trusted_advisor_checks.return_value = api_resp
-        res = self.cls._get_limit_check_id()
+        with patch('%s.boto_query_wrapper' % pbm) as mock_wrapper:
+            mock_wrapper.return_value = api_resp
+            res = self.cls._get_limit_check_id()
         assert res == (
             'bar',
             [
@@ -192,9 +194,11 @@ class Test_TrustedAdvisor(object):
                 'Status'
             ]
         )
-        assert self.mock_conn.mock_calls == [
-            call.describe_trusted_advisor_checks('en')
-        ]
+        assert self.mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [call(
+            self.mock_conn.describe_trusted_advisor_checks,
+            'en'
+            )]
 
     def test_get_limit_check_id_none(self):
         api_resp = {
@@ -211,16 +215,19 @@ class Test_TrustedAdvisor(object):
                 },
             ]
         }
-        self.mock_conn.describe_trusted_advisor_checks.return_value = api_resp
-        res = self.cls._get_limit_check_id()
+        with patch('%s.boto_query_wrapper' % pbm) as mock_wrapper:
+            mock_wrapper.return_value = api_resp
+            res = self.cls._get_limit_check_id()
         assert res == (None, None)
-        assert self.mock_conn.mock_calls == [
-            call.describe_trusted_advisor_checks('en')
-        ]
+        assert self.mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [call(
+            self.mock_conn.describe_trusted_advisor_checks,
+            'en'
+        )]
 
     def test_get_limit_check_id_subscription_required(self):
 
-        def se_api(language):
+        def se_api(foo, language):
             status = 400
             reason = 'Bad Request'
             body = {
@@ -230,16 +237,19 @@ class Test_TrustedAdvisor(object):
             }
             raise JSONResponseError(status, reason, body)
 
-        self.mock_conn.describe_trusted_advisor_checks.side_effect = se_api
         assert self.cls.have_ta is True
         with patch('awslimitchecker.trustedadvisor'
                    '.logger', autospec=True) as mock_logger:
-            res = self.cls._get_limit_check_id()
+            with patch('%s.boto_query_wrapper' % pbm) as mock_wrapper:
+                mock_wrapper.side_effect = se_api
+                res = self.cls._get_limit_check_id()
         assert self.cls.have_ta is False
         assert res == (None, None)
-        assert self.mock_conn.mock_calls == [
-            call.describe_trusted_advisor_checks('en')
-        ]
+        assert self.mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [call(
+            self.mock_conn.describe_trusted_advisor_checks,
+            'en'
+        )]
         assert mock_logger.mock_calls == [
             call.debug("Querying Trusted Advisor checks"),
             call.warning("Cannot check TrustedAdvisor: %s",
@@ -249,7 +259,7 @@ class Test_TrustedAdvisor(object):
 
     def test_get_limit_check_id_other_exception(self):
 
-        def se_api(language):
+        def se_api(foo, language):
             status = 400
             reason = 'foobar'
             body = {
@@ -258,12 +268,15 @@ class Test_TrustedAdvisor(object):
             }
             raise JSONResponseError(status, reason, body)
 
-        self.mock_conn.describe_trusted_advisor_checks.side_effect = se_api
         with pytest.raises(BotoServerError) as excinfo:
-            self.cls._get_limit_check_id()
-        assert self.mock_conn.mock_calls == [
-            call.describe_trusted_advisor_checks('en')
-        ]
+            with patch('%s.boto_query_wrapper' % pbm) as mock_wrapper:
+                mock_wrapper.side_effect = se_api
+                self.cls._get_limit_check_id()
+        assert self.mock_conn.mock_calls == []
+        assert mock_wrapper.mock_calls == [call(
+            self.mock_conn.describe_trusted_advisor_checks,
+            'en'
+        )]
         assert excinfo.value.status == 400
         assert excinfo.value.reason == 'foobar'
         assert excinfo.value.body['__type'] == 'OtherException'
@@ -271,13 +284,16 @@ class Test_TrustedAdvisor(object):
     def test_poll_id_none(self):
         tmp = self.mock_conn.describe_trusted_advisor_check_result
         with patch('%s._get_limit_check_id' % pb, autospec=True) as mock_id:
-            mock_id.return_value = None
-            self.cls._poll()
+            with patch('%s.boto_query_wrapper' % pbm) as mock_wrapper:
+                mock_id.return_value = None
+                res = self.cls._poll()
         assert tmp.mock_calls == []
+        assert mock_wrapper.mock_calls == []
+        assert res is None
 
     def test_poll(self):
         tmp = self.mock_conn.describe_trusted_advisor_check_result
-        tmp.return_value = {
+        poll_return_val = {
             'result': {
                 'timestamp': '2015-06-15T20:27:42Z',
                 'flaggedResources': [
@@ -327,19 +343,22 @@ class Test_TrustedAdvisor(object):
             }
         }
         with patch('%s._get_limit_check_id' % pb, autospec=True) as mock_id:
-            mock_id.return_value = (
-                'foo',
-                [
-                    'Region',
-                    'Service',
-                    'Limit Name',
-                    'Limit Amount',
-                    'Current Usage',
-                    'Status'
-                ]
-            )
-            res = self.cls._poll()
-        assert tmp.mock_calls == [call('foo')]
+            with patch('%s.boto_query_wrapper' % pbm) as mock_wrapper:
+                mock_id.return_value = (
+                    'foo',
+                    [
+                        'Region',
+                        'Service',
+                        'Limit Name',
+                        'Limit Amount',
+                        'Current Usage',
+                        'Status'
+                    ]
+                )
+                mock_wrapper.return_value = poll_return_val
+                res = self.cls._poll()
+        assert tmp.mock_calls == []
+        assert mock_wrapper.mock_calls == [call(tmp, 'foo')]
         assert mock_id.mock_calls == [call(self.cls)]
         assert res == {
             'AutoScaling': {
@@ -351,7 +370,7 @@ class Test_TrustedAdvisor(object):
     def test_poll_region(self):
         tmp = self.mock_conn.describe_trusted_advisor_check_result
         self.cls.ta_region = 'us-west-2'
-        tmp.return_value = {
+        poll_return_value = {
             'result': {
                 'timestamp': '2015-06-15T20:27:42Z',
                 'flaggedResources': [
@@ -401,19 +420,22 @@ class Test_TrustedAdvisor(object):
             }
         }
         with patch('%s._get_limit_check_id' % pb, autospec=True) as mock_id:
-            mock_id.return_value = (
-                'foo',
-                [
-                    'Region',
-                    'Service',
-                    'Limit Name',
-                    'Limit Amount',
-                    'Current Usage',
-                    'Status'
-                ]
-            )
-            res = self.cls._poll()
-        assert tmp.mock_calls == [call('foo')]
+            with patch('%s.boto_query_wrapper' % pbm) as mock_wrapper:
+                mock_id.return_value = (
+                    'foo',
+                    [
+                        'Region',
+                        'Service',
+                        'Limit Name',
+                        'Limit Amount',
+                        'Current Usage',
+                        'Status'
+                    ]
+                )
+                mock_wrapper.return_value = poll_return_value
+                res = self.cls._poll()
+        assert tmp.mock_calls == []
+        assert mock_wrapper.mock_calls == [call(tmp, 'foo')]
         assert mock_id.mock_calls == [call(self.cls)]
         assert res == {
             'AutoScaling': {
@@ -425,9 +447,11 @@ class Test_TrustedAdvisor(object):
         self.cls.have_ta = False
         tmp = self.mock_conn.describe_trusted_advisor_check_result
         with patch('%s._get_limit_check_id' % pb, autospec=True) as mock_id:
-            with patch('awslimitchecker.trustedadvisor'
-                       '.logger', autospec=True) as mock_logger:
-                res = self.cls._poll()
+            with patch('%s.boto_query_wrapper' % pbm) as mock_wrapper:
+                with patch('awslimitchecker.trustedadvisor'
+                           '.logger', autospec=True) as mock_logger:
+                    res = self.cls._poll()
+        assert mock_wrapper.mock_calls == []
         assert tmp.mock_calls == []
         assert mock_id.mock_calls == [
             call(self.cls)

--- a/awslimitchecker/tests/test_utils.py
+++ b/awslimitchecker/tests/test_utils.py
@@ -197,6 +197,18 @@ class TestInvokeWithThrottlingRetries(object):
         assert cls.func.mock_calls == [call('zzz', 'aaa', foo='bar')]
         assert mock_sleep.mock_calls == []
 
+    def test_invoke_ok_alc_args(self):
+        cls = Mock()
+        cls.func.side_effect = self.retry_func
+        with patch('awslimitchecker.utils.time.sleep') as mock_sleep:
+            res = invoke_with_throttling_retries(
+                cls.func, 'zzz', 'aaa', foo='bar', alc_paginate=True,
+                alc_foo='bar'
+            )
+        assert res is True
+        assert cls.func.mock_calls == [call('zzz', 'aaa', foo='bar')]
+        assert mock_sleep.mock_calls == []
+
     def test_invoke_other_error(self):
         cls = Mock()
         cls.func.side_effect = self.other_error
@@ -287,7 +299,8 @@ class TestBotoQueryWrapper(object):
                                          alc_bar='alcbar')
         assert res == retval
         assert mock_invoke.mock_calls == [
-            call(func, 'foo', bar='barval', baz='bazval')
+            call(func, 'foo', bar='barval', baz='bazval', alc_foo='alcfoo',
+                 alc_bar='alcbar')
         ]
         assert mock_paginate.mock_calls == []
 
@@ -304,7 +317,7 @@ class TestBotoQueryWrapper(object):
         assert res == retval
         assert mock_invoke.mock_calls == []
         assert mock_paginate.mock_calls == [
-            call(func, 'foo', bar='barval', baz='bazval')
+            call(func, 'foo', bar='barval', baz='bazval', alc_paginate=True)
         ]
 
 

--- a/awslimitchecker/tests/test_utils.py
+++ b/awslimitchecker/tests/test_utils.py
@@ -203,9 +203,7 @@ class TestInvokeWithThrottlingRetries(object):
         cls.func.side_effect = self.retry_func
         with patch('awslimitchecker.utils.time.sleep') as mock_sleep:
             res = invoke_with_throttling_retries(
-                cls.func, 'zzz', 'aaa', foo='bar', alc_paginate=True,
-                alc_foo='bar'
-            )
+                cls.func, 'zzz', 'aaa', foo='bar', alc_foo='bar')
         assert res is True
         assert cls.func.mock_calls == [call('zzz', 'aaa', foo='bar')]
         assert mock_sleep.mock_calls == []
@@ -304,11 +302,11 @@ class TestBotoQueryWrapper(object):
         with patch('%s.paginate_query' % pbm) as mock_paginate:
             mock_paginate.return_value = retval
             res = boto_query_wrapper(
-                func, 'foo', bar='barval', baz='bazval', alc_paginate=True
+                func, 'foo', bar='barval', baz='bazval'
             )
         assert res == retval
         assert mock_paginate.mock_calls == [
-            call(func, 'foo', bar='barval', baz='bazval', alc_paginate=True)
+            call(func, 'foo', bar='barval', baz='bazval')
         ]
 
 

--- a/awslimitchecker/tests/test_versioncheck.py
+++ b/awslimitchecker/tests/test_versioncheck.py
@@ -61,9 +61,9 @@ if (
         sys.version_info[0] < 3 or
         sys.version_info[0] == 3 and sys.version_info[1] < 4
 ):
-    from mock import patch, call, DEFAULT, Mock
+    from mock import patch, call, DEFAULT, Mock, PropertyMock
 else:
-    from unittest.mock import patch, call, DEFAULT, Mock
+    from unittest.mock import patch, call, DEFAULT, Mock, PropertyMock
 
 
 class Test_AGPLVersionChecker(object):
@@ -502,7 +502,10 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = True
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'git+https://foo',
@@ -513,6 +516,7 @@ class Test_AGPLVersionChecker(object):
         assert mocks['_find_git_info'].mock_calls == [call(cls)]
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_git_notag_dirty(self):
         cls = AGPLVersionChecker()
@@ -537,7 +541,10 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = True
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'git+https://foo',
@@ -548,6 +555,7 @@ class Test_AGPLVersionChecker(object):
         assert mocks['_find_git_info'].mock_calls == [call(cls)]
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_git_tag(self):
         cls = AGPLVersionChecker()
@@ -572,7 +580,10 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = True
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'git+https://foo',
@@ -583,6 +594,7 @@ class Test_AGPLVersionChecker(object):
         assert mocks['_find_git_info'].mock_calls == [call(cls)]
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_git_tag_dirty(self):
         cls = AGPLVersionChecker()
@@ -607,7 +619,10 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = True
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'git+https://foo',
@@ -618,6 +633,7 @@ class Test_AGPLVersionChecker(object):
         assert mocks['_find_git_info'].mock_calls == [call(cls)]
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_pkg_res_exception(self):
         cls = AGPLVersionChecker()
@@ -643,7 +659,10 @@ class Test_AGPLVersionChecker(object):
                 'url': 'http://my.package.url/pip'
             }
             mocks['_find_pkg_info'].side_effect = se_exception
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = True
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'git+https://foo',
@@ -654,6 +673,7 @@ class Test_AGPLVersionChecker(object):
         assert mocks['_find_git_info'].mock_calls == [call(cls)]
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_pip_exception(self):
         cls = AGPLVersionChecker()
@@ -679,7 +699,10 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = True
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'git+https://foo',
@@ -690,6 +713,7 @@ class Test_AGPLVersionChecker(object):
         assert mocks['_find_git_info'].mock_calls == [call(cls)]
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_no_git(self):
         cls = AGPLVersionChecker()
@@ -715,16 +739,20 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = False
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'http://my.package.url/pip',
             'tag': None,
             'commit': None,
         }
-        assert mocks['_find_git_info'].mock_calls == [call(cls)]
+        assert mocks['_find_git_info'].mock_calls == []
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_no_git_no_pip(self):
         cls = AGPLVersionChecker()
@@ -750,16 +778,20 @@ class Test_AGPLVersionChecker(object):
                 'version': '1.2.3',
                 'url': 'http://my.package.url/pkg_resources'
             }
-            res = cls.find_package_version()
+            with patch('%s._is_git_clone' % self.pb,
+                       new_callable=PropertyMock) as mock_is_git:
+                mock_is_git.return_value = False
+                res = cls.find_package_version()
         assert res == {
             'version': '1.2.3',
             'url': 'http://my.package.url/pkg_resources',
             'tag': None,
             'commit': None,
         }
-        assert mocks['_find_git_info'].mock_calls == [call(cls)]
+        assert mocks['_find_git_info'].mock_calls == []
         assert mocks['_find_pip_info'].mock_calls == [call(cls)]
         assert mocks['_find_pkg_info'].mock_calls == [call(cls)]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_debug(self):
         mock_pip_logger = Mock(spec_set=logging.Logger)
@@ -792,13 +824,14 @@ class Test_AGPLVersionChecker(object):
                     with patch('%s.logger' % self.mpb,
                                spec_set=logging.Logger) as mock_mod_logger:
                         mock_logging.getLogger.return_value = mock_pip_logger
-                        cls.find_package_version()
+                        with patch('%s._is_git_clone' % self.pb,
+                                   new_callable=PropertyMock) as mock_is_git:
+                            mock_is_git.return_value = False
+                            cls.find_package_version()
         assert mock_logging.mock_calls == []
         assert mock_pip_logger.mock_calls == []
         assert mock_mod_logger.mock_calls == [
-            call.debug('Git info: %s',
-                       {'url': None, 'commit': None, 'tag': None,
-                        'dirty': None}),
+            call.debug('Install does not appear to be a git clone'),
             call.debug('pip info: %s', {'url': 'http://my.package.url/pip',
                                         'version': '1.2.3'}),
             call.debug('pkg_resources info: %s',
@@ -808,6 +841,7 @@ class Test_AGPLVersionChecker(object):
                        {'url': 'http://my.package.url/pip', 'commit': None,
                         'version': '1.2.3', 'tag': None})
         ]
+        assert mock_is_git.mock_calls == [call()]
 
     def test_find_package_version_no_debug(self):
         mock_pip_logger = Mock()
@@ -841,7 +875,10 @@ class Test_AGPLVersionChecker(object):
                     }
                     with patch('%s.logger' % self.mpb,
                                spec_set=logging.Logger) as mock_mod_logger:
-                        cls.find_package_version()
+                        with patch('%s._is_git_clone' % self.pb,
+                                   new_callable=PropertyMock) as mock_is_git:
+                            mock_is_git.return_value = False
+                            cls.find_package_version()
         assert mock_logging.mock_calls == [
             call.getLogger("pip"),
             call.getLogger().setLevel(mock_logging.WARNING)
@@ -851,9 +888,7 @@ class Test_AGPLVersionChecker(object):
         ]
         assert mock_mod_logger.mock_calls == [
             call.setLevel(mock_logging.WARNING),
-            call.debug('Git info: %s',
-                       {'url': None, 'commit': None, 'tag': None,
-                        'dirty': None}),
+            call.debug('Install does not appear to be a git clone'),
             call.debug('pip info: %s', {'url': 'http://my.package.url/pip',
                                         'version': '1.2.3'}),
             call.debug('pkg_resources info: %s',
@@ -862,6 +897,43 @@ class Test_AGPLVersionChecker(object):
             call.debug('Final package info: %s',
                        {'url': 'http://my.package.url/pip', 'commit': None,
                         'version': '1.2.3', 'tag': None})
+        ]
+        assert mock_is_git.mock_calls == [call()]
+
+    def test_is_git_clone_true(self):
+        foo_path = '/foo/bar/awslimitchecker/awslimitchecker/versioncheck.pyc'
+
+        with patch.multiple(
+                '%s.os.path' % self.mpb,
+                abspath=DEFAULT,
+                exists=DEFAULT,
+        ) as mocks:
+            mocks['abspath'].return_value = foo_path
+            mocks['exists'].return_value = True
+            cls = AGPLVersionChecker()
+            res = cls._is_git_clone
+        assert res is True
+        assert mocks['abspath'].call_count == 1
+        assert mocks['exists'].mock_calls == [
+            call('/foo/bar/awslimitchecker/.git')
+        ]
+
+    def test_is_git_clone_false(self):
+        foo_path = '/foo/bar/awslimitchecker/awslimitchecker/versioncheck.pyc'
+
+        with patch.multiple(
+                '%s.os.path' % self.mpb,
+                abspath=DEFAULT,
+                exists=DEFAULT,
+        ) as mocks:
+            mocks['abspath'].return_value = foo_path
+            mocks['exists'].return_value = False
+            cls = AGPLVersionChecker()
+            res = cls._is_git_clone
+        assert res is False
+        assert mocks['abspath'].call_count == 1
+        assert mocks['exists'].mock_calls == [
+            call('/foo/bar/awslimitchecker/.git')
         ]
 
 
@@ -1171,8 +1243,8 @@ class Test_AGPLVersionChecker_Acceptance(object):
         except subprocess.CalledProcessError:
             pass
 
-    def _set_git_config(self):
-        if os.environ.get('TRAVIS', '') != 'true':
+    def _set_git_config(self, set_in_travis=False):
+        if not set_in_travis and os.environ.get('TRAVIS', '') != 'true':
             print("not running in Travis; not setting git config")
             return
         try:
@@ -1289,6 +1361,25 @@ class Test_AGPLVersionChecker_Acceptance(object):
         res = subprocess.call(final_args)
         print("\n" + "#" * 20 + " DONE: " + ' '.join(final_args) + "#" * 20)
         assert res == 0
+
+    def _make_git_repo(self, path):
+        """create a git repo under path; return the commit"""
+        print("creating git repository in %s" % path)
+        old_cwd = os.getcwd()
+        os.chdir(path)
+        res = subprocess.call(['git', 'init', '.'])
+        assert res == 0
+        with open('foo', 'w') as fh:
+            fh.write('foo')
+        res = subprocess.call(['git', 'add', 'foo'])
+        assert res == 0
+        self._set_git_config(set_in_travis=True)
+        res = subprocess.call(['git', 'commit', '-m', 'foo'])
+        assert res == 0
+        commit = _get_git_commit()
+        print("git repository in %s commit: %s" % (path, commit))
+        os.chdir(old_cwd)
+        return commit
 
     def _get_alc_version(self, path):
         """
@@ -1622,5 +1713,23 @@ class Test_AGPLVersionChecker_Acceptance(object):
         expected = 'awslimitchecker {v} (see <{u}> for source code)'.format(
             v='%s@%s*' % (_VERSION, commit),
             u='https://github.com/jantman/awslimitchecker.git'
+        )
+        assert expected in version_output
+
+    def test_install_sdist_in_git_repo(self, tmpdir):
+        """regression test for issue #73"""
+        path = str(tmpdir)
+        # setup a git repo in tmpdir
+        self._make_git_repo(path)
+        # make the venv
+        self._make_venv(path)
+        # build the sdist
+        pkg_path = self._make_package('sdist', path)
+        # install ALC in it
+        self._pip_install(path, [pkg_path])
+        version_output = self._get_alc_version(path)
+        expected = 'awslimitchecker {v} (see <{u}> for source code)'.format(
+            v=_VERSION,
+            u='https://github.com/jantman/awslimitchecker'
         )
         assert expected in version_output

--- a/awslimitchecker/tests/test_versioncheck.py
+++ b/awslimitchecker/tests/test_versioncheck.py
@@ -1552,6 +1552,15 @@ class Test_AGPLVersionChecker_Acceptance(object):
         )
         assert expected in version_output
 
+    def get_commit_or_tag(self):
+        """return tag if there is one, else commit"""
+        commit = _get_git_commit()
+        tag = _get_git_tag(commit)
+        print("Found commit=%s, tag=%s" % (commit, tag))
+        if tag is not None:
+            return tag
+        return commit
+
     # this doesn't work on PRs, because we can't check out the hash
     @pytest.mark.skipif(os.environ.get('TRAVIS_PULL_REQUEST', 'false') !=
                         'false', reason='git tests dont work on PRs')
@@ -1560,7 +1569,7 @@ class Test_AGPLVersionChecker_Acceptance(object):
         status = self._check_git_pushed()
         assert status != 1, "git clone not equal to origin"
         assert status != 2, 'git clone is dirty'
-        commit = _get_git_commit()
+        commit = self.get_commit_or_tag()
         path = str(tmpdir)
         print(_check_output([
             'git',
@@ -1590,7 +1599,7 @@ class Test_AGPLVersionChecker_Acceptance(object):
         status = self._check_git_pushed()
         assert status != 1, "git clone not equal to origin"
         assert status != 2, 'git clone is dirty'
-        commit = _get_git_commit()
+        commit = self.get_commit_or_tag()
         path = str(tmpdir)
         print(_check_output([
             'git',

--- a/awslimitchecker/trustedadvisor.py
+++ b/awslimitchecker/trustedadvisor.py
@@ -42,6 +42,7 @@ import boto.support
 from dateutil import parser
 import logging
 from .connectable import Connectable
+from .utils import boto_query_wrapper
 
 logger = logging.getLogger(__name__)
 
@@ -140,7 +141,10 @@ class TrustedAdvisor(Connectable):
             return
         check_id, metadata = tmp
         region = self.ta_region or self.conn.region.name
-        checks = self.conn.describe_trusted_advisor_check_result(check_id)
+        checks = boto_query_wrapper(
+            self.conn.describe_trusted_advisor_check_result,
+            check_id
+        )
         check_datetime = parser.parse(checks['result']['timestamp'])
         logger.debug("Got TrustedAdvisor data for check %s as of %s",
                      check_id, check_datetime)
@@ -166,7 +170,10 @@ class TrustedAdvisor(Connectable):
         """
         logger.debug("Querying Trusted Advisor checks")
         try:
-            checks = self.conn.describe_trusted_advisor_checks('en')['checks']
+            checks = boto_query_wrapper(
+                self.conn.describe_trusted_advisor_checks,
+                'en'
+            )['checks']
         except boto.exception.JSONResponseError as ex:
             if (
                     '__type' in ex.body and

--- a/awslimitchecker/utils.py
+++ b/awslimitchecker/utils.py
@@ -180,7 +180,9 @@ def paginate_query(function_ref, *argv, **kwargs):
         'alc_marker_path', 'alc_data_path', 'alc_marker_param'
     ]
     result = invoke_with_throttling_retries(function_ref, *argv, **kwargs)
-    if isinstance(result, ResultSet) and result.next_token is not None:
+    if isinstance(result, ResultSet) and result.next_token is None:
+        return result
+    elif isinstance(result, ResultSet) and result.next_token is not None:
         return _paginate_resultset(result, function_ref, *argv, **kwargs)
     elif isinstance(result, dict):
         if set(paginate_dict_params).issubset(kwargs):

--- a/awslimitchecker/utils.py
+++ b/awslimitchecker/utils.py
@@ -150,7 +150,8 @@ def boto_query_wrapper(function_ref, *argv, **kwargs):
 
     Calls :py:func:`~.invoke_with_throttling_retries` and returns the result.
 
-    Also provides an extension point for future logic to wrap all boto calls.
+    Also provides an extension point for future logic to wrap all boto calls,
+    such as handling pagination in responses.
 
     :param function_ref: the function to call
     :type function_ref: function

--- a/awslimitchecker/utils.py
+++ b/awslimitchecker/utils.py
@@ -134,7 +134,7 @@ def invoke_with_throttling_retries(function_ref, *argv, **kwargs):
         try:
             retval = function_ref(*argv, **kwargs)
             return retval
-        except BotoServerError, e:
+        except BotoServerError as e:
             if e.code != IGNORE_CODE:
                 raise e
             if retries == MAX_RETRIES:

--- a/awslimitchecker/utils.py
+++ b/awslimitchecker/utils.py
@@ -342,17 +342,14 @@ def boto_query_wrapper(function_ref, *argv, **kwargs):
     """
     Function to wrap all boto query method calls, for throttling and pagination.
 
-    Calls :py:func:`~.invoke_with_throttling_retries` and returns the result.
-    If ``kwargs['alc_paginate']`` is ``True``, call :py:func:`~.paginate_query`
-    instead, and return that result.
+    Calls :py:func:`~.paginate_query` and returns the result.
 
     :param function_ref: the function to call
     :type function_ref: function
     :param argv: the parameters to pass to the function
     :type argv: tuple
     :param kwargs: keyword arguments to pass to the function
-      (:py:func:`~.invoke_with_throttling_retries` or
-      :py:func:`~.paginate_query`)
+      (:py:func:`~.paginate_query`)
     :type kwargs: dict
     :returns: return value of ``function_ref``
     """

--- a/awslimitchecker/utils.py
+++ b/awslimitchecker/utils.py
@@ -97,7 +97,7 @@ def dict2cols(d, spaces=2, separator=' '):
     return s
 
 
-def invoke_with_throttling_retries(function_ref, *argv):
+def invoke_with_throttling_retries(function_ref, *argv, **kwargs):
     """
     Invoke a Boto operation using an exponential backoff in the case of
     API request throttling.
@@ -121,6 +121,9 @@ def invoke_with_throttling_retries(function_ref, *argv):
     :type function_ref: function
     :param argv: the parameters to pass to the function
     :type argv: tuple
+    :param kwargs: keyword arguments to pass to the function. Any arguments
+    with names starting with "alc_" will be removed for internal use.
+    :type kwargs: dict
     """
     IGNORE_CODE = 'Throttling'
     MAX_RETRIES = 5
@@ -129,7 +132,7 @@ def invoke_with_throttling_retries(function_ref, *argv):
     retries = 0
     while True:
         try:
-            retval = function_ref(*argv)
+            retval = function_ref(*argv, **kwargs)
             return retval
         except BotoServerError, e:
             if e.code != IGNORE_CODE:

--- a/awslimitchecker/utils.py
+++ b/awslimitchecker/utils.py
@@ -142,3 +142,28 @@ def invoke_with_throttling_retries(function_ref, *argv):
                     "retrying", function_ref, stime)
         time.sleep(stime)
         retries += 1
+
+
+def boto_query_wrapper(function_ref, *argv, **kwargs):
+    """
+    Function to wrap all boto query method calls, for throttling and pagination.
+
+    Calls :py:func:`~.invoke_with_throttling_retries` and returns the result.
+
+    Also provides an extension point for future logic to wrap all boto calls.
+
+    :param function_ref: the function to call
+    :type function_ref: function
+    :param argv: the parameters to pass to the function
+    :type argv: tuple
+    :param kwargs: keyword arguments to pass to the function. Any arguments
+    with names starting with "alc_" will be removed for internal use.
+    :type kwargs: dict
+    :returns: return value of ``function_ref``
+    """
+    pass_kwargs = {}
+    for k, v in kwargs.items():
+        if not k.startswith('alc_'):
+            pass_kwargs[k] = v
+    result = invoke_with_throttling_retries(function_ref, *argv, **pass_kwargs)
+    return result

--- a/awslimitchecker/utils.py
+++ b/awslimitchecker/utils.py
@@ -111,18 +111,18 @@ def invoke_with_throttling_retries(function_ref, *argv, **kwargs):
 
     To use, transform:
 
-        conn.action(args)
+        ``conn.action(args)``
 
     into:
 
-        invoke_with_throttling_retries(conn.action, args)
+        ``invoke_with_throttling_retries(conn.action, args)``
 
     :param function_ref: the function to call
     :type function_ref: function
     :param argv: the parameters to pass to the function
     :type argv: tuple
     :param kwargs: keyword arguments to pass to the function. Any arguments
-    with names starting with "alc_" will be removed for internal use.
+      with names starting with ``alc_`` will be removed for internal use.
     :type kwargs: dict
     """
     IGNORE_CODE = 'Throttling'
@@ -152,7 +152,6 @@ def boto_query_wrapper(function_ref, *argv, **kwargs):
     Function to wrap all boto query method calls, for throttling and pagination.
 
     Calls :py:func:`~.invoke_with_throttling_retries` and returns the result.
-
     Also provides an extension point for future logic to wrap all boto calls,
     such as handling pagination in responses.
 
@@ -161,7 +160,7 @@ def boto_query_wrapper(function_ref, *argv, **kwargs):
     :param argv: the parameters to pass to the function
     :type argv: tuple
     :param kwargs: keyword arguments to pass to the function. Any arguments
-    with names starting with "alc_" will be removed for internal use.
+      with names starting with ``alc_`` will be removed for internal use.
     :type kwargs: dict
     :returns: return value of ``function_ref``
     """

--- a/awslimitchecker/versioncheck.py
+++ b/awslimitchecker/versioncheck.py
@@ -104,15 +104,18 @@ class AGPLVersionChecker(object):
             'tag': None,
             'commit': None
         }
-        git_info = self._find_git_info()
-        logger.debug("Git info: %s", git_info)
-        for k, v in git_info.items():
-            if v is not None:
-                res[k] = v
-        if git_info['dirty'] and res['tag'] is not None:
-            res['tag'] += '*'
-        if git_info['dirty'] and res['commit'] is not None:
-            res['commit'] += '*'
+        if self._is_git_clone:
+            git_info = self._find_git_info()
+            logger.debug("Git info: %s", git_info)
+            for k, v in git_info.items():
+                if v is not None:
+                    res[k] = v
+            if git_info['dirty'] and res['tag'] is not None:
+                res['tag'] += '*'
+            if git_info['dirty'] and res['commit'] is not None:
+                res['commit'] += '*'
+        else:
+            logger.debug("Install does not appear to be a git clone")
         try:
             pip_info = self._find_pip_info()
         except Exception:
@@ -134,6 +137,23 @@ class AGPLVersionChecker(object):
             res['url'] = pkg_info['url']
         logger.debug("Final package info: %s", res)
         return res
+
+    @property
+    def _is_git_clone(self):
+        """
+        Attempt to determine whether this package is installed via git or not.
+
+        :rtype: bool
+        :returns: True if installed via git, False otherwise
+        """
+        distpath = os.path.normpath(
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                '../'
+            )
+        )
+        gitpath = os.path.join(distpath, '.git')
+        return os.path.exists(gitpath)
 
     def _find_pkg_info(self):
         """

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -65,6 +65,11 @@ First, note that all calls to AWS APIs should be handled through
 retries (with exponential backoff) when API request rate limits are hit,
 and also handles paginated responses if they're not handled by boto.
 
+Second, note that queries which may be paginated __and return a dict__ instead
+of a ResultSet object must have the proper parameters for
+:py:func:`~awslimitchecker.utils._paginate_dict` passed in to
+:py:func:`~awslimitchecker.utils.boto_query_wrapper`.
+
 1. Add a new :py:class:`~.AwsLimit` instance to the return value of the
    Service class's :py:meth:`~._AwsService.get_limits` method.
 2. In the Service class's :py:meth:`~._AwsService.find_usage` method (or a method

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -65,7 +65,7 @@ First, note that all calls to AWS APIs should be handled through
 retries (with exponential backoff) when API request rate limits are hit,
 and also handles paginated responses if they're not handled by boto.
 
-Second, note that queries which may be paginated __and return a dict__ instead
+Second, note that queries which may be paginated **and return a dict** instead
 of a ResultSet object must have the proper parameters for
 :py:func:`~awslimitchecker.utils._paginate_dict` passed in to
 :py:func:`~awslimitchecker.utils.boto_query_wrapper`.

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -60,6 +60,11 @@ Guidelines
 Adding New Limits and Checks to Existing Services
 -------------------------------------------------
 
+First, note that all calls to AWS APIs should be handled through
+:py:func:`~awslimitchecker.utils.boto_query_wrapper`, which handles
+retries (with exponential backoff) when API request rate limits are hit,
+and also handles paginated responses if they're not handled by boto.
+
 1. Add a new :py:class:`~.AwsLimit` instance to the return value of the
    Service class's :py:meth:`~._AwsService.get_limits` method.
 2. In the Service class's :py:meth:`~._AwsService.find_usage` method (or a method
@@ -77,6 +82,11 @@ Adding New Services
 
 All Services are sublcasses of :py:class:`~awslimitchecker.services.base._AwsService`
 using the :py:mod:`abc` module.
+
+First, note that all calls to AWS APIs should be handled through
+:py:func:`~awslimitchecker.utils.boto_query_wrapper`, which handles
+retries (with exponential backoff) when API request rate limits are hit,
+and also handles paginated responses if they're not handled by boto.
 
 1. The new service name should be in CamelCase, preferably one word (if not one word, it should be underscore-separated).
    In ``awslimitchecker/services``, use the ``addservice`` script; this will create a templated service class in the

--- a/docs/source/internals.rst
+++ b/docs/source/internals.rst
@@ -22,6 +22,12 @@ connections; connections are created lazily as needed and stored as a class attr
 services, limits and default limit values without ever connecting to AWS (this is also used to generate the
 :ref:`Supported Limits <limits>` documentation automatically).
 
+All calls to the AWS APIs should be made through :py:func:`~awslimitchecker.utils.boto_query_wrapper`. This function
+encapsulates both retrying queries with an exponential backoff when queries are throttled due to your account hitting
+the `request rate limit <http://docs.aws.amazon.com/AWSEC2/latest/APIReference/query-api-troubleshooting.html#api-request-rate>`_
+(via :py:func:`~awslimitchecker.utils.invoke_with_throttling_retries`) and automatically paginating query responses
+that aren't automatically handled by boto.
+
 When :py:class:`~awslimitchecker.checker.AwsLimitChecker` is instantiated, it imports :py:mod:`~awslimitchecker.services`
 which in turn creates instances of all ``awslimitchecker.services.*`` classes and adds them to a dict mapping the
 string Service Name to the Service Class instance. These instances are used for all interaction with the services.

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
   execnet
   pep8
   py
-  pytest
+  pytest>=2.8.3
   pytest-cache
   pytest-cov
   pytest-pep8
@@ -44,7 +44,7 @@ deps =
   execnet
   pep8
   py
-  pytest
+  pytest>=2.8.3
   pytest-cache
   pytest-cov
   pytest-pep8

--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,7 @@ commands =
     # link check
     # -n runs in nit-picky mode
     # -W turns warnings into errors
-    #sphinx-build -a -n -W -b linkcheck {toxinidir}/docs/source {toxinidir}/docs/build/html
+    sphinx-build -a -n -W -b linkcheck {toxinidir}/docs/source {toxinidir}/docs/build/html
     # build
     sphinx-build -a -n -W -b html {toxinidir}/docs/source {toxinidir}/docs/build/html
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27,py32,py33,py34,pypy,pypy3}-{unit,versioncheck}, docs, cov
+envlist = {py26,py27,py32,py33,py34,pypy,pypy3}-{unit,versioncheck}, docs
 
 [testenv]
 deps =
@@ -29,7 +29,7 @@ whitelist_externals = env
 commands =
     env
     pip freeze
-    unit: py.test -rxs -vv --pep8 --flakes --blockage -m "not versioncheck" {posargs} awslimitchecker
+    unit: py.test -rxs -vv --pep8 --flakes --blockage -m "not versioncheck" --cov-report term-missing --cov-report xml --cov-report html --cov-config {toxinidir}/.coveragerc --cov=awslimitchecker {posargs} awslimitchecker
     versioncheck: py.test -rxs -vv -s --pep8 --flakes --blockage -m "versioncheck" {posargs} awslimitchecker
 
 # always recreate the venv
@@ -94,14 +94,3 @@ commands =
     # build
     sphinx-build -a -n -W -b html {toxinidir}/docs/source {toxinidir}/docs/build/html
 
-[testenv:cov]
-# this runs coverage report
-passenv=TRAVIS*
-setenv =
-    TOXINIDIR={toxinidir}
-    TOXDISTDIR={distdir}
-basepython = python2.7
-commands =
-    env
-    pip freeze
-    py.test -rxs --cov-report term-missing --cov-report xml --cov-report html --cov-config {toxinidir}/.coveragerc --cov=awslimitchecker --blockage -m "not versioncheck" {posargs}


### PR DESCRIPTION
This adds handling for pagination of API responses.

* Queries that return a ``boto.resultset.ResultSet`` object are paginated automatically.
* Queries that return a dict need some additional kwargs to power the pagination