### PR TITLE
Support MFA device for cross account role switching

### DIFF
--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -50,7 +50,7 @@ class AwsLimitChecker(object):
 
     def __init__(self, warning_threshold=80, critical_threshold=99,
                  account_id=None, account_role=None, region=None,
-                 external_id=None):
+                 external_id=None, mfa_serial_number=None, mfa_token=None):
         """
         Main AwsLimitChecker class - this should be the only externally-used
         portion of awslimitchecker.
@@ -83,6 +83,12 @@ class AwsLimitChecker(object):
           com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>`_
           string to use when assuming a role via STS.
         :type external_id: str
+        :param mfa_serial_number: (optional) the `MFA Serial Number` string to_
+        use when assuming a role via STS.
+        :type mfa_serial_number: str
+        :param mfa_token: (optional) the `MFA Token` string to use when_
+        assuming a role via STS.
+        :type mfa_token: str
         """
         # ###### IMPORTANT license notice ##########
         # Pursuant to Sections 5(b) and 13 of the GNU Affero General Public
@@ -112,18 +118,23 @@ class AwsLimitChecker(object):
         self.account_id = account_id
         self.account_role = account_role
         self.external_id = external_id
+        self.mfa_serial_number = mfa_serial_number
+        self.mfa_token = mfa_token
         self.region = region
         self.services = {}
         self.ta = TrustedAdvisor(
             account_id=account_id,
             account_role=account_role,
             region=region,
-            external_id=external_id
+            external_id=external_id,
+            mfa_serial_number=mfa_serial_number,
+            mfa_token=mfa_token
         )
         for sname, cls in _services.items():
             self.services[sname] = cls(warning_threshold, critical_threshold,
                                        account_id, account_role, region,
-                                       external_id)
+                                       external_id, mfa_serial_number,
+                                       mfa_token)
 
     def get_version(self):
         """

--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -84,10 +84,10 @@ class AwsLimitChecker(object):
           string to use when assuming a role via STS.
         :type external_id: str
         :param mfa_serial_number: (optional) the `MFA Serial Number` string to_
-        use when assuming a role via STS.
+          use when assuming a role via STS.
         :type mfa_serial_number: str
         :param mfa_token: (optional) the `MFA Token` string to use when_
-        assuming a role via STS.
+          assuming a role via STS.
         :type mfa_token: str
         """
         # ###### IMPORTANT license notice ##########

--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -83,10 +83,10 @@ class AwsLimitChecker(object):
           com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>`_
           string to use when assuming a role via STS.
         :type external_id: str
-        :param mfa_serial_number: (optional) the `MFA Serial Number` string to_
+        :param mfa_serial_number: (optional) the `MFA Serial Number` string to
           use when assuming a role via STS.
         :type mfa_serial_number: str
-        :param mfa_token: (optional) the `MFA Token` string to use when_
+        :param mfa_token: (optional) the `MFA Token` string to use when
           assuming a role via STS.
         :type mfa_token: str
         """

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -139,6 +139,12 @@ class Runner(object):
         p.add_argument('-E', '--external-id', action='store', type=str,
                        default=None, help='External ID to use when assuming '
                        'a role via STS')
+        p.add_argument('-M', '--mfa-serial-number', action='store', type=str,
+                       default=None, help='MFA Serial Number to use when '
+                       'assuming a role via STS')
+        p.add_argument('-T', '--mfa-token', action='store', type=str,
+                       default=None, help='MFA Token to use when assuming '
+                       'a role via STS')
         p.add_argument('-r', '--region', action='store',
                        type=str, default=None,
                        help='AWS region name to connect to; required for STS')
@@ -301,7 +307,9 @@ class Runner(object):
             account_id=args.sts_account_id,
             account_role=args.sts_account_role,
             region=args.region,
-            external_id=args.external_id
+            external_id=args.external_id,
+            mfa_serial_number=args.mfa_serial_number,
+            mfa_token=args.mfa_token
         )
 
         if args.version:

--- a/awslimitchecker/services/base.py
+++ b/awslimitchecker/services/base.py
@@ -85,11 +85,11 @@ class _AwsService(Connectable):
           com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>`_
           string to use when assuming a role via STS.
         :type external_id: str
-        :param mfa_serial_number: (optional) the `MFA Serial Number` string to_
-        use when assuming a role via STS.
+        :param mfa_serial_number: (optional) the `MFA Serial Number` string to
+          use when assuming a role via STS.
         :type mfa_serial_number: str
-        :param mfa_token: (optional) the `MFA Token` string to use when_
-        assuming a role via STS.
+        :param mfa_token: (optional) the `MFA Token` string to use when
+          assuming a role via STS.
         :type mfa_token: str
         """
         self.warning_threshold = warning_threshold

--- a/awslimitchecker/services/base.py
+++ b/awslimitchecker/services/base.py
@@ -50,7 +50,8 @@ class _AwsService(Connectable):
     service_name = 'baseclass'
 
     def __init__(self, warning_threshold, critical_threshold, account_id=None,
-                 account_role=None, region=None, external_id=None):
+                 account_role=None, region=None, external_id=None,
+                 mfa_serial_number=None, mfa_token=None):
         """
         Describes an AWS service and its limits, and provides methods to
         query current utilization.
@@ -84,6 +85,12 @@ class _AwsService(Connectable):
           com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>`_
           string to use when assuming a role via STS.
         :type external_id: str
+        :param mfa_serial_number: (optional) the `MFA Serial Number` string to_
+        use when assuming a role via STS.
+        :type mfa_serial_number: str
+        :param mfa_token: (optional) the `MFA Token` string to use when_
+        assuming a role via STS.
+        :type mfa_token: str
         """
         self.warning_threshold = warning_threshold
         self.critical_threshold = critical_threshold
@@ -91,6 +98,8 @@ class _AwsService(Connectable):
         self.account_role = account_role
         self.region = region
         self.external_id = external_id
+        self.mfa_serial_number = mfa_serial_number
+        self.mfa_token = mfa_token
 
         self.limits = {}
         self.limits = self.get_limits()

--- a/awslimitchecker/tests/test_checker.py
+++ b/awslimitchecker/tests/test_checker.py
@@ -111,14 +111,14 @@ class TestAwsLimitChecker(object):
         }
         # _AwsService instances should exist, but have no other calls
         assert self.mock_foo.mock_calls == [
-            call(80, 99, None, None, None, None)
+            call(80, 99, None, None, None, None, None, None)
         ]
         assert self.mock_bar.mock_calls == [
-            call(80, 99, None, None, None, None)
+            call(80, 99, None, None, None, None, None, None)
         ]
         assert self.mock_ta_constr.mock_calls == [
             call(account_id=None, account_role=None, region=None,
-                 external_id=None)
+                 external_id=None, mfa_serial_number=None, mfa_token=None)
         ]
         assert self.mock_svc1.mock_calls == []
         assert self.mock_svc2.mock_calls == []
@@ -174,11 +174,15 @@ class TestAwsLimitChecker(object):
             'SvcBar': mock_svc2
         }
         # _AwsService instances should exist, but have no other calls
-        assert mock_foo.mock_calls == [call(5, 22, None, None, None, None)]
-        assert mock_bar.mock_calls == [call(5, 22, None, None, None, None)]
+        assert mock_foo.mock_calls == [
+            call(5, 22, None, None, None, None, None, None)
+        ]
+        assert mock_bar.mock_calls == [
+            call(5, 22, None, None, None, None, None, None)
+        ]
         assert mock_ta_constr.mock_calls == [
             call(account_id=None, account_role=None, region=None,
-                 external_id=None)
+                 external_id=None, mfa_serial_number=None, mfa_token=None)
         ]
         assert mock_svc1.mock_calls == []
         assert mock_svc2.mock_calls == []
@@ -215,14 +219,14 @@ class TestAwsLimitChecker(object):
         }
         # _AwsService instances should exist, but have no other calls
         assert mock_foo.mock_calls == [
-            call(80, 99, None, None, 'myregion', None)
+            call(80, 99, None, None, 'myregion', None, None, None)
         ]
         assert mock_bar.mock_calls == [
-            call(80, 99, None, None, 'myregion', None)
+            call(80, 99, None, None, 'myregion', None, None, None)
         ]
         assert mock_ta_constr.mock_calls == [
             call(account_id=None, account_role=None, region='myregion',
-                 external_id=None)
+                 external_id=None, mfa_serial_number=None, mfa_token=None)
         ]
         assert mock_svc1.mock_calls == []
         assert mock_svc2.mock_calls == []
@@ -263,17 +267,21 @@ class TestAwsLimitChecker(object):
         }
         # _AwsService instances should exist, but have no other calls
         assert mock_foo.mock_calls == [
-            call(80, 99, '123456789012', 'myrole', 'myregion', None)
+            call(80, 99, '123456789012', 'myrole', 'myregion', None,
+                 None, None)
         ]
         assert mock_bar.mock_calls == [
-            call(80, 99, '123456789012', 'myrole', 'myregion', None)
+            call(80, 99, '123456789012', 'myrole', 'myregion', None,
+                 None, None)
         ]
         assert mock_ta_constr.mock_calls == [
             call(
                 account_id='123456789012',
                 account_role='myrole',
                 region='myregion',
-                external_id=None
+                external_id=None,
+                mfa_serial_number=None,
+                mfa_token=None
             )
         ]
         assert mock_svc1.mock_calls == []
@@ -307,7 +315,9 @@ class TestAwsLimitChecker(object):
                     account_id='123456789012',
                     account_role='myrole',
                     region='myregion',
-                    external_id='myextid'
+                    external_id='myextid',
+                    mfa_serial_number=None,
+                    mfa_token=None
                 )
         # dict should be of _AwsService instances
         assert cls.services == {
@@ -316,17 +326,21 @@ class TestAwsLimitChecker(object):
         }
         # _AwsService instances should exist, but have no other calls
         assert mock_foo.mock_calls == [
-            call(80, 99, '123456789012', 'myrole', 'myregion', 'myextid')
+            call(80, 99, '123456789012', 'myrole', 'myregion', 'myextid',
+                 None, None)
         ]
         assert mock_bar.mock_calls == [
-            call(80, 99, '123456789012', 'myrole', 'myregion', 'myextid')
+            call(80, 99, '123456789012', 'myrole', 'myregion', 'myextid',
+                 None, None)
         ]
         assert mock_ta_constr.mock_calls == [
             call(
                 account_id='123456789012',
                 account_role='myrole',
                 region='myregion',
-                external_id='myextid'
+                external_id='myextid',
+                mfa_serial_number=None,
+                mfa_token=None
             )
         ]
         assert mock_svc1.mock_calls == []

--- a/awslimitchecker/tests/test_runner.py
+++ b/awslimitchecker/tests/test_runner.py
@@ -169,6 +169,12 @@ class TestAwsLimitCheckerRunner(object):
             call().add_argument('-E', '--external-id', action='store', type=str,
                                 default=None, help='External ID to use when '
                                 'assuming a role via STS'),
+            call().add_argument('-M', '--mfa-serial-number', action='store',
+                                type=str, default=None, help='MFA Serial '
+                                'Number to use when assuming a role via STS'),
+            call().add_argument('-T', '--mfa-token', action='store', type=str,
+                                default=None, help='MFA Token to use when '
+                                'assuming a role via STS'),
             call().add_argument('-r', '--region', action='store',
                                 type=str, default=None,
                                 help='AWS region name to connect to; required '
@@ -211,7 +217,9 @@ class TestAwsLimitCheckerRunner(object):
                 account_id=None,
                 account_role=None,
                 region=None,
-                external_id=None
+                external_id=None,
+                mfa_serial_number=None,
+                mfa_token=None
             ),
             call().get_project_url(),
             call().get_version()
@@ -561,7 +569,9 @@ class TestAwsLimitCheckerRunner(object):
                 account_id=None,
                 account_role=None,
                 region='myregion',
-                external_id=None
+                external_id=None,
+                mfa_serial_number=None,
+                mfa_token=None
             )
         ]
         assert self.cls.service_name is None
@@ -594,7 +604,9 @@ class TestAwsLimitCheckerRunner(object):
                 account_id='098765432109',
                 account_role='myrole',
                 region='myregion',
-                external_id=None
+                external_id=None,
+                mfa_serial_number=None,
+                mfa_token=None
             )
         ]
         assert self.cls.service_name is None
@@ -629,7 +641,9 @@ class TestAwsLimitCheckerRunner(object):
                 account_id='098765432109',
                 account_role='myrole',
                 region='myregion',
-                external_id='myextid'
+                external_id='myextid',
+                mfa_serial_number=None,
+                mfa_token=None
             )
         ]
         assert self.cls.service_name is None
@@ -676,7 +690,8 @@ class TestAwsLimitCheckerRunner(object):
         assert excinfo.value.code == 8
         assert mock_alc.mock_calls == [
             call(warning_threshold=50, critical_threshold=99, account_id=None,
-                 account_role=None, region=None, external_id=None)
+                 account_role=None, region=None, external_id=None,
+                 mfa_serial_number=None, mfa_token=None)
         ]
 
     def test_entry_critical(self):
@@ -691,7 +706,8 @@ class TestAwsLimitCheckerRunner(object):
         assert excinfo.value.code == 9
         assert mock_alc.mock_calls == [
             call(warning_threshold=80, critical_threshold=95, account_id=None,
-                 account_role=None, region=None, external_id=None)
+                 account_role=None, region=None, external_id=None,
+                 mfa_serial_number=None, mfa_token=None)
         ]
 
     def test_entry_check_thresholds(self):

--- a/awslimitchecker/tests/test_trustedadvisor.py
+++ b/awslimitchecker/tests/test_trustedadvisor.py
@@ -84,6 +84,8 @@ class Test_TrustedAdvisor(object):
         assert cls.region == 'us-east-1'
         assert cls.ta_region is None
         assert cls.external_id is None
+        assert cls.mfa_serial_number is None
+        assert cls.mfa_token is None
 
     def test_init_sts(self):
         cls = TrustedAdvisor(account_id='aid', account_role='role', region='r')
@@ -93,6 +95,8 @@ class Test_TrustedAdvisor(object):
         assert cls.region == 'us-east-1'
         assert cls.ta_region == 'r'
         assert cls.external_id is None
+        assert cls.mfa_serial_number is None
+        assert cls.mfa_token is None
 
     def test_init_sts_external_id(self):
         cls = TrustedAdvisor(account_id='aid', account_role='role', region='r',
@@ -103,6 +107,8 @@ class Test_TrustedAdvisor(object):
         assert cls.region == 'us-east-1'
         assert cls.ta_region == 'r'
         assert cls.external_id == 'myeid'
+        assert cls.mfa_serial_number is None
+        assert cls.mfa_token is None
 
     def test_connect(self):
         cls = TrustedAdvisor()

--- a/awslimitchecker/trustedadvisor.py
+++ b/awslimitchecker/trustedadvisor.py
@@ -77,11 +77,11 @@ class TrustedAdvisor(Connectable):
           com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>`_
           string to use when assuming a role via STS.
         :type external_id: str
-        :param mfa_serial_number: (optional) the `MFA Serial Number` string to_
-        use when assuming a role via STS.
+        :param mfa_serial_number: (optional) the `MFA Serial Number` string to
+          use when assuming a role via STS.
         :type mfa_serial_number: str
-        :param mfa_token: (optional) the `MFA Token` string to use when_
-        assuming a role via STS.
+        :param mfa_token: (optional) the `MFA Token` string to use when
+          assuming a role via STS.
         :type mfa_token: str
         """
         self.conn = None

--- a/awslimitchecker/trustedadvisor.py
+++ b/awslimitchecker/trustedadvisor.py
@@ -57,7 +57,7 @@ class TrustedAdvisor(Connectable):
     service_name = 'TrustedAdvisor'
 
     def __init__(self, account_id=None, account_role=None, region=None,
-                 external_id=None):
+                 external_id=None, mfa_serial_number=None, mfa_token=None):
         """
         Class to contain all TrustedAdvisor-related logic.
 
@@ -77,6 +77,12 @@ class TrustedAdvisor(Connectable):
           com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>`_
           string to use when assuming a role via STS.
         :type external_id: str
+        :param mfa_serial_number: (optional) the `MFA Serial Number` string to_
+        use when assuming a role via STS.
+        :type mfa_serial_number: str
+        :param mfa_token: (optional) the `MFA Token` string to use when_
+        assuming a role via STS.
+        :type mfa_token: str
         """
         self.conn = None
         self.have_ta = True
@@ -85,6 +91,8 @@ class TrustedAdvisor(Connectable):
         self.region = 'us-east-1'
         self.ta_region = region
         self.external_id = external_id
+        self.mfa_serial_number = mfa_serial_number
+        self.mfa_token = mfa_token
 
     def connect(self):
         """Connect to API if not already connected; set self.conn."""

--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -27,7 +27,8 @@ use as a Nagios-compatible plugin).
    usage: awslimitchecker [-h] [-S SERVICE] [-s] [-l] [--list-defaults]
                           [-L LIMIT] [-u] [--iam-policy] [-W WARNING_THRESHOLD]
                           [-C CRITICAL_THRESHOLD] [-A STS_ACCOUNT_ID]
-                          [-R STS_ACCOUNT_ROLE] [-E EXTERNAL_ID] [-r REGION]
+                          [-R STS_ACCOUNT_ROLE] [-E EXTERNAL_ID]
+                          [-M MFA_SERIAL_NUMBER] [-T MFA_TOKEN] [-r REGION]
                           [--skip-ta] [--no-color] [-v] [-V]
    Report on AWS service limits and usage via boto, optionally warn about any
    services with usage nearing or exceeding their limits. For further help, see
@@ -65,6 +66,10 @@ use as a Nagios-compatible plugin).
                            for use with STS, the name of the IAM role to assume
      -E EXTERNAL_ID, --external-id EXTERNAL_ID
                            External ID to use when assuming a role via STS
+     -M MFA_SERIAL_NUMBER, --mfa-serial-number MFA_SERIAL_NUMBER
+                           MFA Serial Number to use when assuming a role via STS
+     -T MFA_TOKEN, --mfa-token MFA_TOKEN
+                           MFA Token to use when assuming a role via STS
      -r REGION, --region REGION
                            AWS region name to connect to; required for STS
      --skip-ta             do not attempt to pull *any* information on limits


### PR DESCRIPTION
Support MFA device for cross account role switching, reusing STS credentials between API calls as MFA Token cannot be used more than once.

This introduces two new optional command line arguments:

      -M MFA_SERIAL_NUMBER, --mfa-serial-number MFA_SERIAL_NUMBER
                        MFA Serial Number to use when assuming a role via STS
      -T MFA_TOKEN, --mfa-token MFA_TOKEN
                        MFA Token to use when assuming a role via STS
