### PR TITLE
Issues/117 - re-enable py35 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python:
+  - "3.5"
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 - TOXENV=py32-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py33-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py34-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
+- TOXENV=py35-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=pypy-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=pypy3-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py26-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
@@ -16,6 +17,7 @@ env:
 - TOXENV=py32-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py33-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py34-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
+- TOXENV=py35-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=pypy-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=pypy3-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=docs PIP_DOWNLOAD_CACHE=$HOME/.pip-cache

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 Pre-release (develop branch)
 ----------------------------
 
+* `#117 <https://github.com/jantman/awslimitchecker/issues/117>`_ fix Python 3.5 TravisCI tests and re-enable automatic testing for 3.5.
+
 0.3.0 (2016-02-18)
 ------------------
 


### PR DESCRIPTION
This re-enables py35 on TravisCI. This *does* increase build time - as far as I can tell, by up to 25% - but it's the only way I can figured out to get py35 working, since it's currently an on-demand installation in Travis, and there doesn't seem to be a clear way to install it myself at runtime.