### PR TITLE
Issues/116 - fix EC2 instance types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python:
+  - "3.5"
 sudo: false
 cache:
   directories:
@@ -9,6 +11,7 @@ env:
 - TOXENV=py32-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py33-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py34-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
+- TOXENV=py35-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=pypy-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=pypy3-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py26-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
@@ -16,6 +19,7 @@ env:
 - TOXENV=py32-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py33-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=py34-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
+- TOXENV=py35-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=pypy-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=pypy3-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
 - TOXENV=docs PIP_DOWNLOAD_CACHE=$HOME/.pip-cache

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 Pre-release (develop branch)
 ----------------------------
 
+* `#117 <https://github.com/jantman/awslimitchecker/issues/117>`_ fix Python 3.5 TravisCI tests and re-enable automatic testing for 3.5.
+
 0.3.0 (2016-02-18)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Pre-release (develop branch)
 ----------------------------
 
 * `#117 <https://github.com/jantman/awslimitchecker/issues/117>`_ fix Python 3.5 TravisCI tests and re-enable automatic testing for 3.5.
+* `#116 <https://github.com/jantman/awslimitchecker/issues/116>`_ add t2.nano EC2 instance type; fix typo - "m4.8xlarge" should have been "m4.10xlarge"; update default limits for m4.(4|10)xlarge
 
 0.3.0 (2016-02-18)
 ------------------

--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -415,6 +415,7 @@ class _Ec2Service(_AwsService):
         :rtype: list
         """
         GENERAL_TYPES = [
+            't2.nano',
             't2.micro',
             't2.small',
             't2.medium',
@@ -427,7 +428,7 @@ class _Ec2Service(_AwsService):
             'm4.xlarge',
             'm4.2xlarge',
             'm4.4xlarge',
-            'm4.8xlarge',
+            'm4.10xlarge'
         ]
 
         PREV_GENERAL_TYPES = [

--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -243,6 +243,8 @@ class _Ec2Service(_AwsService):
             'i2.8xlarge': (2, 20, 0),
             'd2.4xlarge': (10, 20, 5),
             'd2.8xlarge': (5, 20, 5),
+            'm4.4xlarge': (10, 20, 5),
+            'm4.10xlarge': (5, 20, 5)
         }
         limits = {}
         for i_type in self._instance_types():


### PR DESCRIPTION
- add t2.nano EC2 instance type
- fix typo - "m4.8xlarge" should have been "m4.10xlarge"
- update default limits for m4.(4|10)xlarge