### PR TITLE
Issues/116 - fix EC2 instance types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Pre-release (develop branch)
 ----------------------------
 
 * `#117 <https://github.com/jantman/awslimitchecker/issues/117>`_ fix Python 3.5 TravisCI tests and re-enable automatic testing for 3.5.
+* `#116 <https://github.com/jantman/awslimitchecker/issues/116>`_ add t2.nano EC2 instance type; fix typo - "m4.8xlarge" should have been "m4.10xlarge"; update default limits for m4.(4|10)xlarge
 
 0.3.0 (2016-02-18)
 ------------------

--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -415,6 +415,7 @@ class _Ec2Service(_AwsService):
         :rtype: list
         """
         GENERAL_TYPES = [
+            't2.nano',
             't2.micro',
             't2.small',
             't2.medium',
@@ -427,7 +428,7 @@ class _Ec2Service(_AwsService):
             'm4.xlarge',
             'm4.2xlarge',
             'm4.4xlarge',
-            'm4.8xlarge',
+            'm4.10xlarge'
         ]
 
         PREV_GENERAL_TYPES = [

--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -243,6 +243,8 @@ class _Ec2Service(_AwsService):
             'i2.8xlarge': (2, 20, 0),
             'd2.4xlarge': (10, 20, 5),
             'd2.8xlarge': (5, 20, 5),
+            'm4.4xlarge': (10, 20, 5),
+            'm4.10xlarge': (5, 20, 5)
         }
         limits = {}
         for i_type in self._instance_types():

--- a/awslimitchecker/tests/services/test_ec2.py
+++ b/awslimitchecker/tests/services/test_ec2.py
@@ -72,7 +72,7 @@ class Test_Ec2Service(object):
     def test_instance_types(self):
         cls = _Ec2Service(21, 43)
         types = cls._instance_types()
-        assert len(types) == 53
+        assert len(types) == 54
         assert 't2.micro' in types
         assert 'r3.8xlarge' in types
         assert 'c3.large' in types
@@ -121,7 +121,7 @@ class Test_Ec2Service(object):
     def test_get_limits_instances(self):
         cls = _Ec2Service(21, 43)
         limits = cls._get_limits_instances()
-        assert len(limits) == 54
+        assert len(limits) == 55
         # check a random subset of limits
         t2_micro = limits['Running On-Demand t2.micro instances']
         assert t2_micro.default_limit == 20


### PR DESCRIPTION
- add t2.nano EC2 instance type
- fix typo - "m4.8xlarge" should have been "m4.10xlarge"
- update default limits for m4.(4|10)xlarge