### PR TITLE
Issues/166 - reduce Travis test time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,8 @@ matrix:
       env: TOXENV=py34-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
     - python: "3.5"
       env: TOXENV=py35-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
-    - python: "2.6"
-      env: TOXENV=py26-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
     - python: "2.7"
       env: TOXENV=py27-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
-    - python: "3.2"
-      env: TOXENV=py32-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
-    - python: "3.3"
-      env: TOXENV=py33-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
-    - python: "3.4"
-      env: TOXENV=py34-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
     - python: "3.5"
       env: TOXENV=py35-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
     - python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ matrix:
       env: TOXENV=py34-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
     - python: "3.5"
       env: TOXENV=py35-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
-    - python: "pypy"
-      env: TOXENV=pypy-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
-    - python: "pypy3"
-      env: TOXENV=pypy3-unit PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
     - python: "2.6"
       env: TOXENV=py26-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
     - python: "2.7"
@@ -33,10 +29,6 @@ matrix:
       env: TOXENV=py34-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
     - python: "3.5"
       env: TOXENV=py35-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
-    - python: "pypy"
-      env: TOXENV=pypy-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
-    - python: "pypy3"
-      env: TOXENV=pypy3-versioncheck PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
     - python: "2.7"
       env: TOXENV=docs PIP_DOWNLOAD_CACHE=$HOME/.pip-cache
     - python: "2.7"

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ What It Does
 Requirements
 ------------
 
-* Python 2.6 through 3.5.
+* Python 2.6 through 3.5 (it should work, but is no longer tested, with PyPy and PyPy3).
 * Python `VirtualEnv <http://www.virtualenv.org/>`_ and ``pip`` (recommended installation method; your OS/distribution should have packages for these)
 * `boto3 <http://boto3.readthedocs.org/>`_ >= 1.2.3
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -291,8 +291,8 @@ Release Checklist
 
 1. Open an issue for the release; cut a branch off ``develop`` for that issue.
 2. Build docs (``tox -e docs``) and ensure they're current; commit any changes.
-3. Ensure that Travis tests are passing in all environments. If there were any changes to ``awslimitchecker.versioncheck``,
-   manually run the ``-versioncheck`` tox environments (these are problematic in Travis and with PRs).
+3. Ensure that Travis tests are passing in all environments. If there were any changes to ``awslimitchecker/versioncheck.py`` or ``awslimitchecker/tests/test_versioncheck.py``,
+   manually run ALL of the ``-versioncheck`` tox environments (these are problematic in Travis and with PRs).
 4. Ensure that test coverage is no less than the last release (ideally, 100%).
 5. Create or update an actual IAM user with the policy from ``awslimitchecker --iam-policy``;
    run the command line wrapper and ensure that the policy works and contains all needed permissions.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -51,7 +51,7 @@ Threshold
 Requirements
 ------------
 
-* Python 2.6 through 3.5.
+* Python 2.6 through 3.5 (it should work, but is no longer tested, with PyPy and PyPy3).
 * Python `VirtualEnv <http://www.virtualenv.org/>`_ and ``pip`` (recommended installation method; your OS/distribution should have packages for these)
 * `boto3 <http://boto3.readthedocs.org/>`_ >= 1.2.3
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -95,7 +95,7 @@ What It Does
 Requirements
 ------------
 
-* Python 2.6 through 3.5.
+* Python 2.6 through 3.5  (it should work, but is no longer tested, with PyPy and PyPy3).
 * Python `VirtualEnv <http://www.virtualenv.org/>`_ and ``pip`` (recommended installation method; your OS/distribution should have packages for these)
 * `boto3 <http://boto3.readthedocs.org/>`_ >= 1.2.3
 


### PR DESCRIPTION
Remove PyPy and PyPy3 testing, and drop -versioncheck to just py27 and py35