### PR TITLE
Issue #70 - Add ElasticBeanstalk service

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 Pre-release (develop branch)
 ----------------------------
 
+* `#177 <https://github.com/jantman/awslimitchecker/issues/177>`_ Integration tests weren't being properly skipped for PRs.
+
 0.4.1 (2016-03-15)
 ------------------
 

--- a/awslimitchecker/services/__init__.py
+++ b/awslimitchecker/services/__init__.py
@@ -42,6 +42,7 @@ from awslimitchecker.services.ec2 import _Ec2Service
 from awslimitchecker.services.vpc import _VpcService
 from awslimitchecker.services.autoscaling import _AutoscalingService
 from awslimitchecker.services.ebs import _EbsService
+from awslimitchecker.services.elasticbeanstalk import _ElasticBeanstalkService
 from awslimitchecker.services.elb import _ElbService
 from awslimitchecker.services.elasticache import _ElastiCacheService
 from awslimitchecker.services.rds import _RDSService

--- a/awslimitchecker/services/elasticbeanstalk.py
+++ b/awslimitchecker/services/elasticbeanstalk.py
@@ -1,0 +1,145 @@
+"""
+awslimitchecker/services/elasticbeanstalk.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2015 Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/pydnstest> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Brian Flad <bflad417@gmail.com> <http://www.fladpad.com>
+################################################################################
+"""
+
+import abc  # noqa
+import logging
+
+from .base import _AwsService
+from ..limit import AwsLimit
+
+logger = logging.getLogger(__name__)
+
+
+class _ElasticBeanstalkService(_AwsService):
+
+    service_name = 'ElasticBeanstalk'
+    api_name = 'elasticbeanstalk'  # AWS API name to connect to (boto3.client)
+
+    def find_usage(self):
+        """
+        Determine the current usage for each limit of this service,
+        and update corresponding Limit via
+        :py:meth:`~.AwsLimit._add_current_usage`.
+        """
+        logger.debug("Checking usage for service %s", self.service_name)
+        self.connect()
+        for lim in self.limits.values():
+            lim._reset_usage()
+        self._find_usage_applications()
+        self._find_usage_application_versions()
+        self._find_usage_environments()
+        self._have_usage = True
+        logger.debug("Done checking usage.")
+
+    def _find_usage_applications(self):
+        """find usage for ElasticBeanstalk applications"""
+        applications = self.conn.describe_applications()
+        self.limits['Applications']._add_current_usage(
+            len(applications['Applications']),
+            aws_type='AWS::ElasticBeanstalk::Application',
+        )
+
+    def _find_usage_application_versions(self):
+        """find usage for ElasticBeanstalk application verions"""
+        versions = self.conn.describe_application_versions()
+        self.limits['Application versions']._add_current_usage(
+            len(versions['ApplicationVersions']),
+            aws_type='AWS::ElasticBeanstalk::ApplicationVersion',
+        )
+
+    def _find_usage_environments(self):
+        """find usage for ElasticBeanstalk environments"""
+        environments = self.conn.describe_environments()
+        self.limits['Environments']._add_current_usage(
+            len(environments['Environments']),
+            aws_type='AWS::ElasticBeanstalk::Environment',
+        )
+
+    def get_limits(self):
+        """
+        Return all known limits for this service, as a dict of their names
+        to :py:class:`~.AwsLimit` objects.
+
+        :returns: dict of limit names to :py:class:`~.AwsLimit` objects
+        :rtype: dict
+        """
+        if self.limits != {}:
+            return self.limits
+        limits = {}
+        limits['Applications'] = AwsLimit(
+            'Applications',
+            self,
+            25,
+            self.warning_threshold,
+            self.critical_threshold,
+            limit_type='AWS::ElasticBeanstalk::Application',
+        )
+        limits['Application versions'] = AwsLimit(
+            'Application versions',
+            self,
+            500,
+            self.warning_threshold,
+            self.critical_threshold,
+            limit_type='AWS::ElasticBeanstalk::ApplicationVersion',
+        )
+        limits['Environments'] = AwsLimit(
+            'Environments',
+            self,
+            200,
+            self.warning_threshold,
+            self.critical_threshold,
+            limit_type='AWS::ElasticBeanstalk::Environment',
+        )
+        self.limits = limits
+        return limits
+
+    def required_iam_permissions(self):
+        """
+        Return a list of IAM Actions required for this Service to function
+        properly. All Actions will be shown with an Effect of "Allow"
+        and a Resource of "*".
+
+        :returns: list of IAM Action strings
+        :rtype: list
+        """
+        return [
+            "elasticbeanstalk:DescribeApplications",
+            "elasticbeanstalk:DescribeApplicationVersions",
+            "elasticbeanstalk:DescribeEnvironments",
+        ]

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -876,6 +876,176 @@ class RDS(object):
     }
 
 
+class ElasticBeanstalk(object):
+
+    test_find_usage_applications = {
+        'Applications': [
+            {
+                'ApplicationName': 'application-1',
+                'Description': 'description-1',
+                'DateCreated': datetime(2015, 1, 1),
+                'DateUpdated': datetime(2015, 1, 1),
+                'Versions': [
+                    'version-1',
+                    'version-2'
+                ],
+                'ConfigurationTemplates': [
+                     'config-1',
+                     'config-2'
+                ]
+            },
+            {
+                'ApplicationName': 'application-2',
+                'Description': 'description-2',
+                'DateCreated': datetime(2015, 1, 2),
+                'DateUpdated': datetime(2015, 1, 2),
+                'Versions': [
+                    'version-1',
+                    'version-2'
+                ],
+                'ConfigurationTemplates': [
+                     'config-1',
+                     'config-2'
+                ]
+            }
+        ]
+    }
+
+    test_find_usage_application_versions = {
+        'ApplicationVersions': [
+            {
+                'ApplicationName': 'application-1',
+                'Description': 'description-1',
+                'DateCreated': datetime(2015, 1, 1),
+                'DateUpdated': datetime(2015, 1, 1),
+                'SourceBundle': {
+                    'S3Bucket': 's3-bucket',
+                    'S3Key': 's3-key'
+                },
+                'VersionLabel': 'version-2'
+            },
+            {
+                'ApplicationName': 'application-1',
+                'Description': 'description-1',
+                'DateCreated': datetime(2015, 1, 1),
+                'DateUpdated': datetime(2015, 1, 1),
+                'SourceBundle': {
+                    'S3Bucket': 's3-bucket',
+                    'S3Key': 's3-key'
+                },
+                'VersionLabel': 'version-1'
+            },
+            {
+                'ApplicationName': 'application-2',
+                'Description': 'description-1',
+                'DateCreated': datetime(2015, 1, 2),
+                'DateUpdated': datetime(2015, 1, 2),
+                'SourceBundle': {
+                    'S3Bucket': 's3-bucket',
+                    'S3Key': 's3-key'
+                },
+                'VersionLabel': 'version-2'
+            },
+            {
+                'ApplicationName': 'application-2',
+                'Description': 'description-1',
+                'DateCreated': datetime(2015, 1, 2),
+                'DateUpdated': datetime(2015, 1, 2),
+                'SourceBundle': {
+                    'S3Bucket': 's3-bucket',
+                    'S3Key': 's3-key'
+                },
+                'VersionLabel': 'version-1'
+            }
+        ]
+    }
+
+    test_find_usage_environments = {
+        'Environments': [
+            {
+                'EnvironmentName': 'application-environment-1',
+                'EnvironmentId': 'environment-id-1',
+                'ApplicationName': 'application-1',
+                'VersionLabel': 'version-2',
+                'SolutionStackName': 'solution-stack',
+                'TemplateName': 'template-name',
+                'Description': 'description-1',
+                'EndpointURL': 'application-1.region.elasticbeanstalk.com',
+                'CNAME': 'application-1.elasticbeanstalk.com',
+                'DateCreated': datetime(2015, 1, 1),
+                'DateUpdated': datetime(2015, 1, 1),
+                'Status': 'Ready',
+                'AbortableOperationInProgress': False,
+                'Health': 'Green',
+                'HealthStatus': 'Ok',
+                'Resources': {
+                    'LoadBalancer': {
+                        'LoadBalancerName': 'load-balancer-1',
+                        'Domain': 'domain',
+                        'Listeners': [
+                            {
+                                'Protocol': 'http',
+                                'Port': 80
+                            }
+                        ]
+                    }
+                },
+                'Tier': {
+                    'Name': 'tier-1',
+                    'Type': 'tier-type',
+                    'Version': 'tier-version'
+                },
+                'EnvironmentLinks': [
+                    {
+                        'LinkName': 'link-name',
+                        'EnvironmentName': 'environment-name'
+                    }
+                ]
+            },
+            {
+                'EnvironmentName': 'application-environment-2',
+                'EnvironmentId': 'environment-id-2',
+                'ApplicationName': 'application-2',
+                'VersionLabel': 'version-2',
+                'SolutionStackName': 'solution-stack',
+                'TemplateName': 'template-name',
+                'Description': 'description-2',
+                'EndpointURL': 'application-2.region.elasticbeanstalk.com',
+                'CNAME': 'application-2.elasticbeanstalk.com',
+                'DateCreated': datetime(2015, 1, 2),
+                'DateUpdated': datetime(2015, 1, 2),
+                'Status': 'Ready',
+                'AbortableOperationInProgress': False,
+                'Health': 'Green',
+                'HealthStatus': 'Ok',
+                'Resources': {
+                    'LoadBalancer': {
+                        'LoadBalancerName': 'load-balancer-2',
+                        'Domain': 'domain',
+                        'Listeners': [
+                            {
+                                'Protocol': 'http',
+                                'Port': 80
+                            }
+                        ]
+                    }
+                },
+                'Tier': {
+                    'Name': 'tier-2',
+                    'Type': 'tier-type',
+                    'Version': 'tier-version'
+                },
+                'EnvironmentLinks': [
+                    {
+                        'LinkName': 'link-name',
+                        'EnvironmentName': 'environment-name'
+                    }
+                ]
+            }
+        ]
+    }
+
+
 class ELB(object):
 
     test_find_usage = {

--- a/awslimitchecker/tests/services/test_elasticbeanstalk.py
+++ b/awslimitchecker/tests/services/test_elasticbeanstalk.py
@@ -1,0 +1,179 @@
+"""
+awslimitchecker/tests/services/test_elasticbeanstalk.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2015 Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/pydnstest> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Brian Flad <bflad417@gmail.com> <http://www.fladpad.com>
+################################################################################
+"""
+
+import sys
+from awslimitchecker.tests.services import result_fixtures
+from awslimitchecker.services.elasticbeanstalk import _ElasticBeanstalkService
+
+# https://code.google.com/p/mock/issues/detail?id=249
+# py>=3.4 should use unittest.mock not the mock package on pypi
+if (
+        sys.version_info[0] < 3 or
+        sys.version_info[0] == 3 and sys.version_info[1] < 4
+):
+    from mock import patch, call, Mock, DEFAULT
+else:
+    from unittest.mock import patch, call, Mock, DEFAULT
+
+
+pbm = 'awslimitchecker.services.elasticbeanstalk'  # module patch base
+pb = '%s._ElasticBeanstalkService' % pbm  # class patch pase
+
+
+class Test_ElasticBeanstalkService(object):
+
+    def test_init(self):
+        """test __init__()"""
+        cls = _ElasticBeanstalkService(21, 43)
+        assert cls.service_name == 'ElasticBeanstalk'
+        assert cls.api_name == 'elasticbeanstalk'
+        assert cls.conn is None
+        assert cls.warning_threshold == 21
+        assert cls.critical_threshold == 43
+
+    def test_get_limits(self):
+        """test get limits returns all keys"""
+        cls = _ElasticBeanstalkService(21, 43)
+        cls.limits = {}
+        res = cls.get_limits()
+        assert sorted(res.keys()) == sorted([
+            'Applications',
+            'Application versions',
+            'Environments',
+        ])
+        for name, limit in res.items():
+            assert limit.service == cls
+            assert limit.def_warning_threshold == 21
+            assert limit.def_critical_threshold == 43
+
+    def test_get_limits_again(self):
+        """test that existing limits dict is returned on subsequent calls"""
+        mock_limits = Mock()
+        cls = _ElasticBeanstalkService(21, 43)
+        cls.limits = mock_limits
+        res = cls.get_limits()
+        assert res == mock_limits
+
+    def test_find_usage(self):
+        """test find usage method calls other methods"""
+        mock_conn = Mock()
+        with patch('%s.connect' % pb) as mock_connect:
+            with patch.multiple(
+                pb,
+                _find_usage_applications=DEFAULT,
+                _find_usage_application_versions=DEFAULT,
+                _find_usage_environments=DEFAULT,
+            ) as mocks:
+                cls = _ElasticBeanstalkService(21, 43)
+                cls.conn = mock_conn
+                assert cls._have_usage is False
+                cls.find_usage()
+        assert mock_connect.mock_calls == [call()]
+        assert cls._have_usage is True
+        assert mock_conn.mock_calls == []
+        for x in [
+            '_find_usage_applications',
+            '_find_usage_application_versions',
+            '_find_usage_environments',
+        ]:
+            assert mocks[x].mock_calls == [call()]
+
+    def test_find_usage_applications(self):
+        response = result_fixtures.ElasticBeanstalk.test_find_usage_applications
+
+        mock_conn = Mock()
+        mock_conn.describe_applications.return_value = response
+
+        cls = _ElasticBeanstalkService(21, 43)
+        cls.conn = mock_conn
+
+        cls._find_usage_applications()
+
+        assert len(cls.limits['Applications'].get_current_usage()) == 1
+        assert cls.limits['Applications'].get_current_usage()[
+            0].get_value() == 2
+        assert mock_conn.mock_calls == [
+            call.describe_applications()
+        ]
+
+    def test_find_usage_application_versions(self):
+        beanstalk_fixtures = result_fixtures.ElasticBeanstalk
+        response = beanstalk_fixtures.test_find_usage_application_versions
+
+        mock_conn = Mock()
+        mock_conn.describe_application_versions.return_value = response
+
+        cls = _ElasticBeanstalkService(21, 43)
+        cls.conn = mock_conn
+
+        cls._find_usage_application_versions()
+
+        assert len(cls.limits['Application versions'].get_current_usage()) == 1
+        assert cls.limits['Application versions'].get_current_usage()[
+            0].get_value() == 4
+        assert mock_conn.mock_calls == [
+            call.describe_application_versions()
+        ]
+
+    def test_find_usage_environments(self):
+        response = result_fixtures.ElasticBeanstalk.test_find_usage_environments
+
+        mock_conn = Mock()
+        mock_conn.describe_environments.return_value = response
+
+        cls = _ElasticBeanstalkService(21, 43)
+        cls.conn = mock_conn
+
+        cls._find_usage_environments()
+
+        assert len(cls.limits['Environments'].get_current_usage()) == 1
+        assert cls.limits['Environments'].get_current_usage()[
+            0].get_value() == 2
+        assert mock_conn.mock_calls == [
+            call.describe_environments()
+        ]
+
+    def test_required_iam_permissions(self):
+        """test expected permissions are returned"""
+        cls = _ElasticBeanstalkService(21, 43)
+        assert cls.required_iam_permissions() == [
+            'elasticbeanstalk:DescribeApplications',
+            'elasticbeanstalk:DescribeApplicationVersions',
+            'elasticbeanstalk:DescribeEnvironments',
+        ]

--- a/awslimitchecker/tests/test_integration.py
+++ b/awslimitchecker/tests/test_integration.py
@@ -59,12 +59,14 @@ if python_implementation() == 'CPython':
 REGION = 'us-west-2'
 MFA_CODE = None
 
-
-@pytest.mark.integration
-@pytest.mark.skipif(
+skip_if_pr = pytest.mark.skipif(
     os.environ.get('TRAVIS_PULL_REQUEST', None) != 'false',
     reason='Not running integration tests for pull request'
 )
+
+
+@pytest.mark.integration
+@skip_if_pr
 class TestIntegration(object):
     """
     !!!!!!IMPORTANT NOTE!!!!!!!
@@ -87,6 +89,7 @@ class TestIntegration(object):
         # capture the AWS-related env vars
 
     @pytest.mark.integration
+    @skip_if_pr
     def verify_limits(self, checker_args, creds, service_name, use_ta,
                       expect_api_source):
         """
@@ -165,6 +168,7 @@ class TestIntegration(object):
             "Advisor once, but polled %s times" % polls
 
     @pytest.mark.integration
+    @skip_if_pr
     def verify_usage(self, checker_args, creds, service_name, expect_usage):
         """
         This essentially replicates what's done when awslimitchecker is called
@@ -234,6 +238,7 @@ class TestIntegration(object):
             "messages at WARN or higher: \n%s" % "\n".join(records)
 
     @pytest.mark.integration
+    @skip_if_pr
     def test_default_creds_all_services(self):
         """Test running alc with all services enabled"""
         creds = self.normal_creds()
@@ -243,6 +248,7 @@ class TestIntegration(object):
         yield "usage", self.verify_usage, checker_args, creds, None, True
 
     @pytest.mark.integration
+    @skip_if_pr
     def test_default_creds_each_service(self):
         """test running one service at a time for all services"""
         creds = self.normal_creds()
@@ -267,6 +273,7 @@ class TestIntegration(object):
     ###########################################################################
 
     @pytest.mark.integration
+    @skip_if_pr
     def test_sts(self):
         """test normal STS role"""
         creds = self.sts_creds()
@@ -280,6 +287,7 @@ class TestIntegration(object):
         yield "VPC usage", self.verify_usage, checker_args, creds, 'VPC', True
 
     @pytest.mark.integration
+    @skip_if_pr
     def test_sts_external_id(self):
         """test STS role with external ID"""
         creds = self.sts_creds()
@@ -294,6 +302,7 @@ class TestIntegration(object):
         yield "VPC usage", self.verify_usage, checker_args, creds, 'VPC', True
 
     @pytest.mark.integration
+    @skip_if_pr
     def test_sts_mfa(self):
         """test STS role with MFA"""
         creds = self.sts_mfa_creds()
@@ -309,6 +318,7 @@ class TestIntegration(object):
         yield "VPC usage", self.verify_usage, checker_args, creds, 'VPC', True
 
     @pytest.mark.integration
+    @skip_if_pr
     def test_sts_mfa_external_id(self):
         """test STS role with MFA"""
         creds = self.sts_mfa_creds()

--- a/docs/source/awslimitchecker.services.elasticbeanstalk.rst
+++ b/docs/source/awslimitchecker.services.elasticbeanstalk.rst
@@ -1,0 +1,7 @@
+awslimitchecker.services.elasticbeanstalk module
+================================================
+
+.. automodule:: awslimitchecker.services.elasticbeanstalk
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/awslimitchecker.services.rst
+++ b/docs/source/awslimitchecker.services.rst
@@ -17,6 +17,7 @@ Submodules
    awslimitchecker.services.ebs
    awslimitchecker.services.ec2
    awslimitchecker.services.elasticache
+   awslimitchecker.services.elasticbeanstalk
    awslimitchecker.services.elb
    awslimitchecker.services.iam
    awslimitchecker.services.rds


### PR DESCRIPTION
This PR adds the ElasticBeanstalk service, with three initial limits for checking:
* Applications
* Application versions
* Environments

Passes all Python 2.7 unit tests and verified using my AWS QA environment for Elastic Beanstalk.

```
tox -e py27-unit
...
awslimitchecker/tests/services/test_elasticbeanstalk.py PASSED
awslimitchecker/tests/services/test_elasticbeanstalk.py PASSED
awslimitchecker/tests/services/test_elasticbeanstalk.py::Test_ElasticBeanstalkService::test_init PASSED
awslimitchecker/tests/services/test_elasticbeanstalk.py::Test_ElasticBeanstalkService::test_get_limits PASSED
awslimitchecker/tests/services/test_elasticbeanstalk.py::Test_ElasticBeanstalkService::test_get_limits_again PASSED
awslimitchecker/tests/services/test_elasticbeanstalk.py::Test_ElasticBeanstalkService::test_find_usage PASSED
awslimitchecker/tests/services/test_elasticbeanstalk.py::Test_ElasticBeanstalkService::test_find_usage_applications PASSED
awslimitchecker/tests/services/test_elasticbeanstalk.py::Test_ElasticBeanstalkService::test_find_usage_application_versions PASSED
awslimitchecker/tests/services/test_elasticbeanstalk.py::Test_ElasticBeanstalkService::test_find_usage_environments PASSED
...
-------------------------------------------- coverage: platform darwin, python 2.7.10-final-0 ---------------------------------------------
Name                                        Stmts   Miss Branch BrMiss  Cover   Missing
---------------------------------------------------------------------------------------
...
awslimitchecker/services/elasticbeanstalk      38      0      4      0   100%
...
---------------------------------------------------------------------------------------
TOTAL                                        1554      0    476      0   100%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml
========================================================= short test summary info =========================================================
SKIP [1] awslimitchecker/tests/test_versioncheck.py:1138: not running py26 test on 2.7.10
SKIP [1] awslimitchecker/tests/test_versioncheck.py:1185: not running py3 test on 2.7.10
SKIP [1] awslimitchecker/tests/services/test_base.py:77: test for py26
SKIP [1] awslimitchecker/tests/services/test_base.py:99: test for py3
SKIP [49] /Users/bflad/Virtualenvs/awslimitchecker-issues-70/src/awslimitchecker/.tox/py27-unit/lib/python2.7/site-packages/pytest_flakes.py:75: file(s) previously passed pyflakes checks
SKIP [1] awslimitchecker/tests/test_versioncheck.py:1112: not running py26 test on 2.7.10
SKIP [1] awslimitchecker/tests/services/test_base.py:88: test for py27

======================================================== slowest 10 test durations ========================================================
0.33s call     awslimitchecker/tests/test_versioncheck.py
0.24s call     awslimitchecker/tests/test_runner.py
0.20s call     awslimitchecker/tests/services/result_fixtures.py
0.16s call     awslimitchecker/tests/test_checker.py
0.14s call     awslimitchecker/tests/test_checker.py::TestAwsLimitChecker::test_init_sts_external_id
0.14s call     awslimitchecker/tests/services/test_ec2.py::Test_Ec2Service::test_find_usage
0.14s call     awslimitchecker/tests/test_limit.py
0.13s call     awslimitchecker/tests/test_connectable.py
0.11s call     awslimitchecker/tests/test_trustedadvisor.py
0.10s call     awslimitchecker/tests/test_runner.py::TestAwsLimitCheckerRunner::test_entry_list_services
===================================== 46 tests deselected by "-m 'not (versioncheck or integration)'" =====================================
========================================== 399 passed, 55 skipped, 46 deselected in 9.57 seconds ==========================================
_________________________________________________________________ summary _________________________________________________________________
  py27-unit: commands succeeded
  congratulations :)

awslimitchecker -S ElasticBeanstalk -l
awslimitchecker 0.4.1@b2127a6* is AGPL-licensed free software; all users have a right to the full source code of this version. See <git@github.com:bflad/awslimitchecker.git>
WARNING:awslimitchecker.trustedadvisor:Cannot check TrustedAdvisor: AWS Premium Support Subscription is required to use this service.
ElasticBeanstalk/Application versions  500
ElasticBeanstalk/Applications          25
ElasticBeanstalk/Environments          200

awslimitchecker -S ElasticBeanstalk -u
awslimitchecker 0.4.1@b2127a6* is AGPL-licensed free software; all users have a right to the full source code of this version. See <git@github.com:bflad/awslimitchecker.git>
WARNING:awslimitchecker.trustedadvisor:Cannot check TrustedAdvisor: AWS Premium Support Subscription is required to use this service.
ElasticBeanstalk/Application versions  15
ElasticBeanstalk/Applications          9
ElasticBeanstalk/Environments          9
```