### PR TITLE
Update security group per VPC default limit to 500

### DIFF
--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -338,7 +338,7 @@ class _Ec2Service(_AwsService):
         limits['Security groups per VPC'] = AwsLimit(
             'Security groups per VPC',
             self,
-            100,
+            500,
             self.warning_threshold,
             self.critical_threshold,
             limit_type='AWS::EC2::SecurityGroup',

--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -263,7 +263,7 @@ threshold only, and another has crossed the critical threshold):
 
    (venv)$ awslimitchecker --no-color
    EBS/Active snapshots                                   (limit 16000) WARNING: 13858
-   EC2/Security groups per VPC                            (limit 100) CRITICAL: vpc-c89074a9=958
+   EC2/Security groups per VPC                            (limit 500) CRITICAL: vpc-c89074a9=958
    EC2/VPC security groups per elastic network interface  (limit 5) CRITICAL: eni-2751546e=5 WARNING: e (...)
    ElastiCache/Clusters                                   (limit 50) WARNING: 44
    ElastiCache/Nodes                                      (limit 50) WARNING: 44
@@ -283,7 +283,7 @@ To set the warning threshold of 50% and a critical threshold of 75% when checkin
 .. code-block:: console
 
    (venv)$ awslimitchecker -W 97 --critical=98 --no-color
-   EC2/Security groups per VPC                            (limit 100) CRITICAL: vpc-c89074a9=958
+   EC2/Security groups per VPC                            (limit 500) CRITICAL: vpc-c89074a9=958
    EC2/VPC security groups per elastic network interface  (limit 5) CRITICAL: eni-2751546e=5
    ElasticBeanstalk/Application versions                  (limit 500) CRITICAL: 2474
    ElasticBeanstalk/Applications                          (limit 25) CRITICAL: 107

--- a/docs/source/limits.rst
+++ b/docs/source/limits.rst
@@ -330,7 +330,7 @@ Running On-Demand t2.medium instances :sup:`(TA)`              20
 Running On-Demand t2.micro instances :sup:`(TA)`               20 
 Running On-Demand t2.nano instances                            20 
 Running On-Demand t2.small instances :sup:`(TA)`               20 
-Security groups per VPC                                        100
+Security groups per VPC                                        500
 VPC Elastic IP addresses (EIPs) :sup:`(TA)` :sup:`(API)`       5  
 VPC security groups per elastic network interface :sup:`(API)` 5  
 ============================================================== ===


### PR DESCRIPTION
This limit was increased from 100 to 500 at some point, though I'm not sure exactly when. http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Appendix_Limits.html#vpc-limits-security-groups

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.

