### PR TITLE
Feature/AWS CLI profile support for authentication

### DIFF
--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -49,8 +49,9 @@ logger = logging.getLogger(__name__)
 class AwsLimitChecker(object):
 
     def __init__(self, warning_threshold=80, critical_threshold=99,
-                 account_id=None, account_role=None, region=None,
-                 external_id=None, mfa_serial_number=None, mfa_token=None):
+                 profile_name=None, account_id=None, account_role=None,
+                 region=None, external_id=None, mfa_serial_number=None,
+                 mfa_token=None):
         """
         Main AwsLimitChecker class - this should be the only externally-used
         portion of awslimitchecker.
@@ -67,6 +68,12 @@ class AwsLimitChecker(object):
           integer percentage, for any limits without a specifically-set
           threshold.
         :type critical_threshold: int
+        :param profile_name: `Profile Name <http://docs.aws.amazon.com/IAM/
+          latest/UserGuide/id_roles.
+          html>`
+          The name of a profile to use. If not given, then the default profile
+          is used.
+        :type profile_name: str
         :param account_id: `AWS Account ID <http://docs.aws.amazon.com/general/
           latest/gr/acct-identifiers.html>`_
           (12-digit string, currently numeric) for the account to connect to
@@ -115,6 +122,7 @@ class AwsLimitChecker(object):
         )
         self.warning_threshold = warning_threshold
         self.critical_threshold = critical_threshold
+        self.profile_name = profile_name
         self.account_id = account_id
         self.account_role = account_role
         self.external_id = external_id
@@ -124,11 +132,12 @@ class AwsLimitChecker(object):
         self.services = {}
         for sname, cls in _services.items():
             self.services[sname] = cls(warning_threshold, critical_threshold,
-                                       account_id, account_role, region,
-                                       external_id, mfa_serial_number,
+                                       profile_name, account_id, account_role,
+                                       region, external_id, mfa_serial_number,
                                        mfa_token)
         self.ta = TrustedAdvisor(
             self.services,
+            profile_name=profile_name,
             account_id=account_id,
             account_role=account_role,
             region=region,

--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -69,8 +69,7 @@ class AwsLimitChecker(object):
           threshold.
         :type critical_threshold: int
         :param profile_name: `Profile Name <http://docs.aws.amazon.com/IAM/
-          latest/UserGuide/id_roles.
-          html>`
+          latest/UserGuide/id_roles.html>`_
           The name of a profile to use. If not given, then the default profile
           is used.
         :type profile_name: str

--- a/awslimitchecker/connectable.py
+++ b/awslimitchecker/connectable.py
@@ -123,7 +123,6 @@ class Connectable(object):
             return
         kwargs = self._boto3_connection_kwargs
         self.conn = boto3.client(self.api_name, **kwargs)
-
         logger.info("Connected to %s in region %s", self.api_name,
                     self.conn._client_config.region_name)
 

--- a/awslimitchecker/connectable.py
+++ b/awslimitchecker/connectable.py
@@ -86,7 +86,14 @@ class Connectable(object):
         :rtype: dict
         """
         kwargs = {'region_name': self.region}
-        if self.account_id is not None:
+        if self.profile_name is not None:
+            # fetch credentials from cache.
+            session = boto3.Session(profile_name=self.profile_name)
+            credentials = session._session.get_credentials()
+            kwargs['aws_access_key_id'] = credentials.access_key
+            kwargs['aws_secret_access_key'] = credentials.secret_key
+            kwargs['aws_session_token'] = credentials.token
+        elif self.account_id is not None:
             if Connectable.credentials is None:
                 logger.debug("Connecting for account %s role '%s' with STS "
                              "(region: %s)", self.account_id, self.account_role,
@@ -116,6 +123,7 @@ class Connectable(object):
             return
         kwargs = self._boto3_connection_kwargs
         self.conn = boto3.client(self.api_name, **kwargs)
+
         logger.info("Connected to %s in region %s", self.api_name,
                     self.conn._client_config.region_name)
 

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -133,6 +133,10 @@ class Runner(object):
                        type=int, default=99,
                        help='default critical threshold (percentage of '
                        'limit); default: 99')
+        p.add_argument('-P', '--profile-name', action='store',
+                       type=str, default=None,
+                       help='AWS CLI profile name to source credentials from'
+                       ' for access to the destination account')
         p.add_argument('-A', '--sts-account-id', action='store',
                        type=str, default=None,
                        help='for use with STS, the Account ID of the '
@@ -309,6 +313,7 @@ class Runner(object):
         self.checker = AwsLimitChecker(
             warning_threshold=args.warning_threshold,
             critical_threshold=args.critical_threshold,
+            profile_name=args.profile_name,
             account_id=args.sts_account_id,
             account_role=args.sts_account_role,
             region=args.region,

--- a/awslimitchecker/services/base.py
+++ b/awslimitchecker/services/base.py
@@ -50,9 +50,10 @@ class _AwsService(Connectable):
     service_name = 'baseclass'
     api_name = 'baseclass'
 
-    def __init__(self, warning_threshold, critical_threshold, account_id=None,
-                 account_role=None, region=None, external_id=None,
-                 mfa_serial_number=None, mfa_token=None):
+    def __init__(self, warning_threshold, critical_threshold,
+                 profile_name=None, account_id=None, account_role=None,
+                 region=None, external_id=None, mfa_serial_number=None,
+                 mfa_token=None):
         """
         Describes an AWS service and its limits, and provides methods to
         query current utilization.
@@ -70,6 +71,12 @@ class _AwsService(Connectable):
           integer percentage, for any limits without a specifically-set
           threshold.
         :type critical_threshold: int
+        :param profile_name: `Profile Name <http://docs.aws.amazon.com/IAM/
+          latest/UserGuide/id_roles.
+          html>`
+          The name of a profile to use. If not given, then the default profile
+          is used.
+        :type profile_name: str
         :param account_id: `AWS Account ID <http://docs.aws.amazon.com/general/
           latest/gr/acct-identifiers.html>`_
           (12-digit string, currently numeric) for the account to connect to
@@ -95,6 +102,7 @@ class _AwsService(Connectable):
         """
         self.warning_threshold = warning_threshold
         self.critical_threshold = critical_threshold
+        self.profile_name = profile_name
         self.account_id = account_id
         self.account_role = account_role
         self.region = region

--- a/awslimitchecker/services/base.py
+++ b/awslimitchecker/services/base.py
@@ -72,8 +72,7 @@ class _AwsService(Connectable):
           threshold.
         :type critical_threshold: int
         :param profile_name: `Profile Name <http://docs.aws.amazon.com/IAM/
-          latest/UserGuide/id_roles.
-          html>`
+          latest/UserGuide/id_roles.html>`_
           The name of a profile to use. If not given, then the default profile
           is used.
         :type profile_name: str

--- a/awslimitchecker/trustedadvisor.py
+++ b/awslimitchecker/trustedadvisor.py
@@ -55,15 +55,21 @@ class TrustedAdvisor(Connectable):
     service_name = 'TrustedAdvisor'
     api_name = 'support'
 
-    def __init__(self, all_services, account_id=None, account_role=None,
-                 region=None, external_id=None, mfa_serial_number=None,
-                 mfa_token=None):
+    def __init__(self, all_services, profile_name=None, account_id=None,
+                 account_role=None, region=None, external_id=None,
+                 mfa_serial_number=None, mfa_token=None):
         """
         Class to contain all TrustedAdvisor-related logic.
 
         :param all_services: :py:class:`~.checker.AwsLimitChecker` ``services``
           dictionary.
         :type all_services: dict
+        :param profile_name: `Profile Name <http://docs.aws.amazon.com/IAM/
+          latest/UserGuide/id_roles.
+          html>`
+          The name of a profile to use. If not given, then the default profile
+          is used.
+        :type profile_name: str
         :param account_id: `AWS Account ID <http://docs.aws.amazon.com/general/
           latest/gr/acct-identifiers.html>`_
           (12-digit string, currently numeric) for the account to connect to
@@ -89,6 +95,7 @@ class TrustedAdvisor(Connectable):
         """
         self.conn = None
         self.have_ta = True
+        self.profile_name = profile_name
         self.account_id = account_id
         self.account_role = account_role
         self.region = 'us-east-1'

--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -26,10 +26,10 @@ use as a Nagios-compatible plugin).
    (venv)$ awslimitchecker --help
    usage: awslimitchecker [-h] [-S SERVICE] [-s] [-l] [--list-defaults]
                           [-L LIMIT] [-u] [--iam-policy] [-W WARNING_THRESHOLD]
-                          [-C CRITICAL_THRESHOLD] [-A STS_ACCOUNT_ID]
-                          [-R STS_ACCOUNT_ROLE] [-E EXTERNAL_ID]
-                          [-M MFA_SERIAL_NUMBER] [-T MFA_TOKEN] [-r REGION]
-                          [--skip-ta] [--no-color] [-v] [-V]
+                          [-C CRITICAL_THRESHOLD] [-P PROFILE_NAME]
+                          [-A STS_ACCOUNT_ID] [-R STS_ACCOUNT_ROLE]
+                          [-E EXTERNAL_ID] [-M MFA_SERIAL_NUMBER]
+                          [-T MFA_TOKEN] [-r REGION] [--skip-ta] [--no-color] [-v] [-V]
    Report on AWS service limits and usage via boto3, optionally warn about any
    services with usage nearing or exceeding their limits. For further help, see
    <http://awslimitchecker.readthedocs.org/>
@@ -59,6 +59,8 @@ use as a Nagios-compatible plugin).
      -C CRITICAL_THRESHOLD, --critical-threshold CRITICAL_THRESHOLD
                            default critical threshold (percentage of limit);
                            default: 99
+     -P PROFILE_NAME, --profile-name PROFILE_NAME
+                           for use with AWS CLI profile name to source credentials for the destination account
      -A STS_ACCOUNT_ID, --sts-account-id STS_ACCOUNT_ID
                            for use with STS, the Account ID of the destination
                            account (account to assume a role in)
@@ -306,10 +308,10 @@ permissions for it to perform all limit checks. This can be viewed with the
      "Statement": [
        {
          "Action": [
-           "autoscaling:DescribeAccountLimits", 
+           "autoscaling:DescribeAccountLimits",
    (...)
        }
-     ], 
+     ],
      "Version": "2012-10-17"
    }
 


### PR DESCRIPTION
Adds capability to authenticate against existing AWS CLI profiles.

Sorry for not including the tests.
## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:
- The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
- My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
- I have the legal power and rights to agree to these terms.
