### PR TITLE
Fixes for NAT Gateways

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,10 +12,12 @@ This release requires the following new IAM permissions to function:
 * ``ec2:DescribeSpotFleetRequests``
 * ``ec2:DescribeSpotInstanceRequests``
 * ``ec2:DescribeSpotPriceHistory``
+* ``ec2:DescribeNatGateways``
 
 These can also be summarized as ``ec2:DescribeSpot*``.
 
 * `#51 <https://github.com/jantman/awslimitchecker/issues/51>`_ - Add experimental support for Spot Instance and Spot Fleet limits (only the ones explicitly documented by AWS). This is currently experimental, as the documentation is not terribly clear or detailed, and the author doesn't have access to any accounts that make use of spot instances. This will be kept experimental until multiple users validate it. For more information, see `the EC2 limit documentation <http://awslimitchecker.readthedocs.io/en/latest/limits.html#ec2>`_.
+* `PR #204 <https://github.com/jantman/awslimitchecker/pull/204>`_ contributed by `hltbra <https://github.com/hltbra>`_ to add support for VPC NAT Gateways limit.
 * Add README and Docs link to waffle.io board.
 * Fix bug where ``--skip-ta`` command line flag was ignored in :py:meth:`~.Runner.show_usage` (when running with ``-u`` / ``--show-usage`` action).
 

--- a/awslimitchecker/services/vpc.py
+++ b/awslimitchecker/services/vpc.py
@@ -44,6 +44,7 @@ from collections import defaultdict
 from .base import _AwsService
 from ..limit import AwsLimit
 from ..utils import paginate_dict
+from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
 
@@ -143,18 +144,25 @@ class _VpcService(_AwsService):
 
     def _find_usage_nat_gateways(self):
         """find usage for NAT Gateways"""
-        # NAT gateways
-        self.limits['NAT gateways']._add_current_usage(
-            len(
-                paginate_dict(
-                    self.conn.describe_nat_gateways,
-                    alc_marker_path=['NextToken'],
-                    alc_data_path=['NatGateways'],
-                    alc_marker_param='NextToken'
-                )['NatGateways']
-            ),
-            aws_type='AWS::EC2::NatGateway',
-        )
+        # currently, some regions (sa-east-1 as one example) don't have NAT
+        # Gateway service; they return an AuthError,
+        # "This request has been administratively disabled."
+        try:
+            self.limits['NAT gateways']._add_current_usage(
+                len(
+                    paginate_dict(
+                        self.conn.describe_nat_gateways,
+                        alc_marker_path=['NextToken'],
+                        alc_data_path=['NatGateways'],
+                        alc_marker_param='NextToken'
+                    )['NatGateways']
+                ),
+                aws_type='AWS::EC2::NatGateway',
+            )
+        except ClientError:
+            logger.error('Caught exception when trying to list NAT Gateways; '
+                         'perhaps NAT service does not exist in this region?',
+                         exc_info=1)
 
     def get_limits(self):
         """

--- a/awslimitchecker/services/vpc.py
+++ b/awslimitchecker/services/vpc.py
@@ -257,6 +257,7 @@ class _VpcService(_AwsService):
         :rtype: list
         """
         return [
+            'ec2:DescribeNatGateways',
             'ec2:DescribeNetworkAcls',
             'ec2:DescribeRouteTables',
             'ec2:DescribeSubnets',

--- a/awslimitchecker/tests/services/test_vpc.py
+++ b/awslimitchecker/tests/services/test_vpc.py
@@ -41,6 +41,8 @@ import sys
 from awslimitchecker.tests.services import result_fixtures
 from awslimitchecker.services.vpc import _VpcService
 
+from botocore.exceptions import ClientError
+
 # https://code.google.com/p/mock/issues/detail?id=249
 # py>=3.4 should use unittest.mock not the mock package on pypi
 if (
@@ -252,6 +254,30 @@ class Test_VpcService(object):
                    0].get_value() == 1
         assert mock_conn.mock_calls == [
             call.describe_nat_gateways(),
+        ]
+
+    def test_find_usage_nat_gateways_exception(self):
+
+        def se_exc(*args, **kwargs):
+            raise ClientError({'Error': {}}, 'opname')
+
+        mock_conn = Mock()
+        mock_conn.describe_nat_gateways.side_effect = se_exc
+
+        cls = _VpcService(21, 43)
+        cls.conn = mock_conn
+
+        with patch('%s.logger' % self.pbm, autospec=True) as mock_logger:
+            cls._find_usage_nat_gateways()
+
+        assert len(cls.limits['NAT gateways'].get_current_usage()) == 0
+        assert mock_conn.mock_calls == [
+            call.describe_nat_gateways(),
+        ]
+        assert mock_logger.mock_calls == [
+            call.error('Caught exception when trying to list NAT Gateways; '
+                       'perhaps NAT service does not exist in this region?',
+                       exc_info=1)
         ]
 
     def test_required_iam_permissions(self):

--- a/awslimitchecker/tests/services/test_vpc.py
+++ b/awslimitchecker/tests/services/test_vpc.py
@@ -257,6 +257,7 @@ class Test_VpcService(object):
     def test_required_iam_permissions(self):
         cls = _VpcService(21, 43)
         assert cls.required_iam_permissions() == [
+            'ec2:DescribeNatGateways',
             'ec2:DescribeNetworkAcls',
             'ec2:DescribeRouteTables',
             'ec2:DescribeSubnets',

--- a/awslimitchecker/tests/support.py
+++ b/awslimitchecker/tests/support.py
@@ -142,6 +142,10 @@ class LogRecordHelper(object):
                     len(r.args) > 0 and
                     'Could not connect to the endpoint URL:' in r.args[0]):
                 continue
+            if (r.levelno == logging.ERROR and r.module == 'vpc' and
+                    r.funcName == '_find_usage_nat_gateways' and
+                    'perhaps NAT service does not exist in this regi' in r.msg):
+                continue
             res.append('%s:%s.%s (%s:%s) %s - %s %s' % (
                 r.name,
                 r.module,

--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -193,15 +193,15 @@ using their IDs).
 .. code-block:: console
 
    (venv)$ awslimitchecker -u
-   AutoScaling/Auto Scaling groups                        458
-   AutoScaling/Launch configurations                      549
-   CloudFormation/Stacks                                  772
-   EBS/Active snapshots                                   15269
-   EBS/Active volumes                                     4702
+   AutoScaling/Auto Scaling groups                        492
+   AutoScaling/Launch configurations                      581
+   CloudFormation/Stacks                                  812
+   EBS/Active snapshots                                   15548
+   EBS/Active volumes                                     4937
    (...)
-   VPC/Rules per network ACL                              max: acl-bde47dd9=6 (acl-4bd96a2e=4, acl-8190 (...)
-   VPC/Subnets per VPC                                    max: vpc-c89074a9=37 (vpc-e2edf486=1, vpc-7bc (...)
-   VPC/VPCs                                               12
+   VPC/Rules per network ACL                              max: acl-bde47dd9=6 (acl-4bd96a2e=4, acl-e93a (...)
+   VPC/Subnets per VPC                                    max: vpc-c89074a9=37 (vpc-ae7bc5cb=1, vpc-1e5 (...)
+   VPC/VPCs                                               13
 
 
 
@@ -262,16 +262,15 @@ threshold only, and another has crossed the critical threshold):
 .. code-block:: console
 
    (venv)$ awslimitchecker --no-color
-   EC2/Security groups per VPC                            (limit 500) CRITICAL: vpc-c89074a9=974
+   CloudFormation/Stacks                                  (limit 1000) WARNING: 812
+   EC2/Security groups per VPC                            (limit 500) CRITICAL: vpc-c89074a9=983
    EC2/VPC security groups per elastic network interface  (limit 5) CRITICAL: eni-c2d513fb=5 WARNING: e (...)
+   ELB/Active load balancers                              (limit 600) WARNING: 493
    ElastiCache/Clusters                                   (limit 50) WARNING: 44
-   ElastiCache/Nodes                                      (limit 50) WARNING: 44
-   ElasticBeanstalk/Application versions                  (limit 500) CRITICAL: 1634
-   ElasticBeanstalk/Applications                          (limit 25) CRITICAL: 131
-   ElasticBeanstalk/Environments                          (limit 200) CRITICAL: 353
-   RDS/DB instances                                       (limit 240) WARNING: 197
-   RDS/DB parameter groups                                (limit 100) WARNING: 80
-   S3/Buckets                                             (limit 100) CRITICAL: 225
+   (...)
+   ElasticBeanstalk/Environments                          (limit 200) CRITICAL: 382
+   S3/Buckets                                             (limit 100) CRITICAL: 224
+   VPC/NAT gateways                                       (limit 5) CRITICAL: 8
 
 
 
@@ -283,12 +282,13 @@ To set the warning threshold of 50% and a critical threshold of 75% when checkin
 .. code-block:: console
 
    (venv)$ awslimitchecker -W 97 --critical=98 --no-color
-   EC2/Security groups per VPC                            (limit 500) CRITICAL: vpc-c89074a9=974
+   EC2/Security groups per VPC                            (limit 500) CRITICAL: vpc-c89074a9=983
    EC2/VPC security groups per elastic network interface  (limit 5) CRITICAL: eni-c2d513fb=5
-   ElasticBeanstalk/Application versions                  (limit 500) CRITICAL: 1634
-   ElasticBeanstalk/Applications                          (limit 25) CRITICAL: 131
-   ElasticBeanstalk/Environments                          (limit 200) CRITICAL: 353
-   S3/Buckets                                             (limit 100) CRITICAL: 225
+   ElasticBeanstalk/Application versions                  (limit 500) CRITICAL: 1761
+   ElasticBeanstalk/Applications                          (limit 25) CRITICAL: 133
+   ElasticBeanstalk/Environments                          (limit 200) CRITICAL: 382
+   S3/Buckets                                             (limit 100) CRITICAL: 224
+   VPC/NAT gateways                                       (limit 5) CRITICAL: 8
 
 
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -221,7 +221,7 @@ branches. You can run them manually from your local machine using:
 
 These tests simply run ``awslimitchecker``'s CLI script for both usage and limits, for all services and each service individually. Note that this covers a very small amount of the code, as the account that I use for integration tests has virtually no resources in it.
 
-If integration tests fail, check the required IAM permissions. The IAM user that I use for Travis integration tests has a manually-maintained IAM policy.
+If integration tests fail, check the required IAM permissions. The IAM user for Travis integration tests is configured via Terraform, which must be re-run after policy changes.
 
 .. _development.docs:
 

--- a/docs/source/iam_policy.rst
+++ b/docs/source/iam_policy.rst
@@ -27,6 +27,7 @@ permissions required for it to function correctly:
             "ec2:DescribeAddresses", 
             "ec2:DescribeInstances", 
             "ec2:DescribeInternetGateways", 
+            "ec2:DescribeNatGateways", 
             "ec2:DescribeNetworkAcls", 
             "ec2:DescribeNetworkAcls", 
             "ec2:DescribeNetworkInterfaces", 

--- a/docs/source/limits.rst
+++ b/docs/source/limits.rst
@@ -54,13 +54,7 @@ updated from Trusted Advisor:
 
   * Running On-Demand c4.2xlarge instances
 
-  * Running On-Demand c4.large instances
-
-  * Running On-Demand c4.xlarge instances
-
   * Running On-Demand m1.medium instances
-
-  * Running On-Demand m1.small instances
 
   * Running On-Demand m3.2xlarge instances
 
@@ -135,8 +129,6 @@ updated from Trusted Advisor:
 * VPC
 
   * Internet gateways
-
-  * NAT gateways
 
   * VPCs
 
@@ -304,8 +296,8 @@ Running On-Demand c3.xlarge instances :sup:`(TA)`              20
 Running On-Demand c4.2xlarge instances :sup:`(TA)`             20  
 Running On-Demand c4.4xlarge instances                         10  
 Running On-Demand c4.8xlarge instances                         5   
-Running On-Demand c4.large instances :sup:`(TA)`               20  
-Running On-Demand c4.xlarge instances :sup:`(TA)`              20  
+Running On-Demand c4.large instances                           20  
+Running On-Demand c4.xlarge instances                          20  
 Running On-Demand cc2.8xlarge instances                        20  
 Running On-Demand cg1.4xlarge instances                        2   
 Running On-Demand cr1.8xlarge instances                        2   
@@ -323,7 +315,7 @@ Running On-Demand i2.8xlarge instances                         2
 Running On-Demand i2.xlarge instances                          8   
 Running On-Demand m1.large instances                           20  
 Running On-Demand m1.medium instances :sup:`(TA)`              20  
-Running On-Demand m1.small instances :sup:`(TA)`               20  
+Running On-Demand m1.small instances                           20  
 Running On-Demand m1.xlarge instances                          20  
 Running On-Demand m2.2xlarge instances                         20  
 Running On-Demand m2.4xlarge instances                         20  
@@ -452,7 +444,7 @@ Limit                         Default
 ============================= ===
 Entries per route table       50 
 Internet gateways :sup:`(TA)` 5  
-NAT gateways                  5
+NAT gateways                  5  
 Network ACLs per VPC          200
 Route tables per VPC          200
 Rules per network ACL         20 


### PR DESCRIPTION
* update docs
* add ec2:DescribeNatGateways permission to VPC
* handle regions that don't have NAT Gateway Service, causing boto to throw a ClientError:

```
ClientError: An error occurred (AuthFailure) when calling the DescribeNatGateways operation: This request has been administratively disabled.
```