### PR TITLE
Add support to Kinesis Firehose delivery streams metric

### DIFF
--- a/awslimitchecker/services/__init__.py
+++ b/awslimitchecker/services/__init__.py
@@ -50,6 +50,7 @@ from awslimitchecker.services.iam import _IamService
 from awslimitchecker.services.s3 import _S3Service
 from awslimitchecker.services.ses import _SesService
 from awslimitchecker.services.cloudformation import _CloudformationService
+from awslimitchecker.services.firehose import _FirehoseService
 
 # dynamically generate the service name to class dict
 _services = {}

--- a/awslimitchecker/services/firehose.py
+++ b/awslimitchecker/services/firehose.py
@@ -1,0 +1,115 @@
+"""
+awslimitchecker/services/firehose.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2016 Hugo Lopes Tavares <hltbra@gmail.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/awslimitchecker> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Hugo Lopes Tavares <hltbra@gmail.com>
+################################################################################
+"""
+
+import abc  # noqa
+import logging
+
+from .base import _AwsService
+from ..limit import AwsLimit
+
+logger = logging.getLogger(__name__)
+
+
+class _FirehoseService(_AwsService):
+
+    service_name = 'Firehose'
+    api_name = 'firehose'
+
+    def find_usage(self):
+        """
+        Determine the current usage for each limit of this service,
+        and update corresponding Limit via
+        :py:meth:`~.AwsLimit._add_current_usage`.
+        """
+        logger.debug("Checking usage for service %s", self.service_name)
+        self.connect()
+        for lim in self.limits.values():
+            lim._reset_usage()
+
+        streams = self.conn.list_delivery_streams()
+        usage = len(streams['DeliveryStreamNames'])
+        while streams.get('HasMoreDeliveryStreams'):
+            last_stream_name = streams['DeliveryStreamNames'][-1]
+            streams = self.conn.list_delivery_streams(
+                ExclusiveStartDeliveryStreamName=last_stream_name)
+            usage += len(streams['DeliveryStreamNames'])
+
+        self.limits['Delivery streams per region']._add_current_usage(
+            usage,
+            resource_id=self.region,
+            aws_type='AWS::KinesisFirehose::DeliveryStream',
+        )
+
+        self._have_usage = True
+        logger.debug("Done checking usage.")
+
+    def get_limits(self):
+        """
+        Return all known limits for this service, as a dict of their names
+        to :py:class:`~.AwsLimit` objects.
+
+        :returns: dict of limit names to :py:class:`~.AwsLimit` objects
+        :rtype: dict
+        """
+        if self.limits != {}:
+            return self.limits
+        limits = {}
+        limits['Delivery streams per region'] = AwsLimit(
+            'Delivery streams per region',
+            self,
+            5,
+            self.warning_threshold,
+            self.critical_threshold,
+            limit_type='AWS::KinesisFirehose::DeliveryStream',
+        )
+        self.limits = limits
+        return limits
+
+    def required_iam_permissions(self):
+        """
+        Return a list of IAM Actions required for this Service to function
+        properly. All Actions will be shown with an Effect of "Allow"
+        and a Resource of "*".
+
+        :returns: list of IAM Action strings
+        :rtype: list
+        """
+        return [
+            "firehose:ListDeliveryStreams",
+        ]

--- a/awslimitchecker/services/firehose.py
+++ b/awslimitchecker/services/firehose.py
@@ -42,6 +42,7 @@ import logging
 
 from .base import _AwsService
 from ..limit import AwsLimit
+from botocore.exceptions import EndpointConnectionError
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +62,15 @@ class _FirehoseService(_AwsService):
         self.connect()
         for lim in self.limits.values():
             lim._reset_usage()
-        self._find_delivery_streams()
+        try:
+            self._find_delivery_streams()
+        except EndpointConnectionError:
+            logger.error(
+                'Caught exception when trying to use Firehose; '
+                'perhaps the Firehose service is not available in this region?',
+                exc_info=1,
+            )
+
         self._have_usage = True
         logger.debug("Done checking usage.")
 

--- a/awslimitchecker/services/firehose.py
+++ b/awslimitchecker/services/firehose.py
@@ -93,7 +93,7 @@ class _FirehoseService(_AwsService):
         limits['Delivery streams per region'] = AwsLimit(
             'Delivery streams per region',
             self,
-            5,
+            20,
             self.warning_threshold,
             self.critical_threshold,
             limit_type='AWS::KinesisFirehose::DeliveryStream',

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -1960,3 +1960,38 @@ class IAM(object):
         'UsersQuota': 5000,
         'VersionsPerPolicyQuota': 8
     }
+
+
+class Firehose(object):
+
+    test_list_delivery_streams = [
+        {
+            'DeliveryStreamNames': [
+                'first-page-stream1',
+                'first-page-stream2',
+                'first-page-stream3',
+                'first-page-stream4',
+                'first-page-stream5',
+                'first-page-stream6',
+                'first-page-stream7',
+                'first-page-stream8',
+                'first-page-stream9',
+                'first-page-stream10',
+            ],
+            'HasMoreDeliveryStreams': True,
+            'ResponseMetadata': {
+                'HTTPStatusCode': 200,
+                'RequestId': '1aaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+            }
+        },
+        {
+            'DeliveryStreamNames': [
+                'second-page-stream11',
+            ],
+            'HasMoreDeliveryStreams': False,
+            'ResponseMetadata': {
+                'HTTPStatusCode': 200,
+                'RequestId': '2aaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+            }
+        }
+    ]

--- a/awslimitchecker/tests/services/test_firehose.py
+++ b/awslimitchecker/tests/services/test_firehose.py
@@ -1,0 +1,116 @@
+"""
+awslimitchecker/tests/services/test_firehose.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2016 Hugo Lopes Tavares <hltbra@gmail.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/awslimitchecker> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Hugo Lopes Tavares <hltbra@gmail.com>
+################################################################################
+"""
+
+import sys
+from awslimitchecker.services.firehose import _FirehoseService
+from awslimitchecker.tests.services import result_fixtures
+
+# https://code.google.com/p/mock/issues/detail?id=249
+# py>=3.4 should use unittest.mock not the mock package on pypi
+if (
+        sys.version_info[0] < 3 or
+        sys.version_info[0] == 3 and sys.version_info[1] < 4
+):
+    from mock import Mock
+else:
+    from unittest.mock import Mock
+
+
+fixtures = result_fixtures.Firehose()
+
+
+class Test_FirehoseService(object):
+
+    pbm = 'awslimitchecker.services.firehose'  # module patch base
+    pb = '%s._FirehoseService' % pbm  # class patch pase
+
+    def test_init(self):
+        """test __init__()"""
+        cls = _FirehoseService(21, 43)
+        assert cls.service_name == 'Firehose'
+        assert cls.api_name == 'firehose'
+        assert cls.conn is None
+        assert cls.warning_threshold == 21
+        assert cls.critical_threshold == 43
+
+    def test_get_limits(self):
+        cls = _FirehoseService(21, 43)
+        cls.limits = {}
+        res = cls.get_limits()
+        assert sorted(res.keys()) == sorted([
+            'Delivery streams per region',
+        ])
+        for name, limit in res.items():
+            assert limit.service == cls
+            assert limit.def_warning_threshold == 21
+            assert limit.def_critical_threshold == 43
+
+    def test_get_limits_again(self):
+        """test that existing limits dict is returned on subsequent calls"""
+        mock_limits = Mock()
+        cls = _FirehoseService(21, 43)
+        cls.limits = mock_limits
+        res = cls.get_limits()
+        assert res == mock_limits
+
+    def test_find_usage(self):
+        responses = fixtures.test_list_delivery_streams
+        # create a flat list of delivery stream names from the fixture
+        response_streams = []
+        for resp in responses:
+            for stream_name in resp['DeliveryStreamNames']:
+                response_streams.append(stream_name)
+        mock_conn = Mock()
+        mock_conn.list_delivery_streams.side_effect = responses
+        cls = _FirehoseService(21, 43, region='us-west-2')
+        cls.conn = mock_conn
+        cls.find_usage()
+        assert mock_conn.list_delivery_streams.call_count == len(responses)
+        assert cls._have_usage is True
+        usage = cls.limits['Delivery streams per region'].get_current_usage()
+        assert len(usage) == 1
+        assert usage[0].value == len(response_streams)
+        assert usage[0].resource_id == 'us-west-2'
+        assert usage[0].aws_type == 'AWS::KinesisFirehose::DeliveryStream'
+
+    def test_required_iam_permissions(self):
+        cls = _FirehoseService(21, 43)
+        assert cls.required_iam_permissions() == [
+            "firehose:ListDeliveryStreams",
+        ]

--- a/docs/source/awslimitchecker.services.rst
+++ b/docs/source/awslimitchecker.services.rst
@@ -19,6 +19,7 @@ Submodules
    awslimitchecker.services.elasticache
    awslimitchecker.services.elasticbeanstalk
    awslimitchecker.services.elb
+   awslimitchecker.services.firehose
    awslimitchecker.services.iam
    awslimitchecker.services.rds
    awslimitchecker.services.s3

--- a/docs/source/limits.rst
+++ b/docs/source/limits.rst
@@ -400,7 +400,7 @@ Firehose
 =========================== ===
 Limit                       Default
 =========================== ===
-Delivery streams per region 5
+Delivery streams per region 20
 =========================== ===
 
 IAM

--- a/docs/source/limits.rst
+++ b/docs/source/limits.rst
@@ -394,6 +394,15 @@ Applications         25
 Environments         200
 ==================== ===
 
+Firehose
+++++++++
+
+=========================== ===
+Limit                       Default
+=========================== ===
+Delivery streams per region 5
+=========================== ===
+
 IAM
 ++++
 


### PR DESCRIPTION
This pull request creates the service Firehose and implements the metric "'Delivery streams per region".

More information on this limit:
- http://docs.aws.amazon.com/firehose/latest/dev/limits.html
- http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits-akf

---

Before submitting pull requests, please see the
[Development documentation](http://awslimitchecker.readthedocs.org/en/latest/development.html)
and specifically the [Pull Request Guidelines](http://awslimitchecker.readthedocs.org/en/latest/development.html#pull-requests).

**IMPORTANT:** Please take note of the below checklist, especially the first two items.
# Pull Request Checklist
- [x] All pull requests should be **against the develop branch**, not master.
- [x] All pull requests must include the Contributor License Agreement (see below).
- [x] Code should conform to the [Development Guidelines](http://awslimitchecker.readthedocs.org/en/latest/development.html#guidelines):
  - [x] pep8 compliant with some exceptions (see pytest.ini)
  - [x] 100% test coverage with pytest (with valid tests). If you have difficulty
    writing tests for the code, feel free to ask for help or submit the PR without tests.
  - [x] Complete, correctly-formatted documentation for all classes, functions and methods.
  - [x] documentation has been rebuilt with `tox -e docs`
  - [x] Connections to the AWS services should only be made by the class's
    `connect()` and `connect_resource()` methods, inherited from
    [awslimitchecker.connectable.Connectable](http://awslimitchecker.readthedocs.org/en/latest/awslimitchecker.connectable.html)
  - [x] All modules should have (and use) module-level loggers.
  - [x] **Commit messages** should be meaningful, and reference the Issue number
    if you're working on a GitHub issue (i.e. "issue #x - <message>"). Please
    refrain from using the "fixes #x" notation unless you are _sure_ that the
    the issue is fixed in that commit.
  - [x] Git history is fully intact; please do not squash or rewrite history.
- [x] If you made changes to the `versioncheck` code, be sure to locally run the
  `-versioncheck` tox tests.
## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:
- The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
- My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
- I have the legal power and rights to agree to these terms.
