### PR TITLE
fixes #217 - add support for some new/missing instance types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.6.0 (unreleased)
+------------------
+
+* `#217 <https://github.com/jantman/awslimitchecker/issues/217>`_ - add support
+  for new/missing EC2 instance types: ``m4.16xlarge``, ``x1.16xlarge``, ``x1.32xlarge``,
+  ``p2.xlarge``, ``p2.8xlarge``, ``p2.16xlarge``.
+
 0.5.1 (2016-09-25)
 ------------------
 

--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -299,12 +299,18 @@ class _Ec2Service(_AwsService):
         # (On-Demand, Reserved, Spot)
         default_limits = (20, 20, 5)
         special_limits = {
+            'm4.4xlarge': (10, 20, 5),
+            'm4.10xlarge': (5, 20, 5),
+            'm4.16xlarge': (5, 20, 5),
             'c4.4xlarge': (10, 20, 5),
             'c4.8xlarge': (5, 20, 5),
             'cg1.4xlarge': (2, 20, 5),
             'hi1.4xlarge': (2, 20, 5),
             'hs1.8xlarge': (2, 20, 0),
             'cr1.8xlarge': (2, 20, 5),
+            'p2.xlarge': (1, 20, 5),
+            'p2.8xlarge': (1, 20, 5),
+            'p2.16xlarge': (1, 20, 5),
             'g2.2xlarge': (5, 20, 5),
             'g2.8xlarge': (2, 20, 5),
             'r3.4xlarge': (10, 20, 5),
@@ -315,8 +321,6 @@ class _Ec2Service(_AwsService):
             'i2.8xlarge': (2, 20, 0),
             'd2.4xlarge': (10, 20, 5),
             'd2.8xlarge': (5, 20, 5),
-            'm4.4xlarge': (10, 20, 5),
-            'm4.10xlarge': (5, 20, 5)
         }
         limits = {}
         for i_type in self._instance_types():
@@ -559,7 +563,8 @@ class _Ec2Service(_AwsService):
             'm4.xlarge',
             'm4.2xlarge',
             'm4.4xlarge',
-            'm4.10xlarge'
+            'm4.10xlarge',
+            'm4.16xlarge'
         ]
 
         PREV_GENERAL_TYPES = [
@@ -576,6 +581,8 @@ class _Ec2Service(_AwsService):
             'r3.2xlarge',
             'r3.4xlarge',
             'r3.8xlarge',
+            'x1.16xlarge',
+            'x1.32xlarge'
         ]
 
         PREV_MEMORY_TYPES = [
@@ -602,6 +609,12 @@ class _Ec2Service(_AwsService):
             'c1.medium',
             'c1.xlarge',
             'cc2.8xlarge',
+        ]
+
+        ACCELERATED_COMPUTE_TYPES = [
+            'p2.xlarge',
+            'p2.8xlarge',
+            'p2.16xlarge'
         ]
 
         STORAGE_TYPES = [
@@ -639,6 +652,7 @@ class _Ec2Service(_AwsService):
             PREV_MEMORY_TYPES +
             COMPUTE_TYPES +
             PREV_COMPUTE_TYPES +
+            ACCELERATED_COMPUTE_TYPES +
             STORAGE_TYPES +
             PREV_STORAGE_TYPES +
             DENSE_STORAGE_TYPES +

--- a/awslimitchecker/tests/services/test_ec2.py
+++ b/awslimitchecker/tests/services/test_ec2.py
@@ -72,7 +72,7 @@ class Test_Ec2Service(object):
     def test_instance_types(self):
         cls = _Ec2Service(21, 43)
         types = cls._instance_types()
-        assert len(types) == 54
+        assert len(types) == 60
         assert 't2.micro' in types
         assert 'r3.8xlarge' in types
         assert 'c3.large' in types
@@ -82,6 +82,9 @@ class Test_Ec2Service(object):
         assert 'hs1.8xlarge' in types
         assert 'cg1.4xlarge' in types
         assert 'm4.4xlarge' in types
+        assert 'p2.16xlarge' in types
+        assert 'm4.16xlarge' in types
+        assert 'x1.32xlarge' in types
 
     def test_get_limits(self):
         cls = _Ec2Service(21, 43)
@@ -127,7 +130,7 @@ class Test_Ec2Service(object):
     def test_get_limits_instances(self):
         cls = _Ec2Service(21, 43)
         limits = cls._get_limits_instances()
-        assert len(limits) == 55
+        assert len(limits) == 61
         # check a random subset of limits
         t2_micro = limits['Running On-Demand t2.micro instances']
         assert t2_micro.default_limit == 20
@@ -141,6 +144,14 @@ class Test_Ec2Service(object):
         assert i2_8xlarge.default_limit == 2
         assert i2_8xlarge.limit_type == 'On-Demand instances'
         assert i2_8xlarge.limit_subtype == 'i2.8xlarge'
+        m4_16xlarge = limits['Running On-Demand m4.16xlarge instances']
+        assert m4_16xlarge.default_limit == 5
+        assert m4_16xlarge.limit_type == 'On-Demand instances'
+        assert m4_16xlarge.limit_subtype == 'm4.16xlarge'
+        p2_16xlarge = limits['Running On-Demand p2.16xlarge instances']
+        assert p2_16xlarge.default_limit == 1
+        assert p2_16xlarge.limit_type == 'On-Demand instances'
+        assert p2_16xlarge.limit_subtype == 'p2.16xlarge'
         all_ec2 = limits['Running On-Demand EC2 instances']
         assert all_ec2.default_limit == 20
         assert all_ec2.limit_type == 'On-Demand instances'

--- a/docs/source/limits.rst
+++ b/docs/source/limits.rst
@@ -54,9 +54,9 @@ updated from Trusted Advisor:
 
   * Running On-Demand c4.2xlarge instances
 
-  * Running On-Demand c4.large instances
+  * Running On-Demand c4.4xlarge instances
 
-  * Running On-Demand m1.medium instances
+  * Running On-Demand c4.large instances
 
   * Running On-Demand m3.2xlarge instances
 
@@ -308,7 +308,7 @@ Running On-Demand c3.8xlarge instances                         20
 Running On-Demand c3.large instances :sup:`(TA)`               20  
 Running On-Demand c3.xlarge instances :sup:`(TA)`              20  
 Running On-Demand c4.2xlarge instances :sup:`(TA)`             20  
-Running On-Demand c4.4xlarge instances                         10  
+Running On-Demand c4.4xlarge instances :sup:`(TA)`             10  
 Running On-Demand c4.8xlarge instances                         5   
 Running On-Demand c4.large instances :sup:`(TA)`               20  
 Running On-Demand c4.xlarge instances                          20  
@@ -328,7 +328,7 @@ Running On-Demand i2.4xlarge instances                         4
 Running On-Demand i2.8xlarge instances                         2   
 Running On-Demand i2.xlarge instances                          8   
 Running On-Demand m1.large instances                           20  
-Running On-Demand m1.medium instances :sup:`(TA)`              20  
+Running On-Demand m1.medium instances                          20  
 Running On-Demand m1.small instances                           20  
 Running On-Demand m1.xlarge instances                          20  
 Running On-Demand m2.2xlarge instances                         20  
@@ -339,10 +339,14 @@ Running On-Demand m3.large instances :sup:`(TA)`               20
 Running On-Demand m3.medium instances :sup:`(TA)`              20  
 Running On-Demand m3.xlarge instances :sup:`(TA)`              20  
 Running On-Demand m4.10xlarge instances                        5   
+Running On-Demand m4.16xlarge instances                        5   
 Running On-Demand m4.2xlarge instances :sup:`(TA)`             20  
 Running On-Demand m4.4xlarge instances :sup:`(TA)`             10  
 Running On-Demand m4.large instances :sup:`(TA)`               20  
 Running On-Demand m4.xlarge instances :sup:`(TA)`              20  
+Running On-Demand p2.16xlarge instances                        1   
+Running On-Demand p2.8xlarge instances                         1   
+Running On-Demand p2.xlarge instances                          1   
 Running On-Demand r3.2xlarge instances :sup:`(TA)`             20  
 Running On-Demand r3.4xlarge instances :sup:`(TA)`             10  
 Running On-Demand r3.8xlarge instances                         5   
@@ -354,6 +358,8 @@ Running On-Demand t2.medium instances :sup:`(TA)`              20
 Running On-Demand t2.micro instances :sup:`(TA)`               20  
 Running On-Demand t2.nano instances                            20  
 Running On-Demand t2.small instances :sup:`(TA)`               20  
+Running On-Demand x1.16xlarge instances                        20  
+Running On-Demand x1.32xlarge instances                        20  
 Security groups per VPC                                        500 
 VPC Elastic IP addresses (EIPs) :sup:`(TA)` :sup:`(API)`       5   
 VPC security groups per elastic network interface :sup:`(API)` 5   


### PR DESCRIPTION
Adds support for some missing instance types:

* ``m4.16xlarge``
* ``x1.16xlarge``
* ``x1.32xlarge``
* ``p2.xlarge``
* ``p2.8xlarge``
* ``p2.16xlarge``