### PR TITLE
issue #215 - don't die on AZ-less EC2 reserved instances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,14 @@ Changelog
 * `#217 <https://github.com/jantman/awslimitchecker/issues/217>`_ - add support
   for new/missing EC2 instance types: ``m4.16xlarge``, ``x1.16xlarge``, ``x1.32xlarge``,
   ``p2.xlarge``, ``p2.8xlarge``, ``p2.16xlarge``.
+* `#215 <https://github.com/jantman/awslimitchecker/issues/215>`_ - support
+  "Regional Benefit" Reserved Instances that have no specific AZ set on them (
+  bug fix for a KeyError when calculating EC2 Reserved Instances). It's unclear
+  to me whether, for the purpose of calculating limits, these are subtracted from
+  On-Demand Running Instances or ignored (because they're not actually a specific
+  capacity reservation). For the time being, they'll be ignored (i.e. not subtracted
+  from On-Demand Running Instances) but a debug-level message will be logged
+  for each.
 
 0.5.1 (2016-09-25)
 ------------------

--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -200,6 +200,18 @@ class _Ec2Service(_AwsService):
                 logger.debug("Skipping ReservedInstance %s with state %s",
                              x['ReservedInstancesId'], x['State'])
                 continue
+            if 'AvailabilityZone' not in x:
+                # "Regional Benefit" AZ-less reservation; I'm unsure whether
+                # for the purposes of limits, these are counted as On-Demand
+                # or reserved;
+                # see <https://github.com/jantman/awslimitchecker/issues/215>
+                logger.debug("Skipping 'Regional Benefit' ReservedInstance "
+                             "without AZ %s (%d x %s) - see "
+                             "<https://github.com/jantman/awslimitchecker/"
+                             "issues/215> for more information",
+                             x['ReservedInstancesId'], x['InstanceCount'],
+                             x['InstanceType'])
+                continue
             if x['AvailabilityZone'] not in az_to_res:
                 az_to_res[x['AvailabilityZone']] = deepcopy(reservations)
             az_to_res[x['AvailabilityZone']][

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -1563,6 +1563,12 @@ class EC2(object):
                 'InstanceCount': 98,
                 'State': 'active',
             },
+            {
+                'ReservedInstancesId': 'res5',
+                'InstanceType': 'it2',
+                'InstanceCount': 9,
+                'State': 'active',
+            },
         ]
     }
 


### PR DESCRIPTION
for 'Regional Benefit' AZ-less Reserved Instances, don't die with a KeyError but don't subtract them from On-Demand either; just log a debug message

I may need to come back and fix this, if they should really be subtracted from the On-Demand count.