### PR TITLE
fixes #215 - subtract AZ-less 'Regional Benefit' RIs from usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,13 +8,9 @@ Changelog
   for new/missing EC2 instance types: ``m4.16xlarge``, ``x1.16xlarge``, ``x1.32xlarge``,
   ``p2.xlarge``, ``p2.8xlarge``, ``p2.16xlarge``.
 * `#215 <https://github.com/jantman/awslimitchecker/issues/215>`_ - support
-  "Regional Benefit" Reserved Instances that have no specific AZ set on them (
-  bug fix for a KeyError when calculating EC2 Reserved Instances). It's unclear
-  to me whether, for the purpose of calculating limits, these are subtracted from
-  On-Demand Running Instances or ignored (because they're not actually a specific
-  capacity reservation). For the time being, they'll be ignored (i.e. not subtracted
-  from On-Demand Running Instances) but a debug-level message will be logged
-  for each.
+  "Regional Benefit" Reserved Instances that have no specific AZ set on them. Per
+  AWS, these are exempt from On-Demand Running Instances limits like all other
+  RIs.
 
 0.5.1 (2016-09-25)
 ------------------

--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -47,6 +47,8 @@ from ..limit import AwsLimit
 
 logger = logging.getLogger(__name__)
 
+RI_NO_AZ = 'xxREGIONAL_BENEFIT-NO_AZxx'
+
 
 class _Ec2Service(_AwsService):
 
@@ -97,6 +99,20 @@ class _Ec2Service(_AwsService):
                     # we have unused reservations
                     continue
                 ondemand_usage[i_type] += od
+        # subtract any "Regional Benefit" AZ-less reservations
+        for i_type in ondemand_usage.keys():
+            if RI_NO_AZ in res_usage and i_type in res_usage[RI_NO_AZ]:
+                logger.debug('Subtracting %d AZ-less "Regional Benefit" '
+                             'Reserved Instances from %d running %s instances',
+                             res_usage[RI_NO_AZ][i_type],
+                             ondemand_usage[i_type], i_type)
+                # we have Regional Benefit reservations for this type;
+                # we don't want to show negative usage, even if we're
+                #  over-reserved
+                ondemand_usage[i_type] = max(
+                    ondemand_usage[i_type] - res_usage[RI_NO_AZ][i_type],
+                    0
+                )
         total_instances = 0
         for i_type, usage in ondemand_usage.items():
             key = 'Running On-Demand {t} instances'.format(
@@ -202,17 +218,8 @@ class _Ec2Service(_AwsService):
                              x['ReservedInstancesId'], x['State'])
                 continue
             if 'AvailabilityZone' not in x:
-                # "Regional Benefit" AZ-less reservation; I'm unsure whether
-                # for the purposes of limits, these are counted as On-Demand
-                # or reserved;
-                # see <https://github.com/jantman/awslimitchecker/issues/215>
-                logger.debug("Skipping 'Regional Benefit' ReservedInstance "
-                             "without AZ %s (%d x %s) - see "
-                             "<https://github.com/jantman/awslimitchecker/"
-                             "issues/215> for more information",
-                             x['ReservedInstancesId'], x['InstanceCount'],
-                             x['InstanceType'])
-                continue
+                # "Regional Benefit" AZ-less reservation
+                x['AvailabilityZone'] = RI_NO_AZ
             if x['AvailabilityZone'] not in az_to_res:
                 az_to_res[x['AvailabilityZone']] = deepcopy(reservations)
             az_to_res[x['AvailabilityZone']][

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -1569,6 +1569,12 @@ class EC2(object):
                 'InstanceCount': 9,
                 'State': 'active',
             },
+            {
+                'ReservedInstancesId': 'res6',
+                'InstanceType': 'it3',
+                'InstanceCount': 6,
+                'State': 'active',
+            },
         ]
     }
 


### PR DESCRIPTION
Fixes #215

The fact that Regional Benefit (AZ-less) RIs don't count against on-demand usage was confirmed for me by AWS Support.