### PR TITLE
Fix ExpiredTokenException Errors - GH #220

### DIFF
--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -37,9 +37,11 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ################################################################################
 """
 
+from .connectable import ConnectableCredentials
 from .services import _services
-from .version import _get_version_info
 from .trustedadvisor import TrustedAdvisor
+from .version import _get_version_info
+import boto3
 import sys
 import logging
 import warnings
@@ -153,24 +155,58 @@ class AwsLimitChecker(object):
         self.mfa_serial_number = mfa_serial_number
         self.mfa_token = mfa_token
         self.region = region
+
         self.services = {}
+
+        boto_conn_kwargs = self._boto_conn_kwargs
         for sname, cls in _services.items():
-            self.services[sname] = cls(warning_threshold, critical_threshold,
-                                       profile_name, account_id, account_role,
-                                       region, external_id, mfa_serial_number,
-                                       mfa_token)
-        self.ta = TrustedAdvisor(
-            self.services,
-            profile_name=profile_name,
-            account_id=account_id,
-            account_role=account_role,
-            region=region,
-            external_id=external_id,
-            mfa_serial_number=mfa_serial_number,
-            mfa_token=mfa_token,
-            ta_refresh_mode=ta_refresh_mode,
-            ta_refresh_timeout=ta_refresh_timeout
-        )
+            self.services[sname] = cls(warning_threshold,
+                                       critical_threshold,
+                                       boto_conn_kwargs)
+
+        self.ta = TrustedAdvisor(self.services,
+                                 boto_conn_kwargs,
+                                 ta_refresh_mode=ta_refresh_mode,
+                                 ta_refresh_timeout=ta_refresh_timeout)
+
+    @property
+    def _boto_conn_kwargs(self):
+        """
+        Generate keyword arguments for boto3 connection functions.
+
+        If ``self.account_id`` is defined, this will call
+        :py:meth:`~._get_sts_token` to get STS token credentials using
+        `boto3.STS.Client.assume_role <https://boto3.readthedocs.org/en/
+        latest/reference/services/sts.html#STS.Client.assume_role>`_ and include
+        those credentials in the return value.
+
+        If ``self.profile_name`` is defined, this will call `boto3.Session()
+        <http://boto3.readthedocs.io/en/latest/reference/core/session.html>`
+        with that profile and include those credentials in the return value.
+
+        :return: keyword arguments for boto3 connection functions
+        :rtype: dict
+        """
+        kwargs = {'region_name': self.region}
+        if self.account_id is not None:
+            logger.debug("Connecting for account %s role '%s' with STS "
+                         "(region: %s)", self.account_id, self.account_role,
+                         self.region)
+            credentials = self._get_sts_token()
+            kwargs['aws_access_key_id'] = credentials.access_key
+            kwargs['aws_secret_access_key'] = credentials.secret_key
+            kwargs['aws_session_token'] = credentials.session_token
+        elif self.profile_name is not None:
+            # use boto3.Session to get credentials from the named profile
+            logger.debug("Using credentials profile: %s", self.profile_name)
+            session = boto3.Session(profile_name=self.profile_name)
+            credentials = session._session.get_credentials()
+            kwargs['aws_access_key_id'] = credentials.access_key
+            kwargs['aws_secret_access_key'] = credentials.secret_key
+            kwargs['aws_session_token'] = credentials.token
+        else:
+            logger.debug("Connecting to region %s", self.region)
+        return kwargs
 
     def get_version(self):
         """
@@ -226,6 +262,44 @@ class AwsLimitChecker(object):
         :rtype: list
         """
         return sorted(self.services.keys())
+
+    def _get_sts_token(self):
+        """
+        Assume a role via STS and return the credentials.
+
+        First connect to STS via :py:func:`boto3.client`, then
+        assume a role using `boto3.STS.Client.assume_role <https://boto3.readthe
+        docs.org/en/latest/reference/services/sts.html#STS.Client.assume_role>`_
+        using ``self.account_id`` and ``self.account_role`` (and optionally
+        ``self.external_id``, ``self.mfa_serial_number``, ``self.mfa_token``).
+        Return the resulting :py:class:`~.ConnectableCredentials`
+        object.
+
+        :returns: STS assumed role credentials
+        :rtype: :py:class:`~.ConnectableCredentials`
+        """
+        logger.debug("Connecting to STS in region %s", self.region)
+        sts = boto3.client('sts', region_name=self.region)
+        arn = "arn:aws:iam::%s:role/%s" % (self.account_id, self.account_role)
+        logger.debug("STS assume role for %s", arn)
+        assume_kwargs = {
+            'RoleArn': arn,
+            'RoleSessionName': 'awslimitchecker'
+        }
+        if self.external_id is not None:
+            assume_kwargs['ExternalId'] = self.external_id
+        if self.mfa_serial_number is not None:
+            assume_kwargs['SerialNumber'] = self.mfa_serial_number
+        if self.mfa_token is not None:
+            assume_kwargs['TokenCode'] = self.mfa_token
+        role = sts.assume_role(**assume_kwargs)
+
+        creds = ConnectableCredentials(role)
+        creds.account_id = self.account_id
+
+        logger.debug("Got STS credentials for role; access_key_id=%s "
+                     "(account_id=%s)", creds.access_key, creds.account_id)
+        return creds
 
     def find_usage(self, service=None, use_ta=True):
         """

--- a/awslimitchecker/services/base.py
+++ b/awslimitchecker/services/base.py
@@ -51,9 +51,7 @@ class _AwsService(Connectable):
     api_name = 'baseclass'
 
     def __init__(self, warning_threshold, critical_threshold,
-                 profile_name=None, account_id=None, account_role=None,
-                 region=None, external_id=None, mfa_serial_number=None,
-                 mfa_token=None):
+                 boto_connection_kwargs={}):
         """
         Describes an AWS service and its limits, and provides methods to
         query current utilization.
@@ -101,14 +99,7 @@ class _AwsService(Connectable):
         """
         self.warning_threshold = warning_threshold
         self.critical_threshold = critical_threshold
-        self.profile_name = profile_name
-        self.account_id = account_id
-        self.account_role = account_role
-        self.region = region
-        self.external_id = external_id
-        self.mfa_serial_number = mfa_serial_number
-        self.mfa_token = mfa_token
-
+        self._boto3_connection_kwargs = boto_connection_kwargs
         self.limits = {}
         self.limits = self.get_limits()
         self.conn = None

--- a/awslimitchecker/services/firehose.py
+++ b/awslimitchecker/services/firehose.py
@@ -84,7 +84,7 @@ class _FirehoseService(_AwsService):
             usage += len(streams['DeliveryStreamNames'])
         self.limits['Delivery streams per region']._add_current_usage(
             usage,
-            resource_id=self.region,
+            resource_id=self._boto3_connection_kwargs['region_name'],
             aws_type='AWS::KinesisFirehose::DeliveryStream',
         )
 

--- a/awslimitchecker/tests/services/test_base.py
+++ b/awslimitchecker/tests/services/test_base.py
@@ -109,40 +109,21 @@ class Test_AwsService(object):
         assert cls.limits == {'foo': 'bar'}
         assert cls.conn is None
         assert cls._have_usage is False
-        assert cls.account_id is None
-        assert cls.account_role is None
-        assert cls.region is None
-        assert cls.external_id is None
+        assert not cls._boto3_connection_kwargs
 
-    def test_init_subclass_sts(self):
-        cls = AwsServiceTester(
-            1,
-            2,
-            account_id='012345678912',
-            account_role='myrole',
-            region='myregion'
-        )
+    def test_init_subclass_boto_xargs(self):
+        boto_args = {'region_name': 'myregion',
+                     'aws_access_key_id': 'myaccesskey',
+                     'aws_secret_access_key': 'mysecretkey',
+                     'aws_session_token': 'mytoken'}
+
+        cls = AwsServiceTester(1, 2, boto_args)
         assert cls.warning_threshold == 1
         assert cls.critical_threshold == 2
         assert cls.limits == {'foo': 'bar'}
         assert cls.conn is None
         assert cls._have_usage is False
-        assert cls.account_id == '012345678912'
-        assert cls.account_role == 'myrole'
-        assert cls.region == 'myregion'
-
-    def test_init_subclass_profile(self):
-        cls = AwsServiceTester(
-            1,
-            2,
-            profile_name='foo'
-        )
-        assert cls.warning_threshold == 1
-        assert cls.critical_threshold == 2
-        assert cls.limits == {'foo': 'bar'}
-        assert cls.conn is None
-        assert cls._have_usage is False
-        assert cls.profile_name == 'foo'
+        assert cls._boto3_connection_kwargs == boto_args
 
     def test_set_limit_override(self):
         mock_limit = Mock(spec_set=AwsLimit)
@@ -305,12 +286,12 @@ class Test_AwsServiceSubclasses(object):
         # ensure warning and critical thresholds
         assert inst.warning_threshold == 3
         assert inst.critical_threshold == 7
-        assert inst.account_id is None
-        assert inst.account_role is None
-        assert inst.region is None
+        assert not inst._boto3_connection_kwargs
 
-        sts_inst = cls(3, 7, account_id='123', account_role='myrole',
-                       region='myregion')
-        assert sts_inst.account_id == '123'
-        assert sts_inst.account_role == 'myrole'
-        assert sts_inst.region == 'myregion'
+        boto_args = dict(region_name='myregion',
+                         aws_access_key_id='myaccesskey',
+                         aws_secret_access_key='mysecretkey',
+                         aws_session_token='mytoken')
+
+        sts_inst = cls(3, 7, boto_args)
+        assert sts_inst._boto3_connection_kwargs == boto_args

--- a/awslimitchecker/tests/services/test_firehose.py
+++ b/awslimitchecker/tests/services/test_firehose.py
@@ -99,7 +99,7 @@ class Test_FirehoseService(object):
                 response_streams.append(stream_name)
         mock_conn = Mock()
         mock_conn.list_delivery_streams.side_effect = responses
-        cls = _FirehoseService(21, 43, region='us-west-2')
+        cls = _FirehoseService(21, 43, {'region_name': 'us-west-2'})
         cls.conn = mock_conn
         cls.find_usage()
         assert mock_conn.list_delivery_streams.call_count == len(responses)

--- a/awslimitchecker/tests/test_connectable.py
+++ b/awslimitchecker/tests/test_connectable.py
@@ -77,152 +77,6 @@ class ConnectableTester(Connectable):
 
 class Test_Connectable(object):
 
-    def test_boto3_connection_kwargs(self):
-        cls = ConnectableTester()
-
-        with patch('%s._get_sts_token' % pb) as mock_get_sts:
-            with patch('%s.logger' % pbm) as mock_logger:
-                with patch('%s.boto3.Session' % pbm) as mock_sess:
-                    Connectable.credentials = None
-                    res = cls._boto3_connection_kwargs
-        assert mock_get_sts.mock_calls == []
-        assert mock_logger.mock_calls == [
-            call.debug('Connecting to region %s', None)
-        ]
-        assert mock_sess.mock_calls == []
-        assert res == {
-            'region_name': None
-        }
-
-    def test_boto3_connection_kwargs_profile(self):
-        cls = ConnectableTester(profile_name='myprof')
-        m_creds = Mock()
-        type(m_creds).access_key = 'ak'
-        type(m_creds).secret_key = 'sk'
-        type(m_creds).token = 'tkn'
-        mock_session = Mock()
-        m_sess = Mock()
-        m_sess.get_credentials.return_value = m_creds
-        type(mock_session)._session = m_sess
-
-        with patch('%s._get_sts_token' % pb) as mock_get_sts:
-            with patch('%s.logger' % pbm) as mock_logger:
-                with patch('%s.boto3.Session' % pbm) as mock_sess:
-                    Connectable.credentials = None
-                    mock_sess.return_value = mock_session
-                    res = cls._boto3_connection_kwargs
-        assert mock_get_sts.mock_calls == []
-        assert mock_logger.mock_calls == [
-            call.debug('Using credentials profile: %s', 'myprof')
-        ]
-        assert mock_sess.mock_calls == [call(profile_name='myprof')]
-        assert res == {
-            'region_name': None,
-            'aws_access_key_id': 'ak',
-            'aws_secret_access_key': 'sk',
-            'aws_session_token': 'tkn'
-        }
-
-    def test_boto3_connection_kwargs_region(self):
-        cls = ConnectableTester(region='myregion')
-
-        with patch('%s._get_sts_token' % pb) as mock_get_sts:
-            with patch('%s.logger' % pbm) as mock_logger:
-                with patch('%s.boto3.Session' % pbm) as mock_sess:
-                    Connectable.credentials = None
-                    res = cls._boto3_connection_kwargs
-        assert mock_get_sts.mock_calls == []
-        assert mock_logger.mock_calls == [
-            call.debug('Connecting to region %s', 'myregion')
-        ]
-        assert mock_sess.mock_calls == []
-        assert res == {
-            'region_name': 'myregion'
-        }
-
-    def test_boto3_connection_kwargs_sts(self):
-        cls = ConnectableTester(account_id='123', account_role='myrole',
-                                region='myregion')
-        mock_creds = Mock()
-        type(mock_creds).access_key = 'sts_ak'
-        type(mock_creds).secret_key = 'sts_sk'
-        type(mock_creds).session_token = 'sts_token'
-
-        with patch('%s._get_sts_token' % pb) as mock_get_sts:
-            with patch('%s.logger' % pbm) as mock_logger:
-                with patch('%s.boto3.Session' % pbm) as mock_sess:
-                    mock_get_sts.return_value = mock_creds
-                    Connectable.credentials = None
-                    res = cls._boto3_connection_kwargs
-        assert mock_get_sts.mock_calls == [call()]
-        assert mock_logger.mock_calls == [
-            call.debug("Connecting for account %s role '%s' with STS "
-                       "(region: %s)", '123', 'myrole', 'myregion')
-        ]
-        assert mock_sess.mock_calls == []
-        assert res == {
-            'region_name': 'myregion',
-            'aws_access_key_id': 'sts_ak',
-            'aws_secret_access_key': 'sts_sk',
-            'aws_session_token': 'sts_token'
-        }
-
-    def test_boto3_connection_kwargs_sts_again(self):
-        cls = ConnectableTester(account_id='123', account_role='myrole',
-                                region='myregion')
-        mock_creds = Mock()
-        type(mock_creds).access_key = 'sts_ak'
-        type(mock_creds).secret_key = 'sts_sk'
-        type(mock_creds).session_token = 'sts_token'
-        type(mock_creds).account_id = '123'
-
-        with patch('%s._get_sts_token' % pb) as mock_get_sts:
-            with patch('%s.logger' % pbm) as mock_logger:
-                with patch('%s.boto3.Session' % pbm) as mock_sess:
-                    mock_get_sts.return_value = mock_creds
-                    Connectable.credentials = mock_creds
-                    res = cls._boto3_connection_kwargs
-        assert mock_get_sts.mock_calls == []
-        assert mock_logger.mock_calls == [
-            call.debug('Reusing previous STS credentials for account %s', '123')
-        ]
-        assert mock_sess.mock_calls == []
-        assert res == {
-            'region_name': 'myregion',
-            'aws_access_key_id': 'sts_ak',
-            'aws_secret_access_key': 'sts_sk',
-            'aws_session_token': 'sts_token'
-        }
-
-    def test_boto3_connection_kwargs_sts_again_other_account(self):
-        cls = ConnectableTester(account_id='123', account_role='myrole',
-                                region='myregion')
-        mock_creds = Mock()
-        type(mock_creds).access_key = 'sts_ak'
-        type(mock_creds).secret_key = 'sts_sk'
-        type(mock_creds).session_token = 'sts_token'
-        type(mock_creds).account_id = '456'
-
-        with patch('%s._get_sts_token' % pb) as mock_get_sts:
-            with patch('%s.logger' % pbm) as mock_logger:
-                with patch('%s.boto3.Session' % pbm) as mock_sess:
-                    mock_get_sts.return_value = mock_creds
-                    Connectable.credentials = mock_creds
-                    res = cls._boto3_connection_kwargs
-        assert mock_get_sts.mock_calls == [call()]
-        assert mock_logger.mock_calls == [
-            call.debug("Previous STS credentials are for account %s; "
-                       "getting new credentials for current account "
-                       "(%s)", '456', '123')
-        ]
-        assert mock_sess.mock_calls == []
-        assert res == {
-            'region_name': 'myregion',
-            'aws_access_key_id': 'sts_ak',
-            'aws_secret_access_key': 'sts_sk',
-            'aws_session_token': 'sts_token'
-        }
-
     def test_connect(self):
         mock_conn = Mock()
         mock_cc = Mock()
@@ -234,7 +88,7 @@ class Test_Connectable(object):
         kwargs = {'foo': 'fooval', 'bar': 'barval'}
 
         with patch('%s._boto3_connection_kwargs' % pb,
-                   new_callable=PropertyMock) as mock_kwargs:
+                   new_callable=PropertyMock, create=True) as mock_kwargs:
             mock_kwargs.return_value = kwargs
             with patch('%s.logger' % pbm) as mock_logger:
                 with patch('%s.boto3.client' % pbm) as mock_client:
@@ -267,7 +121,7 @@ class Test_Connectable(object):
         kwargs = {'foo': 'fooval', 'bar': 'barval'}
 
         with patch('%s._boto3_connection_kwargs' % pb,
-                   new_callable=PropertyMock) as mock_kwargs:
+                   new_callable=PropertyMock, create=True) as mock_kwargs:
             mock_kwargs.return_value = kwargs
             with patch('%s.logger' % pbm) as mock_logger:
                 with patch('%s.boto3.client' % pbm) as mock_client:
@@ -293,7 +147,7 @@ class Test_Connectable(object):
         kwargs = {'foo': 'fooval', 'bar': 'barval'}
 
         with patch('%s._boto3_connection_kwargs' % pb,
-                   new_callable=PropertyMock) as mock_kwargs:
+                   new_callable=PropertyMock, create=True) as mock_kwargs:
             mock_kwargs.return_value = kwargs
             with patch('%s.logger' % pbm) as mock_logger:
                 with patch('%s.boto3.resource' % pbm) as mock_resource:
@@ -325,12 +179,13 @@ class Test_Connectable(object):
         type(mock_conn).meta = mock_meta
 
         cls = ConnectableTester()
+
         cls.api_name = 'myapi'
         cls.resource_conn = mock_conn
         kwargs = {'foo': 'fooval', 'bar': 'barval'}
 
         with patch('%s._boto3_connection_kwargs' % pb,
-                   new_callable=PropertyMock) as mock_kwargs:
+                   new_callable=PropertyMock, create=True) as mock_kwargs:
             mock_kwargs.return_value = kwargs
             with patch('%s.logger' % pbm) as mock_logger:
                 with patch('%s.boto3.resource' % pbm) as mock_resource:
@@ -340,102 +195,6 @@ class Test_Connectable(object):
         assert mock_logger.mock_calls == []
         assert mock_resource.mock_calls == []
         assert cls.resource_conn == mock_conn
-
-    def test_get_sts_token(self):
-        ret_dict = Mock()
-        cls = ConnectableTester(account_id='789',
-                                account_role='myr', region='foobar')
-        with patch('%s.boto3.client' % pbm) as mock_connect:
-            with patch('%s.ConnectableCredentials' % pbm,
-                       create=True) as mock_creds:
-                mock_connect.return_value.assume_role.return_value = ret_dict
-                res = cls._get_sts_token()
-        arn = 'arn:aws:iam::789:role/myr'
-        assert mock_connect.mock_calls == [
-            call('sts', region_name='foobar'),
-            call().assume_role(
-                RoleArn=arn,
-                RoleSessionName='awslimitchecker'),
-        ]
-        assert mock_creds.mock_calls == [
-            call(ret_dict)
-        ]
-        assert res == mock_creds.return_value
-
-    def test_get_sts_token_extid(self):
-        ret_dict = Mock()
-        cls = ConnectableTester(account_id='789',
-                                account_role='myr', region='foobar',
-                                external_id='extid')
-        with patch('%s.boto3.client' % pbm) as mock_connect:
-            with patch('%s.ConnectableCredentials' % pbm,
-                       create=True) as mock_creds:
-                mock_connect.return_value.assume_role.return_value = ret_dict
-                res = cls._get_sts_token()
-        arn = 'arn:aws:iam::789:role/myr'
-        assert mock_connect.mock_calls == [
-            call('sts', region_name='foobar'),
-            call().assume_role(
-                RoleArn=arn,
-                RoleSessionName='awslimitchecker',
-                ExternalId='extid'),
-        ]
-        assert mock_creds.mock_calls == [
-            call(ret_dict)
-        ]
-        assert res == mock_creds.return_value
-
-    def test_get_sts_token_mfa(self):
-        ret_dict = Mock()
-        cls = ConnectableTester(account_id='789',
-                                account_role='myr', region='foobar',
-                                mfa_serial_number='mfaser',
-                                mfa_token='mfatoken')
-        with patch('%s.boto3.client' % pbm) as mock_connect:
-            with patch('%s.ConnectableCredentials' % pbm,
-                       create=True) as mock_creds:
-                mock_connect.return_value.assume_role.return_value = ret_dict
-                res = cls._get_sts_token()
-        arn = 'arn:aws:iam::789:role/myr'
-        assert mock_connect.mock_calls == [
-            call('sts', region_name='foobar'),
-            call().assume_role(
-                RoleArn=arn,
-                RoleSessionName='awslimitchecker',
-                SerialNumber='mfaser',
-                TokenCode='mfatoken'),
-        ]
-        assert mock_creds.mock_calls == [
-            call(ret_dict)
-        ]
-        assert res == mock_creds.return_value
-
-    def test_get_sts_token_extid_mfa(self):
-        ret_dict = Mock()
-        cls = ConnectableTester(account_id='789',
-                                account_role='myr', region='foobar',
-                                external_id='extid',
-                                mfa_serial_number='mfaser',
-                                mfa_token='mfatoken')
-        with patch('%s.boto3.client' % pbm) as mock_connect:
-            with patch('%s.ConnectableCredentials' % pbm,
-                       create=True) as mock_creds:
-                mock_connect.return_value.assume_role.return_value = ret_dict
-                res = cls._get_sts_token()
-        arn = 'arn:aws:iam::789:role/myr'
-        assert mock_connect.mock_calls == [
-            call('sts', region_name='foobar'),
-            call().assume_role(
-                RoleArn=arn,
-                RoleSessionName='awslimitchecker',
-                ExternalId='extid',
-                SerialNumber='mfaser',
-                TokenCode='mfatoken'),
-        ]
-        assert mock_creds.mock_calls == [
-            call(ret_dict)
-        ]
-        assert res == mock_creds.return_value
 
 
 class TestConnectableCredentials(object):

--- a/awslimitchecker/tests/test_integration.py
+++ b/awslimitchecker/tests/test_integration.py
@@ -48,7 +48,6 @@ import onetimepass as otp
 from awslimitchecker.utils import dict2cols
 from awslimitchecker.limit import SOURCE_TA, SOURCE_API
 from awslimitchecker.checker import AwsLimitChecker
-from awslimitchecker.connectable import Connectable
 from awslimitchecker.tests.support import LogRecordHelper
 
 if python_implementation() == 'CPython':
@@ -124,8 +123,6 @@ class TestIntegration(object):
           :py:meth:`~.support.LogRecordHelper.unexpected_logs`
         :type allow_endpoint_error: bool
         """
-        # clear the Connectable credentials
-        Connectable.credentials = None
         # destroy boto3's session, so it creates a new one
         boto3.DEFAULT_SESSION = None
         # set the env vars to the creds we want
@@ -215,8 +212,6 @@ class TestIntegration(object):
           :py:meth:`~.support.LogRecordHelper.unexpected_logs`
         :type allow_endpoint_error: bool
         """
-        # clear the Connectable credentials
-        Connectable.credentials = None
         # destroy boto3's session, so it creates a new one
         boto3.DEFAULT_SESSION = None
         # set the env vars to the creds we want

--- a/awslimitchecker/tests/test_trustedadvisor.py
+++ b/awslimitchecker/tests/test_trustedadvisor.py
@@ -69,7 +69,7 @@ class TestInit(object):
         self.mock_client_config = Mock()
         type(self.mock_client_config).region_name = 'us-east-1'
         type(self.mock_conn)._client_config = self.mock_client_config
-        self.cls = TrustedAdvisor({})
+        self.cls = TrustedAdvisor({}, {})
         self.cls.conn = self.mock_conn
 
         self.mock_svc1 = Mock(spec_set=_AwsService)
@@ -80,61 +80,39 @@ class TestInit(object):
         }
 
     def test_simple(self):
-        cls = TrustedAdvisor({})
+        cls = TrustedAdvisor({}, {})
         assert cls.conn is None
-        assert cls.account_id is None
-        assert cls.account_role is None
-        assert cls.region == 'us-east-1'
-        assert cls.ta_region is None
-        assert cls.external_id is None
-        assert cls.mfa_serial_number is None
-        assert cls.mfa_token is None
+        assert not cls._boto3_connection_kwargs
         assert cls.all_services == {}
         assert cls.limits_updated is False
         assert cls.refresh_mode is None
         assert cls.refresh_timeout is None
 
-    def test_sts(self):
+    def test_boto_kwargs(self):
         mock_svc = Mock(spec_set=_AwsService)
         mock_svc.get_limits.return_value = {}
+        boto_args = dict(region_name='myregion',
+                         aws_access_key_id='myaccesskey',
+                         aws_secret_access_key='mysecretkey',
+                         aws_session_token='mytoken')
+
         cls = TrustedAdvisor(
             {'foo': mock_svc},
-            account_id='aid',
-            account_role='role',
-            region='r',
+            boto_args,
             ta_refresh_mode=123,
             ta_refresh_timeout=456
         )
         assert cls.conn is None
-        assert cls.account_id == 'aid'
-        assert cls.account_role == 'role'
-        assert cls.region == 'us-east-1'
-        assert cls.ta_region == 'r'
-        assert cls.external_id is None
-        assert cls.mfa_serial_number is None
-        assert cls.mfa_token is None
+        cls_boto_args = cls._boto3_connection_kwargs
+        assert cls_boto_args.get('region_name') == 'myregion'
+        assert cls_boto_args.get('aws_access_key_id') == 'myaccesskey'
+        assert cls_boto_args.get('aws_secret_access_key') == 'mysecretkey'
+        assert cls_boto_args.get('aws_session_token') == 'mytoken'
+        assert cls.ta_region == 'myregion'
         assert cls.all_services == {'foo': mock_svc}
         assert cls.limits_updated is False
         assert cls.refresh_mode == 123
         assert cls.refresh_timeout == 456
-
-    def test_sts_external_id(self):
-        cls = TrustedAdvisor(
-            {}, account_id='aid', account_role='role', region='r',
-            external_id='myeid',
-            ta_refresh_mode='wait'
-        )
-        assert cls.conn is None
-        assert cls.account_id == 'aid'
-        assert cls.account_role == 'role'
-        assert cls.region == 'us-east-1'
-        assert cls.ta_region == 'r'
-        assert cls.external_id == 'myeid'
-        assert cls.mfa_serial_number is None
-        assert cls.mfa_token is None
-        assert cls.limits_updated is False
-        assert cls.refresh_mode == 'wait'
-        assert cls.refresh_timeout is None
 
 
 class TestUpdateLimits(object):
@@ -144,7 +122,7 @@ class TestUpdateLimits(object):
         self.mock_client_config = Mock()
         type(self.mock_client_config).region_name = 'us-east-1'
         type(self.mock_conn)._client_config = self.mock_client_config
-        self.cls = TrustedAdvisor({})
+        self.cls = TrustedAdvisor({}, {})
         self.cls.conn = self.mock_conn
 
         self.mock_svc1 = Mock(spec_set=_AwsService)
@@ -193,7 +171,7 @@ class TestGetLimitCheckId(object):
         self.mock_client_config = Mock()
         type(self.mock_client_config).region_name = 'us-east-1'
         type(self.mock_conn)._client_config = self.mock_client_config
-        self.cls = TrustedAdvisor({})
+        self.cls = TrustedAdvisor({}, {})
         self.cls.conn = self.mock_conn
 
         self.mock_svc1 = Mock(spec_set=_AwsService)
@@ -332,7 +310,7 @@ class TestPoll(object):
         self.mock_client_config = Mock()
         type(self.mock_client_config).region_name = 'us-east-1'
         type(self.mock_conn)._client_config = self.mock_client_config
-        self.cls = TrustedAdvisor({})
+        self.cls = TrustedAdvisor({}, {})
         self.cls.conn = self.mock_conn
 
         self.mock_svc1 = Mock(spec_set=_AwsService)
@@ -720,7 +698,7 @@ class TestGetRefreshedCheckResult(object):
         self.mock_client_config = Mock()
         type(self.mock_client_config).region_name = 'us-east-1'
         type(self.mock_conn)._client_config = self.mock_client_config
-        self.cls = TrustedAdvisor({})
+        self.cls = TrustedAdvisor({}, {})
         self.cls.conn = self.mock_conn
 
         self.mock_svc1 = Mock(spec_set=_AwsService)
@@ -858,7 +836,7 @@ class TestGetCheckResult(object):
         self.mock_client_config = Mock()
         type(self.mock_client_config).region_name = 'us-east-1'
         type(self.mock_conn)._client_config = self.mock_client_config
-        self.cls = TrustedAdvisor({})
+        self.cls = TrustedAdvisor({}, {})
         self.cls.conn = self.mock_conn
 
         self.mock_svc1 = Mock(spec_set=_AwsService)
@@ -938,7 +916,7 @@ class TestCanRefreshCheck(object):
         self.mock_client_config = Mock()
         type(self.mock_client_config).region_name = 'us-east-1'
         type(self.mock_conn)._client_config = self.mock_client_config
-        self.cls = TrustedAdvisor({})
+        self.cls = TrustedAdvisor({}, {})
         self.cls.conn = self.mock_conn
 
     def test_true(self):
@@ -1016,7 +994,7 @@ class TestPollForRefresh(object):
         self.mock_client_config = Mock()
         type(self.mock_client_config).region_name = 'us-east-1'
         type(self.mock_conn)._client_config = self.mock_client_config
-        self.cls = TrustedAdvisor({})
+        self.cls = TrustedAdvisor({}, {})
         self.cls.conn = self.mock_conn
 
     def test_no_timeout(self):
@@ -1182,7 +1160,7 @@ class TestUpdateServices(object):
         self.mock_client_config = Mock()
         type(self.mock_client_config).region_name = 'us-east-1'
         type(self.mock_conn)._client_config = self.mock_client_config
-        self.cls = TrustedAdvisor({})
+        self.cls = TrustedAdvisor({}, {})
         self.cls.conn = self.mock_conn
 
         self.mock_svc1 = Mock(spec_set=_AwsService)
@@ -1264,7 +1242,7 @@ class TestMakeTAServiceDict(object):
         self.mock_client_config = Mock()
         type(self.mock_client_config).region_name = 'us-east-1'
         type(self.mock_conn)._client_config = self.mock_client_config
-        self.cls = TrustedAdvisor({})
+        self.cls = TrustedAdvisor({}, {})
         self.cls.conn = self.mock_conn
 
         self.mock_svc1 = Mock(spec_set=_AwsService)

--- a/awslimitchecker/trustedadvisor.py
+++ b/awslimitchecker/trustedadvisor.py
@@ -49,7 +49,6 @@ logger = logging.getLogger(__name__)
 
 
 class TrustedAdvisor(Connectable):
-
     """
     Class to handle interaction with TrustedAdvisor API, polling TA and updating
     limits from TA information.
@@ -58,10 +57,8 @@ class TrustedAdvisor(Connectable):
     service_name = 'TrustedAdvisor'
     api_name = 'support'
 
-    def __init__(self, all_services, profile_name=None, account_id=None,
-                 account_role=None, region=None, external_id=None,
-                 mfa_serial_number=None, mfa_token=None, ta_refresh_mode=None,
-                 ta_refresh_timeout=None):
+    def __init__(self, all_services, boto_connection_kwargs,
+                 ta_refresh_mode=None, ta_refresh_timeout=None):
         """
         Class to contain all TrustedAdvisor-related logic.
 
@@ -115,14 +112,9 @@ class TrustedAdvisor(Connectable):
         """
         self.conn = None
         self.have_ta = True
-        self.profile_name = profile_name
-        self.account_id = account_id
-        self.account_role = account_role
         self.region = 'us-east-1'
-        self.ta_region = region
-        self.external_id = external_id
-        self.mfa_serial_number = mfa_serial_number
-        self.mfa_token = mfa_token
+        self.ta_region = boto_connection_kwargs.get('region_name')
+        self._boto3_connection_kwargs = boto_connection_kwargs
         self.refresh_mode = ta_refresh_mode
         self.refresh_timeout = ta_refresh_timeout
         self.all_services = all_services
@@ -226,8 +218,8 @@ class TrustedAdvisor(Connectable):
                 raise ex
         for check in checks:
             if (
-                    check['category'] == 'performance' and
-                    check['name'] == 'Service Limits'
+                            check['category'] == 'performance' and
+                            check['name'] == 'Service Limits'
             ):
                 logger.debug("Found TA check; id=%s", check['id'])
                 return (


### PR DESCRIPTION
Move creds and boto3 session construction into AwsLimitChecker to avoid
session timeouts in long-lived sessions.

Fixes GH issue #220. See thread for detailed discussion of this change.

Thanks to @jantman for all the help on this.

----

This contribution is being made under the same license as the
awslimitchecker project (AGPL, or any subsequent version of that
license as adopted by awslimitchecker), and may perpetually be
included in and distributed with awslimitchecker.
