### PR TITLE
Accept multiple services.

### DIFF
--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -235,7 +235,7 @@ class AwsLimitChecker(object):
         the service name, whose value is a nested dict as described below.
 
         :param service: the name of one service to return limits for
-        :type service: string
+        :type service: list
         :param use_ta: check Trusted Advisor for information on limits
         :type use_ta: bool
         :returns: dict of service name (string) to nested dict
@@ -245,7 +245,7 @@ class AwsLimitChecker(object):
         res = {}
         to_get = self.services
         if service is not None:
-            to_get = {service: self.services[service]}
+            to_get = {each: self.services[each] for each in service}
         if use_ta:
             self.ta.update_limits()
         for sname, cls in to_get.items():
@@ -313,13 +313,13 @@ class AwsLimitChecker(object):
 
         :param service: :py:class:`~._AwsService` name, or ``None`` to
           check all services.
-        :type service: :py:obj:`None`, or :py:obj:`string` service name to get
+        :type service: :py:obj:`None`, or :py:obj:`list` service name to get
         :param use_ta: check Trusted Advisor for information on limits
         :type use_ta: bool
         """
         to_get = self.services
         if service is not None:
-            to_get = {service: self.services[service]}
+            to_get = {each: self.services[each] for each in service}
         if use_ta:
             self.ta.update_limits()
         for cls in to_get.values():
@@ -517,7 +517,7 @@ class AwsLimitChecker(object):
         res = {}
         to_get = self.services
         if service is not None:
-            to_get = {service: self.services[service]}
+            to_get = {each: self.services[each] for each in service}
         if use_ta:
             self.ta.update_limits()
         for sname, cls in to_get.items():

--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -245,7 +245,7 @@ class AwsLimitChecker(object):
         res = {}
         to_get = self.services
         if service is not None:
-            to_get = {each: self.services[each] for each in service}
+            to_get = dict((each, self.services[each]) for each in service)
         if use_ta:
             self.ta.update_limits()
         for sname, cls in to_get.items():
@@ -319,7 +319,7 @@ class AwsLimitChecker(object):
         """
         to_get = self.services
         if service is not None:
-            to_get = {each: self.services[each] for each in service}
+            to_get = dict((each, self.services[each]) for each in service)
         if use_ta:
             self.ta.update_limits()
         for cls in to_get.values():
@@ -517,7 +517,7 @@ class AwsLimitChecker(object):
         res = {}
         to_get = self.services
         if service is not None:
-            to_get = {each: self.services[each] for each in service}
+            to_get = dict((each, self.services[each]) for each in service)
         if use_ta:
             self.ta.update_limits()
         for sname, cls in to_get.items():

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -99,7 +99,7 @@ class Runner(object):
                  'entitled to a copy of the source code. Use `--version` for ' \
                  'information on the source code location.'
         p = argparse.ArgumentParser(description=desc, epilog=epilog)
-        p.add_argument('-S', '--service', action='store', default=None,
+        p.add_argument('-S', '--service', action='store', nargs='*',
                        help='perform action for only the specified service name'
                             '; see -s|--list-services for valid names')
         p.add_argument('-s', '--list-services', action='store_true',

--- a/awslimitchecker/tests/test_checker.py
+++ b/awslimitchecker/tests/test_checker.py
@@ -456,7 +456,7 @@ class TestAwsLimitChecker(object):
         limits = sample_limits()
         self.mock_svc1.get_limits.return_value = limits['SvcFoo']
         self.mock_svc2.get_limits.return_value = limits['SvcBar']
-        res = self.cls.get_limits(service='SvcFoo')
+        res = self.cls.get_limits(service=['SvcFoo'])
         assert res == {'SvcFoo': limits['SvcFoo']}
         assert self.mock_ta.mock_calls == [
             call.update_limits()
@@ -470,7 +470,7 @@ class TestAwsLimitChecker(object):
         limits = sample_limits()
         self.mock_svc1.get_limits.return_value = limits['SvcFoo']
         self.mock_svc2.get_limits.return_value = limits['SvcBar']
-        res = self.cls.get_limits(service='SvcBar')
+        res = self.cls.get_limits(service=['SvcBar'])
         assert res == {'SvcBar': limits['SvcBar']}
         assert self.mock_ta.mock_calls == [
             call.update_limits()
@@ -506,7 +506,7 @@ class TestAwsLimitChecker(object):
         assert self.mock_ta.mock_calls == []
 
     def test_find_usage_service(self):
-        self.cls.find_usage(service='SvcFoo')
+        self.cls.find_usage(service=['SvcFoo'])
         assert self.mock_svc1.mock_calls == [
             call.find_usage()
         ]
@@ -516,7 +516,7 @@ class TestAwsLimitChecker(object):
         ]
 
     def test_find_usage_service_with_api(self):
-        self.cls.find_usage(service='SvcBar')
+        self.cls.find_usage(service=['SvcBar'])
         assert self.mock_svc1.mock_calls == []
         assert self.mock_svc2.mock_calls == [
             call._update_limits_from_api(),
@@ -740,7 +740,7 @@ class TestAwsLimitChecker(object):
     def test_check_thresholds_service(self):
         self.mock_svc1.check_thresholds.return_value = {'foo': 'bar'}
         self.mock_svc2.check_thresholds.return_value = {'baz': 'blam'}
-        res = self.cls.check_thresholds(service='SvcFoo')
+        res = self.cls.check_thresholds(service=['SvcFoo'])
         assert res == {
             'SvcFoo': {
                 'foo': 'bar',
@@ -757,7 +757,7 @@ class TestAwsLimitChecker(object):
     def test_check_thresholds_service_api(self):
         self.mock_svc1.check_thresholds.return_value = {'foo': 'bar'}
         self.mock_svc2.check_thresholds.return_value = {'baz': 'blam'}
-        res = self.cls.check_thresholds(service='SvcBar')
+        res = self.cls.check_thresholds(service=['SvcBar'])
         assert res == {
             'SvcBar': {
                 'baz': 'blam',

--- a/awslimitchecker/tests/test_runner.py
+++ b/awslimitchecker/tests/test_runner.py
@@ -123,7 +123,7 @@ class TestAwsLimitCheckerRunner(object):
             self.cls.parse_args(argv)
         assert mock_parser.mock_calls == [
             call(description=desc, epilog=epilog),
-            call().add_argument('-S', '--service', action='store', default=None,
+            call().add_argument('-S', '--service', action='store', nargs='*',
                                 help='perform action for only the specified '
                                      'service name; see -s|--list-services for '
                                      'valid names'),
@@ -381,7 +381,7 @@ class TestAwsLimitCheckerRunner(object):
             'SvcFoo': sample_limits()['SvcFoo'],
         }
         self.cls.checker = mock_checker
-        self.cls.service_name = 'SvcFoo'
+        self.cls.service_name = ['SvcFoo']
         with patch('awslimitchecker.runner.dict2cols',
                    autospec=True) as mock_d2c:
             mock_d2c.return_value = 'd2cval'
@@ -389,7 +389,7 @@ class TestAwsLimitCheckerRunner(object):
         out, err = capsys.readouterr()
         assert out == 'd2cval\n'
         assert mock_checker.mock_calls == [
-            call.get_limits(service='SvcFoo')
+            call.get_limits(service=['SvcFoo'])
         ]
         assert mock_d2c.mock_calls == [
             call({
@@ -436,14 +436,14 @@ class TestAwsLimitCheckerRunner(object):
             'SvcFoo': sample_limits_api()['SvcFoo'],
         }
         self.cls.checker = mock_checker
-        self.cls.service_name = 'SvcFoo'
+        self.cls.service_name = ['SvcFoo']
         with patch('awslimitchecker.runner.dict2cols') as mock_d2c:
             mock_d2c.return_value = 'd2cval'
             self.cls.list_limits()
         out, err = capsys.readouterr()
         assert out == 'd2cval\n'
         assert mock_checker.mock_calls == [
-            call.get_limits(use_ta=True, service='SvcFoo')
+            call.get_limits(use_ta=True, service=['SvcFoo'])
         ]
         assert mock_d2c.mock_calls == [
             call({
@@ -558,7 +558,7 @@ class TestAwsLimitCheckerRunner(object):
         mock_checker = Mock(spec_set=AwsLimitChecker)
         mock_checker.get_limits.return_value = limits
         self.cls.checker = mock_checker
-        self.cls.service_name = 'SvcFoo'
+        self.cls.service_name = ['SvcFoo']
         self.cls.skip_ta = True
         with patch('awslimitchecker.runner.dict2cols') as mock_d2c:
             mock_d2c.return_value = 'd2cval'
@@ -566,8 +566,8 @@ class TestAwsLimitCheckerRunner(object):
         out, err = capsys.readouterr()
         assert out == 'd2cval\n'
         assert mock_checker.mock_calls == [
-            call.find_usage(service='SvcFoo', use_ta=False),
-            call.get_limits(service='SvcFoo', use_ta=False)
+            call.find_usage(service=['SvcFoo'], use_ta=False),
+            call.get_limits(service=['SvcFoo'], use_ta=False)
         ]
         assert mock_d2c.mock_calls == [
             call({
@@ -599,7 +599,7 @@ class TestAwsLimitCheckerRunner(object):
         out, err = capsys.readouterr()
         assert out == ''
         assert excinfo.value.code == 6
-        assert self.cls.service_name == 'foo'
+        assert self.cls.service_name == ['foo']
 
     def test_entry_no_service_name(self, capsys):
         argv = ['awslimitchecker']
@@ -1013,7 +1013,7 @@ class TestAwsLimitCheckerRunner(object):
         }
 
         self.cls.checker = mock_checker
-        self.cls.service_name = 'svc2'
+        self.cls.service_name = ['svc2']
         with patch('awslimitchecker.runner.Runner.print_issue',
                    autospec=True) as mock_print:
             mock_print.return_value = ('', '')
@@ -1021,7 +1021,7 @@ class TestAwsLimitCheckerRunner(object):
                 mock_d2c.return_value = 'd2cval'
                 res = self.cls.check_thresholds()
         assert mock_checker.mock_calls == [
-            call.check_thresholds(use_ta=True, service='svc2')
+            call.check_thresholds(use_ta=True, service=['svc2'])
         ]
         assert mock_print.mock_calls == [
             call(self.cls, 'svc2', mock_limit2, [], [mock_w3]),


### PR DESCRIPTION
Allows the `--service` argument to accept multiple values.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.
