### PR TITLE
fixes #236 - drop py32 support and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
       env: TOXENV=py26
     - python: "2.7"
       env: TOXENV=py27
-    - python: "3.2"
-      env: TOXENV=py32
     - python: "3.3"
       env: TOXENV=py33
     - python: "3.4"
@@ -24,7 +22,6 @@ matrix:
     - python: "3.6"
       env: TOXENV=integration3
 install:
-- virtualenv --version; test $TOXENV = "py32" -o $TOXENV = "pypy3" && pip install --upgrade virtualenv==13.1.2 || /bin/true
 - git config --global user.email "travisci@jasonantman.com"
 - git config --global user.name "travisci"
 - pip install tox

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ API changes will only come with a major version increment.
 
 This release **requires new IAM permissions**: ``redshift:DescribeClusterSnapshots`` and ``redshift:DescribeClusterSubnetGroups``.
 
+This release **removes Python 3.2 support**. This was deprecated in 0.7.0. As of this release,
+awslimitchecker may still work on Python 3.2, but it is no longer tested and any support tickets
+or bug reports specific to 3.2 will be closed.
+
 * `PR #250 <https://github.com/jantman/awslimitchecker/pull/250>`_ - Allow the
   ``--service`` command line option to accept multiple values. This is a
   **breaking public API change**; the ``awslimitchecker.checker.AwsLimitChecker``
@@ -30,6 +34,8 @@ This release **requires new IAM permissions**: ``redshift:DescribeClusterSnapsho
   * Switch integration3 tox env from py3.4 to py3.6
 
 * `PR #256 <https://github.com/jantman/awslimitchecker/pull/256>`_ - Add example of wrapping awslimitchecker in a script to send metrics to `Prometheus <https://prometheus.io/>`_.
+* `Issue #236 <https://github.com/jantman/awslimitchecker/issues/236>`_ Drop support for Python 3.2; stop testing under py32.
+
 
 0.7.0 (2017-01-15)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -102,10 +102,7 @@ What It Does
 Requirements
 ------------
 
-* Python 2.6, 2.7, 3.3+. It should work, but is no longer tested, with PyPy and
-  PyPy3. Python 3.2 support is deprecated as of 0.7.0 and
-  `will be removed <https://github.com/jantman/awslimitchecker/issues/236>`_
-  in the next release.
+* Python 2.6, 2.7, 3.3+.
 * Python `VirtualEnv <http://www.virtualenv.org/>`_ and ``pip`` (recommended installation method; your OS/distribution should have packages for these)
 * `boto3 <http://boto3.readthedocs.org/>`_ >= 1.2.3
 

--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -44,7 +44,6 @@ from .version import _get_version_info
 import boto3
 import sys
 import logging
-import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -139,13 +138,6 @@ class AwsLimitChecker(object):
                 self.vinfo.url
             )
         )
-        if sys.version_info[0:2] == (3, 2):
-            warnings.warn("Python 3.2 support will be removed in the "
-                          "next release; see https://github.com/jantman/"
-                          "awslimitchecker/issues/236", DeprecationWarning)
-            logger.warning("Python 3.2 support will be removed in the "
-                           "next release; see https://github.com/jantman/"
-                           "awslimitchecker/issues/236")
         self.warning_threshold = warning_threshold
         self.critical_threshold = critical_threshold
         self.profile_name = profile_name

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -38,7 +38,6 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 """
 
 import sys
-import warnings
 import argparse
 import logging
 import json
@@ -371,68 +370,26 @@ class Runner(object):
 
         if args.list_services:
             self.list_services()
-            if sys.version_info[0:2] == (3, 2):
-                warnings.warn("Python 3.2 support will be removed in the "
-                              "next release; see https://github.com/jantman/"
-                              "awslimitchecker/issues/236", DeprecationWarning)
-                logger.warning("Python 3.2 support will be removed in the "
-                               "next release; see https://github.com/jantman/"
-                               "awslimitchecker/issues/236")
             raise SystemExit(0)
 
         if args.list_defaults:
             self.list_defaults()
-            if sys.version_info[0:2] == (3, 2):
-                warnings.warn("Python 3.2 support will be removed in the "
-                              "next release; see https://github.com/jantman/"
-                              "awslimitchecker/issues/236", DeprecationWarning)
-                logger.warning("Python 3.2 support will be removed in the "
-                               "next release; see https://github.com/jantman/"
-                               "awslimitchecker/issues/236")
             raise SystemExit(0)
 
         if args.list_limits:
             self.list_limits()
-            if sys.version_info[0:2] == (3, 2):
-                warnings.warn("Python 3.2 support will be removed in the "
-                              "next release; see https://github.com/jantman/"
-                              "awslimitchecker/issues/236", DeprecationWarning)
-                logger.warning("Python 3.2 support will be removed in the "
-                               "next release; see https://github.com/jantman/"
-                               "awslimitchecker/issues/236")
             raise SystemExit(0)
 
         if args.iam_policy:
             self.iam_policy()
-            if sys.version_info[0:2] == (3, 2):
-                warnings.warn("Python 3.2 support will be removed in the "
-                              "next release; see https://github.com/jantman/"
-                              "awslimitchecker/issues/236", DeprecationWarning)
-                logger.warning("Python 3.2 support will be removed in the "
-                               "next release; see https://github.com/jantman/"
-                               "awslimitchecker/issues/236")
             raise SystemExit(0)
 
         if args.show_usage:
             self.show_usage()
-            if sys.version_info[0:2] == (3, 2):
-                warnings.warn("Python 3.2 support will be removed in the "
-                              "next release; see https://github.com/jantman/"
-                              "awslimitchecker/issues/236", DeprecationWarning)
-                logger.warning("Python 3.2 support will be removed in the "
-                               "next release; see https://github.com/jantman/"
-                               "awslimitchecker/issues/236")
             raise SystemExit(0)
 
         # else check
         res = self.check_thresholds()
-        if sys.version_info[0:2] == (3, 2):
-            warnings.warn("Python 3.2 support will be removed in the "
-                          "next release; see https://github.com/jantman/"
-                          "awslimitchecker/issues/236", DeprecationWarning)
-            logger.warning("Python 3.2 support will be removed in the "
-                           "next release; see https://github.com/jantman/"
-                           "awslimitchecker/issues/236")
         raise SystemExit(res)
 
 

--- a/awslimitchecker/tests/test_checker.py
+++ b/awslimitchecker/tests/test_checker.py
@@ -128,10 +128,9 @@ class TestAwsLimitChecker(object):
         assert self.cls.ta == self.mock_ta
         assert self.mock_version.mock_calls == [call()]
         assert self.cls.vinfo == self.mock_ver_info
-        if sys.version_info[0:2] != (3, 2):
-            assert self.mock_logger.mock_calls == [
-                call.debug('Connecting to region %s', None)
-            ]
+        assert self.mock_logger.mock_calls == [
+            call.debug('Connecting to region %s', None)
+        ]
 
     def test_init_AGPL_message(self, capsys):
         # get rid of the class

--- a/awslimitchecker/tests/test_version.py
+++ b/awslimitchecker/tests/test_version.py
@@ -39,10 +39,10 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 
 import awslimitchecker.version as version
 from awslimitchecker.version import AWSLimitCheckerVersion
+from versionfinder.versioninfo import VersionInfo
 
 import re
 import sys
-import pytest
 from logging import CRITICAL
 
 # https://code.google.com/p/mock/issues/detail?id=249
@@ -55,10 +55,6 @@ if (
 else:
     from unittest.mock import patch, call, Mock
 
-# GitPython doesn't work at all on py32
-if sys.version_info[0:2] != (3, 2):
-    from versionfinder.versioninfo import VersionInfo
-
 
 class TestVersion(object):
 
@@ -66,8 +62,6 @@ class TestVersion(object):
         expected = 'https://github.com/jantman/awslimitchecker'
         assert version._PROJECT_URL == expected
 
-    @pytest.mark.skipif(sys.version_info[0:2] == (3, 2),
-                        reason='versionfinder doesnt work on py32')
     def test__get_version_info(self):
         with patch('awslimitchecker.version.find_version') as mock_ver:
             mock_ver.return_value = VersionInfo(
@@ -81,8 +75,6 @@ class TestVersion(object):
         assert v.tag == 'foobar'
         assert mock_ver.mock_calls == [call('awslimitchecker')]
 
-    @pytest.mark.skipif(sys.version_info[0:2] == (3, 2),
-                        reason='versionfinder doesnt work on py32')
     def test__get_version_info_dirty_commit(self):
         with patch('awslimitchecker.version.find_version') as mock_ver:
             mock_ver.return_value = VersionInfo(
@@ -97,8 +89,6 @@ class TestVersion(object):
         assert v.commit == '1234567*'
         assert mock_ver.mock_calls == [call('awslimitchecker')]
 
-    @pytest.mark.skipif(sys.version_info[0:2] == (3, 2),
-                        reason='versionfinder doesnt work on py32')
     def test__get_version_info_long_commit(self):
         with patch('awslimitchecker.version.find_version') as mock_ver:
             mock_ver.return_value = VersionInfo(
@@ -112,8 +102,6 @@ class TestVersion(object):
         assert v.commit == '12345678'
         assert mock_ver.mock_calls == [call('awslimitchecker')]
 
-    @pytest.mark.skipif(sys.version_info[0:2] == (3, 2),
-                        reason='versionfinder doesnt work on py32')
     def test__get_version_info_fallback(self):
         def se(foo):
             raise Exception("foo")
@@ -132,18 +120,6 @@ class TestVersion(object):
                            ' may not be in compliance with the AGPLv3 license:')
         ]
 
-    @pytest.mark.skipif(sys.version_info[0:2] != (3, 2),
-                        reason='py32 versionfinder test')
-    def test__get_version_info_py32(self):
-        with patch('awslimitchecker.version.logger') as mock_logger:
-            version._get_version_info()
-        assert mock_logger.mock_calls == [
-            call.exception('Error checking installed version; this installation'
-                           ' may not be in compliance with the AGPLv3 license:')
-        ]
-
-    @pytest.mark.skipif(sys.version_info[0:2] == (3, 2),
-                        reason='versionfinder doesnt work on py32')
     def test__get_version_info_loggers(self):
         mock_loggers = {
             'versionfinder': Mock(),
@@ -176,8 +152,6 @@ class TestVersion(object):
             call.setLevel(CRITICAL)
         ]
 
-    @pytest.mark.skipif(sys.version_info[0:2] == (3, 2),
-                        reason='versionfinder doesnt work on py32')
     def test__get_version_info_loggers_enabled(self):
         mock_loggers = {
             'versionfinder': Mock(),

--- a/awslimitchecker/version.py
+++ b/awslimitchecker/version.py
@@ -38,17 +38,14 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 """
 
 import os
-import sys
 
 import logging
 logger = logging.getLogger(__name__)
 
-# GitPython doesn't work at all on py32; throws SyntaxErrors
-if sys.version_info[0:2] != (3, 2):
-    try:
-        from versionfinder import find_version
-    except ImportError:
-        logger.error("Unable to import versionfinder", exc_info=True)
+try:
+    from versionfinder import find_version
+except ImportError:
+    logger.error("Unable to import versionfinder", exc_info=True)
 
 _VERSION = '0.7.0'
 _PROJECT_URL = 'https://github.com/jantman/awslimitchecker'

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -57,10 +57,7 @@ Threshold
 Requirements
 ------------
 
-* Python 2.6, 2.7, 3.3+. It should work, but is no longer tested, with PyPy and
-  PyPy3. Python 3.2 support is deprecated as of 0.7.0 and
-  `will be removed <https://github.com/jantman/awslimitchecker/issues/236>`_
-  in the next release.
+* Python 2.6, 2.7, 3.3+.
 * Python `VirtualEnv <http://www.virtualenv.org/>`_ and ``pip`` (recommended installation method; your OS/distribution should have packages for these)
 * `boto3 <http://boto3.readthedocs.org/>`_ >= 1.2.3
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ classifiers = [
     'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.2',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,14 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,py35,py36,pypy,pypy3,docs,localdocs,integration,integration3
+envlist = py26,py27,py33,py34,py35,py36,pypy,pypy3,docs,localdocs,integration,integration3
 
 [testenv]
 deps =
   cov-core
-  # py3.2 needs coverage == 3.7.1
-  py26,py27,py33,py34,py35,py36,pypy,pypy3,integration,integration3: coverage
-  py32: coverage==3.7.1
+  coverage
   execnet
   pep8
   py
-  # py3.2 needs pytest < 3.0.0
-  py26,py27,py33,py34,py35,py36,pypy,pypy3,integration,integration3: pytest>=2.8.3
-  py32: pytest>=2.8.3,<3.0.0
+  pytest>=2.8.3
   pytest-cache
   pytest-cov
   pytest-pep8
@@ -21,9 +17,7 @@ deps =
   freezegun
   boto3
   pytest-blockage
-  # we need virtualenv==13.1.2 on py32
-  py26,py27,py33,py34,py35,py36,pypy,pypy3,integration,integration3: virtualenv
-  py32: virtualenv==13.1.2
+  virtualenv
   onetimepass==1.0.1
   testfixtures
 


### PR DESCRIPTION
This drops support and testing for py32, per #236