### PR TITLE
fixes #200 - remove EC2 Spot Instance support from experimental status

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ or bug reports specific to 3.2 will be closed.
 * `PR #256 <https://github.com/jantman/awslimitchecker/pull/256>`_ - Add example of wrapping awslimitchecker in a script to send metrics to `Prometheus <https://prometheus.io/>`_.
 * `Issue #236 <https://github.com/jantman/awslimitchecker/issues/236>`_ - Drop support for Python 3.2; stop testing under py32.
 * `Issue #257 <https://github.com/jantman/awslimitchecker/issues/257>`_ - Handle ElastiCache DescribeCacheCluster responses that are missing ``CacheNodes`` key in a cluster description.
+* `Issue #200 <https://github.com/jantman/awslimitchecker/issues/200>`_ - Remove EC2 Spot Instances/Fleets limits from experimental status.
 
 0.7.0 (2017-01-15)
 ------------------

--- a/awslimitchecker/tests/services/test_ec2.py
+++ b/awslimitchecker/tests/services/test_ec2.py
@@ -540,10 +540,6 @@ class Test_Ec2Service(object):
         assert usage[0].get_value() == 2
         assert mock_logger.mock_calls == [
             call.debug('Getting spot instance request usage'),
-            call.warning('EC2 spot instance support is experimental and '
-                         'results may not me accurate in all cases. Please '
-                         'see the notes at: <http://awslimitchecker'
-                         '.readthedocs.io/en/latest/limits.html#ec2>'),
             call.debug('NOT counting spot instance request %s state=%s',
                        'reqID1', 'closed'),
             call.debug('Counting spot instance request %s state=%s',
@@ -551,9 +547,7 @@ class Test_Ec2Service(object):
             call.debug('Counting spot instance request %s state=%s',
                        'reqID3', 'open'),
             call.debug('NOT counting spot instance request %s state=%s',
-                       'reqID4', 'failed'),
-            call.debug('Setting "Max spot instance requests per region" '
-                       'limit (%s) current usage to: %d', lim, 2)
+                       'reqID4', 'failed')
         ]
 
     def test_find_usage_spot_instances_unsupported(self):
@@ -636,14 +630,8 @@ class Test_Ec2Service(object):
             call.debug('Getting spot fleet request usage'),
             call.debug('Skipping spot fleet request %s in state %s', 'req1',
                        'failed'),
-            call.debug('Active fleet %s: target capacity=%s, %d launch specs',
-                       'req2', 11, 3),
             call.debug('Skipping spot fleet request %s in state %s',
-                       'req3', 'modifying'),
-            call.debug('Active fleet %s: target capacity=%s, %d launch specs',
-                       'req4', 33, 1),
-            call.debug('Total active spot fleets: %d; total target capacity '
-                       'for all spot fleets: %d', 2, 44)
+                       'req3', 'modifying')
         ]
 
     def test_find_usage_spot_fleets_paginated(self):
@@ -695,14 +683,8 @@ class Test_Ec2Service(object):
                        'configured in awslimitchecker.'),
             call.debug('Skipping spot fleet request %s in state %s', 'req1',
                        'failed'),
-            call.debug('Active fleet %s: target capacity=%s, %d launch specs',
-                       'req2', 11, 3),
             call.debug('Skipping spot fleet request %s in state %s',
-                       'req3', 'modifying'),
-            call.debug('Active fleet %s: target capacity=%s, %d launch specs',
-                       'req4', 33, 1),
-            call.debug('Total active spot fleets: %d; total target capacity '
-                       'for all spot fleets: %d', 2, 44)
+                       'req3', 'modifying')
         ]
 
     def test_find_usage_spot_fleets_unsupported(self):

--- a/docs/build_generated_docs.py
+++ b/docs/build_generated_docs.py
@@ -107,16 +107,6 @@ def build_limits(checker):
         limit_info += ('+' * (len(svc_name)+1)) + "\n"
         if svc_name == 'EC2':
             limit_info += "\n" + dedent("""
-            **Note on Spot Instances:** spot instance
-            support in awslimitchecker is experimental and not thoroughly used
-            outside of testing. Be advised that spot instances are _not_ counted
-            against the Running On-Demand Instances limits. Also be advised that
-            spot instance and fleet requests are only counted towards usage
-            if they are in the *active* state. If you find any problems with
-            spot instance or fleet usage or limits, please
-            `open an issue on GitHub <https://github.com/jantman/awslimitchecker
-            /issues/new>`_""") + "\n"
-            limit_info += "\n" + dedent("""
             **Note on On-Demand vs Reserved Instances:** The EC2 limits for
             "Running On-Demand" EC2 Instances apply only to On-Demand instances,
             not Reserved Instances. If you list all EC2 instances that are

--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -220,7 +220,7 @@ using their IDs).
    AutoScaling/Auto Scaling groups                        673
    AutoScaling/Launch configurations                      788
    CloudFormation/Stacks                                  1125
-   EBS/Active snapshots                                   18852
+   EBS/Active snapshots                                   18854
    EBS/Active volumes                                     1743
    (...)
    VPC/Rules per network ACL                              max: acl-bde47dd9=6 (acl-4bd96a2e=4, acl-8190 (...)

--- a/docs/source/limits.rst
+++ b/docs/source/limits.rst
@@ -287,17 +287,6 @@ EC2
 ++++
 
 
-**Note on Spot Instances:** spot instance
-support in awslimitchecker is experimental and not thoroughly used
-outside of testing. Be advised that spot instances are _not_ counted
-against the Running On-Demand Instances limits. Also be advised that
-spot instance and fleet requests are only counted towards usage
-if they are in the *active* state. If you find any problems with
-spot instance or fleet usage or limits, please
-`open an issue on GitHub <https://github.com/jantman/awslimitchecker
-/issues/new>`_
-
-
 **Note on On-Demand vs Reserved Instances:** The EC2 limits for
 "Running On-Demand" EC2 Instances apply only to On-Demand instances,
 not Reserved Instances. If you list all EC2 instances that are


### PR DESCRIPTION
Fixes #200 - EC2 Spot Instance support has been live for 4+ months. Removing from experimental status.