### PR TITLE
add new flag: --skip-service

### DIFF
--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -218,6 +218,19 @@ class AwsLimitChecker(object):
         """
         return self.vinfo.url
 
+    def remove_skipped_services(self, service_to_skip=None):
+        """
+        If ``service_to_skip`` is specified, the listed services
+        are removed from the services[] class list.
+
+        :param service_to_skip: the name(s) of one or more services to avoid
+          returning limits for
+        :type service_to_skip: list
+        """
+        if service_to_skip is not None:
+            for sname in service_to_skip:
+                del self.services[sname]
+
     def get_limits(self, service=None, use_ta=True):
         """
         Return all :py:class:`~.AwsLimit` objects for the given

--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -218,18 +218,17 @@ class AwsLimitChecker(object):
         """
         return self.vinfo.url
 
-    def remove_skipped_services(self, service_to_skip=None):
+    def remove_services(self, services_to_remove=[]):
         """
-        If ``service_to_skip`` is specified, the listed services
+        If ``services_to_remove`` is specified, the list of services
         are removed from the services[] class list.
 
-        :param service_to_skip: the name(s) of one or more services to avoid
-          returning limits for
+        :param services_to_remove: the name(s) of one or more services to
+          permanently exclude from future calls to this class
         :type service_to_skip: list
         """
-        if service_to_skip is not None:
-            for sname in service_to_skip:
-                del self.services[sname]
+        for sname in services_to_remove:
+            del self.services[sname]
 
     def get_limits(self, service=None, use_ta=True):
         """

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -102,6 +102,7 @@ class Runner(object):
                        help='perform action for only the specified service name'
                             '; see -s|--list-services for valid names')
         p.add_argument('--skip-service', action='store', nargs='*',
+                       default=[],
                        help='avoid performing actions for the specified service'
                             ' name; see -s|--list-services for valid names')
         p.add_argument('-s', '--list-services', action='store_true',

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -102,8 +102,8 @@ class Runner(object):
                        help='perform action for only the specified service name'
                             '; see -s|--list-services for valid names')
         p.add_argument('--skip-service', action='store', nargs='*',
-                       help='avoid performing actions for the specified service name'
-                            '; see -s|--list-services for valid names')
+                       help='avoid performing actions for the specified service '
+                            'name; see -s|--list-services for valid names')
         p.add_argument('-s', '--list-services', action='store_true',
                        default=False,
                        help='print a list of all AWS service types that '

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -364,7 +364,7 @@ class Runner(object):
         if args.skip_service is not None:
             if args.service is not None:
                 raise SystemExit(0)
-            self.checker.remove_skipped_services(args.skip_service)
+            self.checker.remove_services(args.skip_service)
 
         if args.version:
             print('awslimitchecker {v} (see <{s}> for source code)'.format(

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -102,8 +102,8 @@ class Runner(object):
                        help='perform action for only the specified service name'
                             '; see -s|--list-services for valid names')
         p.add_argument('--skip-service', action='store', nargs='*',
-                       help='avoid performing actions for the specified service '
-                            'name; see -s|--list-services for valid names')
+                       help='avoid performing actions for the specified service'
+                            ' name; see -s|--list-services for valid names')
         p.add_argument('-s', '--list-services', action='store_true',
                        default=False,
                        help='print a list of all AWS service types that '

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -101,6 +101,9 @@ class Runner(object):
         p.add_argument('-S', '--service', action='store', nargs='*',
                        help='perform action for only the specified service name'
                             '; see -s|--list-services for valid names')
+        p.add_argument('--skip-service', action='store', nargs='*',
+                       help='avoid performing actions for the specified service name'
+                            '; see -s|--list-services for valid names')
         p.add_argument('-s', '--list-services', action='store_true',
                        default=False,
                        help='print a list of all AWS service types that '
@@ -357,6 +360,11 @@ class Runner(object):
             ta_refresh_mode=args.ta_refresh_mode,
             ta_refresh_timeout=args.ta_refresh_timeout
         )
+
+        if args.skip_service is not None:
+            if args.service is not None:
+                raise SystemExit(0)
+            self.checker.remove_skipped_services(args.skip_service)
 
         if args.version:
             print('awslimitchecker {v} (see <{s}> for source code)'.format(

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -362,11 +362,6 @@ class Runner(object):
             ta_refresh_timeout=args.ta_refresh_timeout
         )
 
-        if args.skip_service is not None:
-            if args.service is not None:
-                raise SystemExit(0)
-            self.checker.remove_services(args.skip_service)
-
         if args.version:
             print('awslimitchecker {v} (see <{s}> for source code)'.format(
                 s=self.checker.get_project_url(),

--- a/awslimitchecker/tests/test_runner.py
+++ b/awslimitchecker/tests/test_runner.py
@@ -128,6 +128,7 @@ class TestAwsLimitCheckerRunner(object):
                                      'service name; see -s|--list-services for '
                                      'valid names'),
             call().add_argument('--skip-service', action='store', nargs='*',
+                                default=[],
                                 help='avoid performing actions for the '
                                      'specified service name; see '
                                      '-s|--list-services for valid names'),

--- a/awslimitchecker/tests/test_runner.py
+++ b/awslimitchecker/tests/test_runner.py
@@ -128,9 +128,9 @@ class TestAwsLimitCheckerRunner(object):
                                      'service name; see -s|--list-services for '
                                      'valid names'),
             call().add_argument('--skip-service', action='store', nargs='*',
-                                help='avoid performing actions for the specified '
-                                     'service name; see -s|--list-services for '
-                                     'valid names'),
+                                help='avoid performing actions for the '
+                                     'specified service name; see '
+                                     '-s|--list-services for valid names'),
             call().add_argument('-s', '--list-services',
                                 default=False, action='store_true',
                                 help='print a list of all AWS service types '


### PR DESCRIPTION
1) `tox -e docs` was producing non-useful diffs.
2) Please suggest a better test?
3) I'll be the first to admit, the method used to disable services is slightly unconventional, but I believe the approach employed results in the least number of changed lines of code.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.

Signed-off-by: tamsky