### PR TITLE
Fixes #294 - ignore failed/deleted NAT Gateways

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 Unreleased Changes
 ------------------
 
+* `Issue #294 <https://github.com/jantman/awslimitchecker/issues/294>`_ - Ignore NAT Gateways that are not in "available" or "pending" state.
 * Pin `tox <https://tox.readthedocs.io/>`_ version to 2.7.0 as workaround for parsing change.
 
 0.11.0 (2017-08-06)

--- a/awslimitchecker/services/vpc.py
+++ b/awslimitchecker/services/vpc.py
@@ -166,6 +166,12 @@ class _VpcService(_AwsService):
                                     alc_data_path=['NatGateways'],
                                     alc_marker_param='NextToken'
                                     )['NatGateways']:
+                if gw['State'] not in ['pending', 'available']:
+                    logger.debug(
+                        'Skipping NAT Gateway %s in state: %s',
+                        gw['NatGatewayId'], gw['State']
+                    )
+                    continue
                 if gw['SubnetId'] not in subnet_to_az:
                     logger.error('ERROR: NAT Gateway %s in SubnetId %s, but '
                                  'SubnetId not found in subnet_to_az; Gateway '

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -496,6 +496,27 @@ class VPC(object):
                 'CreateTime': datetime(1970, 1, 1),
                 'State': 'available',
             },
+            {
+                'VpcId': 'vpc-123',
+                'SubnetId': 'subnet2',
+                'NatGatewayId': 'nat-125',
+                'CreateTime': datetime(1970, 1, 1),
+                'State': 'deleted',
+            },
+            {
+                'VpcId': 'vpc-123',
+                'SubnetId': 'subnet3',
+                'NatGatewayId': 'nat-126',
+                'CreateTime': datetime(1970, 1, 1),
+                'State': 'pending',
+            },
+            {
+                'VpcId': 'vpc-123',
+                'SubnetId': 'subnet3',
+                'NatGatewayId': 'nat-127',
+                'CreateTime': datetime(1970, 1, 1),
+                'State': 'failed',
+            }
         ],
         'NextToken': None,
     }

--- a/awslimitchecker/tests/services/test_vpc.py
+++ b/awslimitchecker/tests/services/test_vpc.py
@@ -262,7 +262,7 @@ class Test_VpcService(object):
 
         assert len(cls.limits['NAT Gateways per AZ'].get_current_usage()) == 2
         az2 = cls.limits['NAT Gateways per AZ'].get_current_usage()[0]
-        assert az2.get_value() == 2
+        assert az2.get_value() == 3
         assert az2.resource_id == 'az2'
         az3 = cls.limits['NAT Gateways per AZ'].get_current_usage()[1]
         assert az3.get_value() == 1
@@ -275,6 +275,12 @@ class Test_VpcService(object):
                 'ERROR: NAT Gateway %s in SubnetId %s, but SubnetId not '
                 'found in subnet_to_az; Gateway cannot be counted!',
                 'nat-124', 'subnet4'
+            ),
+            call.debug(
+                'Skipping NAT Gateway %s in state: %s', 'nat-125', 'deleted'
+            ),
+            call.debug(
+                'Skipping NAT Gateway %s in state: %s', 'nat-127', 'failed'
             )
         ]
 

--- a/awslimitchecker/tests/services/test_vpc.py
+++ b/awslimitchecker/tests/services/test_vpc.py
@@ -255,10 +255,10 @@ class Test_VpcService(object):
         mock_conn = Mock()
         mock_conn.describe_nat_gateways.return_value = response
 
-        cls = _VpcService(21, 43)
-        cls.conn = mock_conn
-
-        cls._find_usage_nat_gateways(subnets)
+        with patch('%s.logger' % self.pbm) as mock_logger:
+            cls = _VpcService(21, 43)
+            cls.conn = mock_conn
+            cls._find_usage_nat_gateways(subnets)
 
         assert len(cls.limits['NAT Gateways per AZ'].get_current_usage()) == 2
         az2 = cls.limits['NAT Gateways per AZ'].get_current_usage()[0]
@@ -269,6 +269,13 @@ class Test_VpcService(object):
         assert az3.resource_id == 'az3'
         assert mock_conn.mock_calls == [
             call.describe_nat_gateways(),
+        ]
+        assert mock_logger.mock_calls == [
+            call.error(
+                'ERROR: NAT Gateway %s in SubnetId %s, but SubnetId not '
+                'found in subnet_to_az; Gateway cannot be counted!',
+                'nat-124', 'subnet4'
+            )
         ]
 
     def test_find_usage_nat_gateways_exception(self):


### PR DESCRIPTION
Fixes #294 - ignore [NAT Gateways](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_NatGateway.html) not in "available" or "pending" state (i.e. ignore ones that have a State of ``failed | deleting | deleted``).