### PR TITLE
Fixes #253 - latest version check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased Changes
 
 * `Issue #254 <https://github.com/jantman/awslimitchecker/issues/254>`_ - Officially adopt SemVer for this project, and document our :ref:`versioning policy <development.versioning_policy>`.
 * `Issue #294 <https://github.com/jantman/awslimitchecker/issues/294>`_ - Ignore NAT Gateways that are not in "available" or "pending" state.
+* `Issue #253 <https://github.com/jantman/awslimitchecker/issues/253>`_ - Check latest awslimitchecker version on PyPI at class instantiation; log warning if a newer version is available. Add Python API and CLI options to disable this.
 * Pin `tox <https://tox.readthedocs.io/>`_ version to 2.7.0 as workaround for parsing change.
 
 0.11.0 (2017-08-06)

--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -41,6 +41,7 @@ from .connectable import ConnectableCredentials
 from .services import _services
 from .trustedadvisor import TrustedAdvisor
 from .version import _get_version_info
+from .utils import _get_latest_version
 import boto3
 import sys
 import logging
@@ -53,7 +54,8 @@ class AwsLimitChecker(object):
     def __init__(self, warning_threshold=80, critical_threshold=99,
                  profile_name=None, account_id=None, account_role=None,
                  region=None, external_id=None, mfa_serial_number=None,
-                 mfa_token=None, ta_refresh_mode=None, ta_refresh_timeout=None):
+                 mfa_token=None, ta_refresh_mode=None, ta_refresh_timeout=None,
+                 check_version=True):
         """
         Main AwsLimitChecker class - this should be the only externally-used
         portion of awslimitchecker.
@@ -114,6 +116,9 @@ class AwsLimitChecker(object):
           parameter is not None, only wait up to this number of seconds for the
           refresh to finish before continuing on anyway.
         :type ta_refresh_timeout: :py:class:`int` or :py:data:`None`
+        :param check_version: Whether or not to check for latest version of
+          awslimitchecker on PyPI during instantiation.
+        :type check_version: bool
         """
         # ###### IMPORTANT license notice ##########
         # Pursuant to Sections 5(b) and 13 of the GNU Affero General Public
@@ -138,6 +143,14 @@ class AwsLimitChecker(object):
                 self.vinfo.url
             )
         )
+        if check_version:
+            latest_ver = _get_latest_version()
+            if latest_ver is not None:
+                logger.warning(
+                    'You are running awslimitchecker %s, but the latest version'
+                    ' is %s; please consider upgrading.', self.vinfo.release,
+                    latest_ver
+                )
         self.warning_threshold = warning_threshold
         self.critical_threshold = critical_threshold
         self.profile_name = profile_name

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -191,6 +191,9 @@ class Runner(object):
                             'anyway.')
         p.add_argument('--no-color', action='store_true', default=False,
                        help='do not colorize output')
+        p.add_argument('--no-check-version', action='store_false', default=True,
+                       dest='check_version',
+                       help='do not check latest version at startup')
         p.add_argument('-v', '--verbose', dest='verbose', action='count',
                        default=0,
                        help='verbose output. specify twice for debug-level '
@@ -359,7 +362,8 @@ class Runner(object):
             mfa_serial_number=args.mfa_serial_number,
             mfa_token=args.mfa_token,
             ta_refresh_mode=args.ta_refresh_mode,
-            ta_refresh_timeout=args.ta_refresh_timeout
+            ta_refresh_timeout=args.ta_refresh_timeout,
+            check_version=args.check_version
         )
 
         if args.version:

--- a/awslimitchecker/tests/test_checker.py
+++ b/awslimitchecker/tests/test_checker.py
@@ -81,7 +81,6 @@ class TestAwsLimitChecker(object):
             tag='mytag',
             version_str='1.2.3@mytag'
         )
-
         self.mock_svc1 = Mock(spec_set=_AwsService)
         self.mock_svc2 = Mock(spec_set=ApiServiceSpec)
         self.mock_foo = Mock(spec_set=_AwsService)
@@ -96,14 +95,17 @@ class TestAwsLimitChecker(object):
                     logger=DEFAULT,
                     _get_version_info=DEFAULT,
                     TrustedAdvisor=DEFAULT,
+                    _get_latest_version=DEFAULT,
                     autospec=True,
             ) as mocks:
                 self.mock_logger = mocks['logger']
                 self.mock_version = mocks['_get_version_info']
                 self.mock_ta_constr = mocks['TrustedAdvisor']
+                self.mock_glv = mocks['_get_latest_version']
                 mocks['TrustedAdvisor'].return_value = self.mock_ta
+                mocks['_get_latest_version'].return_value = None
                 self.mock_version.return_value = self.mock_ver_info
-                self.cls = AwsLimitChecker()
+                self.cls = AwsLimitChecker(check_version=False)
 
     def test_init(self):
         # dict should be of _AwsService instances
@@ -128,6 +130,7 @@ class TestAwsLimitChecker(object):
         assert self.cls.ta == self.mock_ta
         assert self.mock_version.mock_calls == [call()]
         assert self.cls.vinfo == self.mock_ver_info
+        assert self.mock_glv.mock_calls == []
         assert self.mock_logger.mock_calls == [
             call.debug('Connecting to region %s', None)
         ]
@@ -147,6 +150,44 @@ class TestAwsLimitChecker(object):
             "all users have a right to the full source code of "
             "this version. See <http://myurl>\n")
 
+    def test_check_version_old(self):
+        with patch.multiple(
+            'awslimitchecker.checker',
+            logger=DEFAULT,
+            _get_version_info=DEFAULT,
+            TrustedAdvisor=DEFAULT,
+            _get_latest_version=DEFAULT,
+            autospec=True,
+        ) as mocks:
+            mocks['_get_version_info'].return_value = self.mock_ver_info
+            mocks['_get_latest_version'].return_value = '3.4.5'
+            AwsLimitChecker()
+        assert mocks['_get_latest_version'].mock_calls == [call()]
+        assert mocks['logger'].mock_calls == [
+            call.warning(
+                'You are running awslimitchecker %s, but the latest version'
+                ' is %s; please consider upgrading.', '1.2.3', '3.4.5'
+            ),
+            call.debug('Connecting to region %s', None)
+        ]
+
+    def test_check_version_not_old(self):
+        with patch.multiple(
+            'awslimitchecker.checker',
+            logger=DEFAULT,
+            _get_version_info=DEFAULT,
+            TrustedAdvisor=DEFAULT,
+            _get_latest_version=DEFAULT,
+            autospec=True,
+        ) as mocks:
+            mocks['_get_version_info'].return_value = self.mock_ver_info
+            mocks['_get_latest_version'].return_value = None
+            AwsLimitChecker()
+        assert mocks['_get_latest_version'].mock_calls == [call()]
+        assert mocks['logger'].mock_calls == [
+            call.debug('Connecting to region %s', None)
+        ]
+
     def test_init_thresholds(self):
         mock_svc1 = Mock(spec_set=_AwsService)
         mock_svc2 = Mock(spec_set=_AwsService)
@@ -162,12 +203,14 @@ class TestAwsLimitChecker(object):
                     logger=DEFAULT,
                     _get_version_info=DEFAULT,
                     TrustedAdvisor=DEFAULT,
+                    _get_latest_version=DEFAULT,
                     autospec=True,
             ) as mocks:
                 mock_version = mocks['_get_version_info']
                 mock_version.return_value = self.mock_ver_info
                 mock_ta_constr = mocks['TrustedAdvisor']
                 mocks['TrustedAdvisor'].return_value = mock_ta
+                mocks['_get_latest_version'].return_value = None
                 cls = AwsLimitChecker(
                     warning_threshold=5,
                     critical_threshold=22,
@@ -210,12 +253,14 @@ class TestAwsLimitChecker(object):
                         logger=DEFAULT,
                         _get_version_info=DEFAULT,
                         TrustedAdvisor=DEFAULT,
+                        _get_latest_version=DEFAULT,
                         autospec=True,
                 ) as mocks:
                     mock_boto3.Session.return_value._session = Mock()
                     mock_version = mocks['_get_version_info']
                     mock_version.return_value = self.mock_ver_info
                     mocks['TrustedAdvisor'].return_value = mock_ta
+                    mocks['_get_latest_version'].return_value = None
                     cls = AwsLimitChecker(region='regionX', profile_name='foo')
         # dict should be of _AwsService instances
         services = {
@@ -246,11 +291,13 @@ class TestAwsLimitChecker(object):
                     logger=DEFAULT,
                     _get_version_info=DEFAULT,
                     TrustedAdvisor=DEFAULT,
+                    _get_latest_version=DEFAULT,
                     autospec=True,
                 ) as mocks:
                     mock_version = mocks['_get_version_info']
                     mock_version.return_value = self.mock_ver_info
                     mocks['TrustedAdvisor'].return_value = mock_ta
+                    mocks['_get_latest_version'].return_value = None
                     cls = AwsLimitChecker(
                         account_id='123456789012',
                         account_role='myrole',
@@ -283,11 +330,13 @@ class TestAwsLimitChecker(object):
                         logger=DEFAULT,
                         _get_version_info=DEFAULT,
                         TrustedAdvisor=DEFAULT,
+                        _get_latest_version=DEFAULT,
                         autospec=True,
                 ) as mocks:
                     mock_version = mocks['_get_version_info']
                     mock_version.return_value = self.mock_ver_info
                     mocks['TrustedAdvisor'].return_value = mock_ta
+                    mocks['_get_latest_version'].return_value = None
                     cls = AwsLimitChecker(
                         account_id='123456789012',
                         account_role='myrole',

--- a/awslimitchecker/tests/test_runner.py
+++ b/awslimitchecker/tests/test_runner.py
@@ -228,6 +228,9 @@ class TestAwsLimitCheckerRunner(object):
             call().add_argument('--no-color', action='store_true',
                                 default=False,
                                 help='do not colorize output'),
+            call().add_argument('--no-check-version', action='store_false',
+                                default=True, dest='check_version',
+                                help='do not check latest version at startup'),
             call().add_argument('-v', '--verbose', dest='verbose',
                                 action='count',
                                 default=0,
@@ -307,7 +310,8 @@ class TestAwsLimitCheckerRunner(object):
                 mfa_token=None,
                 profile_name=None,
                 ta_refresh_mode=None,
-                ta_refresh_timeout=None
+                ta_refresh_timeout=None,
+                check_version=True
             ),
             call().get_project_url(),
             call().get_version()
@@ -490,7 +494,8 @@ class TestAwsLimitCheckerRunner(object):
             call(account_id=None, account_role=None, critical_threshold=99,
                  external_id=None, mfa_serial_number=None, mfa_token=None,
                  profile_name=None, region=None, ta_refresh_mode=None,
-                 ta_refresh_timeout=None, warning_threshold=80)
+                 ta_refresh_timeout=None, warning_threshold=80,
+                 check_version=True)
         ]
 
     def test_entry_skip_service(self):
@@ -507,7 +512,8 @@ class TestAwsLimitCheckerRunner(object):
             call(account_id=None, account_role=None, critical_threshold=99,
                  external_id=None, mfa_serial_number=None, mfa_token=None,
                  profile_name=None, region=None, ta_refresh_mode=None,
-                 ta_refresh_timeout=None, warning_threshold=80),
+                 ta_refresh_timeout=None, warning_threshold=80,
+                 check_version=True),
             call().remove_services(['foo'])
         ]
 
@@ -529,7 +535,8 @@ class TestAwsLimitCheckerRunner(object):
             call(account_id=None, account_role=None, critical_threshold=99,
                  external_id=None, mfa_serial_number=None, mfa_token=None,
                  profile_name=None, region=None, ta_refresh_mode=None,
-                 ta_refresh_timeout=None, warning_threshold=80),
+                 ta_refresh_timeout=None, warning_threshold=80,
+                 check_version=True),
             call().remove_services(['foo', 'bar'])
         ]
 
@@ -720,7 +727,8 @@ class TestAwsLimitCheckerRunner(object):
                 mfa_token=None,
                 profile_name=None,
                 ta_refresh_mode=None,
-                ta_refresh_timeout=None
+                ta_refresh_timeout=None,
+                check_version=True
             )
         ]
         assert self.cls.service_name is None
@@ -758,7 +766,8 @@ class TestAwsLimitCheckerRunner(object):
                 mfa_token=None,
                 profile_name=None,
                 ta_refresh_mode=None,
-                ta_refresh_timeout=None
+                ta_refresh_timeout=None,
+                check_version=True
             )
         ]
         assert self.cls.service_name is None
@@ -773,7 +782,8 @@ class TestAwsLimitCheckerRunner(object):
             '-R',
             'myrole',
             '-E',
-            'myextid'
+            'myextid',
+            '--no-check-version'
         ]
         with patch.object(sys, 'argv', argv):
             with patch('%s.Runner.check_thresholds' % pb,
@@ -798,7 +808,8 @@ class TestAwsLimitCheckerRunner(object):
                 mfa_token=None,
                 profile_name=None,
                 ta_refresh_mode=None,
-                ta_refresh_timeout=None
+                ta_refresh_timeout=None,
+                check_version=False
             )
         ]
         assert self.cls.service_name is None
@@ -855,7 +866,8 @@ class TestAwsLimitCheckerRunner(object):
                 mfa_token=None,
                 profile_name=None,
                 ta_refresh_mode=None,
-                ta_refresh_timeout=None
+                ta_refresh_timeout=None,
+                check_version=True
             )
         ]
 
@@ -881,7 +893,8 @@ class TestAwsLimitCheckerRunner(object):
                 mfa_token=None,
                 profile_name='myprof',
                 ta_refresh_mode=None,
-                ta_refresh_timeout=None
+                ta_refresh_timeout=None,
+                check_version=True
             )
         ]
 
@@ -907,7 +920,8 @@ class TestAwsLimitCheckerRunner(object):
                 mfa_token=None,
                 profile_name=None,
                 ta_refresh_mode=None,
-                ta_refresh_timeout=None
+                ta_refresh_timeout=None,
+                check_version=True
             )
         ]
 
@@ -934,7 +948,8 @@ class TestAwsLimitCheckerRunner(object):
                 mfa_token=None,
                 profile_name=None,
                 ta_refresh_mode=456,
-                ta_refresh_timeout=123
+                ta_refresh_timeout=123,
+                check_version=True
             )
         ]
 

--- a/awslimitchecker/utils.py
+++ b/awslimitchecker/utils.py
@@ -221,6 +221,8 @@ def _get_latest_version():
     be retrieved or is not greater than the currently running version, return
     None.
 
+    This function MUST not ever raise an exception.
+
     :return: latest version from PyPI, if newer than current version
     :rtype: `str` or `None`
     """

--- a/awslimitchecker/version.py
+++ b/awslimitchecker/version.py
@@ -47,7 +47,8 @@ try:
 except ImportError:
     logger.error("Unable to import versionfinder", exc_info=True)
 
-_VERSION = '0.11.0'
+_VERSION_TUP = (0, 11, 0)
+_VERSION = '.'.join([str(x) for x in _VERSION_TUP])
 _PROJECT_URL = 'https://github.com/jantman/awslimitchecker'
 
 


### PR DESCRIPTION
Checks PyPI for latest version, logs a warning if a newer version is available. Has a 4-second timeout and can be disabled.