### PR TITLE
Update README to require boto3 >= 1.4.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ Requirements
 
 * Python 2.6, 2.7, 3.3+.
 * Python `VirtualEnv <http://www.virtualenv.org/>`_ and ``pip`` (recommended installation method; your OS/distribution should have packages for these)
-* `boto3 <http://boto3.readthedocs.org/>`_ >= 1.2.3
+* `boto3 <http://boto3.readthedocs.org/>`_ >= 1.4.4
 
 Installation and Usage
 -----------------------


### PR DESCRIPTION
[`describe_account_limits`](https://github.com/jantman/awslimitchecker/blob/master/awslimitchecker/services/elb.py#L253) for  `AWS::ElasticLoadBalancing::LoadBalancer` requires boto3 >= 1.4.4. It would be helpful to update the README accordingly. Thanks!