### PR TITLE
Issues/311 - 2.0.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-Unreleased Changes
+2.0.0 (2017-10-12)
 ------------------
 
 * Update README with correct boto version requirement. (Thanks to `nadlerjessie <https://github.com/nadlerjessie>`_ for the contribution.)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased Changes
+------------------
+
+* Update README with correct boto version requirement. (Thanks to `nadlerjessie <https://github.com/nadlerjessie>`_ for the contribution.)
+* Update minimum ``boto3`` version requirement from 1.2.3 to 1.4.4; the code for `Issue #268 <https://github.com/jantman/awslimitchecker/issues/268>`_ released in 0.11.0 requires boto3 >= 1.4.4 to make the ElasticLoadBalancing ``DescribeAccountLimits`` call.
+* **Bug fix for "Running On-Demand EC2 instances" limit** - `Issue #308 <https://github.com/jantman/awslimitchecker/issues/308>`_ - The fix for `Issue #215 <https://github.com/jantman/awslimitchecker/issues/215>`_ / `PR #223 <https://github.com/jantman/awslimitchecker/pull/223>`_, released in 0.6.0 on November 11, 2016 was based on `incorrect information <https://github.com/jantman/awslimitchecker/issues/215#issuecomment-259144130>`_ about how Regional Benefit Reserved Instances (RIs) impact the service limit. The code implemented at that time subtracted Regional Benefit RIs from the count of running instances that we use to establish usage. Upon further review, as well as confirmation from AWS Support, some AWS TAMs, and the `relevant AWS documentation <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-reserved-instances.html#ri-limits>`_, only Zonal RIs (AZ-specific) are exempt from the Running On-Demand Instances limit. Regional Benefit RIs are counted the same as any other On-Demand Instances, as they don't have reserved capacity. This release stops subtracting Regional Benefit RIs from the count of Running Instances, which was causing awslimitchecker to report inaccurately low Running Instances usage.
+
 1.0.0 (2017-09-21)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ Requirements
 
 * Python 2.6, 2.7, 3.3+.
 * Python `VirtualEnv <http://www.virtualenv.org/>`_ and ``pip`` (recommended installation method; your OS/distribution should have packages for these)
-* `boto3 <http://boto3.readthedocs.org/>`_ >= 1.2.3
+* `boto3 <http://boto3.readthedocs.org/>`_ >= 1.4.4
 
 Installation and Usage
 -----------------------

--- a/awslimitchecker/tests/services/test_ec2.py
+++ b/awslimitchecker/tests/services/test_ec2.py
@@ -322,7 +322,7 @@ class Test_Ec2Service(object):
                 mock_res_inst_count.return_value = ri_count
                 cls._find_usage_instances()
         assert mock_t2_micro.mock_calls == [call._add_current_usage(
-            35,
+            36,
             aws_type='AWS::EC2::Instance'
         )]
         assert mock_r3_2xlarge.mock_calls == [call._add_current_usage(
@@ -334,11 +334,11 @@ class Test_Ec2Service(object):
             aws_type='AWS::EC2::Instance'
         )]
         assert mock_c4_large.mock_calls == [call._add_current_usage(
-            0,
+            4,
             aws_type='AWS::EC2::Instance'
         )]
         assert mock_all_ec2.mock_calls == [call._add_current_usage(
-            48,
+            53,
             aws_type='AWS::EC2::Instance'
         )]
         assert mock_inst_usage.mock_calls == [call(cls)]

--- a/awslimitchecker/version.py
+++ b/awslimitchecker/version.py
@@ -47,7 +47,7 @@ try:
 except ImportError:
     logger.error("Unable to import versionfinder", exc_info=True)
 
-_VERSION_TUP = (1, 0, 0)
+_VERSION_TUP = (2, 0, 0)
 _VERSION = '.'.join([str(x) for x in _VERSION_TUP])
 _PROJECT_URL = 'https://github.com/jantman/awslimitchecker'
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -59,7 +59,7 @@ Requirements
 
 * Python 2.6, 2.7, 3.3+.
 * Python `VirtualEnv <http://www.virtualenv.org/>`_ and ``pip`` (recommended installation method; your OS/distribution should have packages for these)
-* `boto3 <http://boto3.readthedocs.org/>`_ >= 1.2.3
+* `boto3 <http://boto3.readthedocs.org/>`_ >= 1.4.4
 
 
 .. _getting_started.installing:

--- a/docs/source/limits.rst
+++ b/docs/source/limits.rst
@@ -60,7 +60,7 @@ updated from Trusted Advisor:
 
   * Running On-Demand c4.xlarge instances
 
-  * Running On-Demand m1.small instances
+  * Running On-Demand m1.medium instances
 
   * Running On-Demand m3.2xlarge instances
 
@@ -89,6 +89,8 @@ updated from Trusted Advisor:
   * Running On-Demand r4.large instances
 
   * Running On-Demand t1.micro instances
+
+  * Running On-Demand t2.2xlarge instances
 
   * Running On-Demand t2.large instances
 
@@ -412,8 +414,8 @@ Running On-Demand i3.8xlarge instances                         2
 Running On-Demand i3.large instances                           2   
 Running On-Demand i3.xlarge instances                          2   
 Running On-Demand m1.large instances                           20  
-Running On-Demand m1.medium instances                          20  
-Running On-Demand m1.small instances :sup:`(TA)`               20  
+Running On-Demand m1.medium instances :sup:`(TA)`              20  
+Running On-Demand m1.small instances                           20  
 Running On-Demand m1.xlarge instances                          20  
 Running On-Demand m2.2xlarge instances                         20  
 Running On-Demand m2.4xlarge instances                         20  
@@ -443,7 +445,7 @@ Running On-Demand r4.8xlarge instances                         20
 Running On-Demand r4.large instances :sup:`(TA)`               20  
 Running On-Demand r4.xlarge instances                          20  
 Running On-Demand t1.micro instances :sup:`(TA)`               20  
-Running On-Demand t2.2xlarge instances                         20  
+Running On-Demand t2.2xlarge instances :sup:`(TA)`             20  
 Running On-Demand t2.large instances :sup:`(TA)`               20  
 Running On-Demand t2.medium instances :sup:`(TA)`              20  
 Running On-Demand t2.micro instances :sup:`(TA)`               20  

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ with open('README.rst') as file:
     long_description = file.read()
 
 requires = [
-    'boto3>=1.2.3',
+    'boto3>=1.4.4',
     'termcolor>=1.1.0',
     'python-dateutil>=2.4.2',
     'versionfinder>=0.1.1',


### PR DESCRIPTION
2.0.0 release.

There aren't many changes, but per our versioning policy, bumping the boto3 requirement from 1.2.3 to 1.4.4 requires a major version bump.