### PR TITLE
fixes #337 - handle Trusted Advisor broken checks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+4.0.1 (2018-03-09)
+------------------
+
+This is a minor bugfix release for a few issues that users have reported recently.
+
+* Fix `Issue #337 <https://github.com/jantman/awslimitchecker/issues/337>`_ where sometimes an account even with Business-level support will not have a Trusted Advisor result for the Service Limits check, and will return a result with ``status: not_available`` or a missing ``flaggedResources`` key.
+
 4.0.0 (2018-02-17)
 ------------------
 

--- a/awslimitchecker/tests/test_trustedadvisor.py
+++ b/awslimitchecker/tests/test_trustedadvisor.py
@@ -692,6 +692,66 @@ class TestPoll(object):
         ]
         assert res == {}
 
+    def test_not_available(self):
+        poll_return_val = {
+            'result': {
+                'checkId': 'xxxxxxx',
+                'status': 'not_available'
+            }
+        }
+        with patch('%s._get_limit_check_id' % pb, autospec=True) as mock_id:
+            with patch('%s._get_refreshed_check_result' % pb,
+                       autospec=True) as mock_hr:
+                mock_hr.return_value = poll_return_val
+                mock_id.return_value = (
+                    'foo',
+                    [
+                        'Region',
+                        'Service',
+                        'Limit Name',
+                        'Limit Amount',
+                        'Current Usage',
+                        'Status'
+                    ]
+                )
+                res = self.cls._poll()
+        assert self.mock_conn.mock_calls == []
+        assert mock_id.mock_calls == [call(self.cls)]
+        assert mock_hr.mock_calls == [
+            call(self.cls, 'foo')
+        ]
+        assert res == {}
+
+    def test_no_flagged_resources(self):
+        poll_return_val = {
+            'result': {
+                'checkId': 'xxxxxxx',
+                'timestamp': '2015-06-15T20:27:42Z'
+            }
+        }
+        with patch('%s._get_limit_check_id' % pb, autospec=True) as mock_id:
+            with patch('%s._get_refreshed_check_result' % pb,
+                       autospec=True) as mock_hr:
+                mock_hr.return_value = poll_return_val
+                mock_id.return_value = (
+                    'foo',
+                    [
+                        'Region',
+                        'Service',
+                        'Limit Name',
+                        'Limit Amount',
+                        'Current Usage',
+                        'Status'
+                    ]
+                )
+                res = self.cls._poll()
+        assert self.mock_conn.mock_calls == []
+        assert mock_id.mock_calls == [call(self.cls)]
+        assert mock_hr.mock_calls == [
+            call(self.cls, 'foo')
+        ]
+        assert res == {}
+
 
 class TestGetRefreshedCheckResult(object):
 

--- a/awslimitchecker/trustedadvisor.py
+++ b/awslimitchecker/trustedadvisor.py
@@ -172,6 +172,18 @@ class TrustedAdvisor(Connectable):
         checks = self._get_refreshed_check_result(check_id)
         region = self.ta_region or self.conn._client_config.region_name
         res = {}
+        if checks['result'].get('status', '') == 'not_available':
+            logger.warning(
+                'Trusted Advisor returned status "not_available" for '
+                'service limit check; cannot retrieve limits from TA.'
+            )
+            return {}
+        if 'flaggedResources' not in checks['result']:
+            logger.warning(
+                'Trusted Advisor returned no results for '
+                'service limit check; cannot retrieve limits from TA.'
+            )
+            return {}
         for check in checks['result']['flaggedResources']:
             if 'region' in check and check['region'] != region:
                 continue


### PR DESCRIPTION
handle checks with status not_available or missing flaggedResources key