### PR TITLE
Add required S3 permissions for Elastic Beanstalk

### DIFF
--- a/awslimitchecker/services/elasticbeanstalk.py
+++ b/awslimitchecker/services/elasticbeanstalk.py
@@ -142,4 +142,6 @@ class _ElasticBeanstalkService(_AwsService):
             "elasticbeanstalk:DescribeApplications",
             "elasticbeanstalk:DescribeApplicationVersions",
             "elasticbeanstalk:DescribeEnvironments",
+            "s3:GetBucketLocation",
+            "s3:ListBucket",
         ]


### PR DESCRIPTION
Add required S3 permissions for Elastic Beanstalk. Permission requirements identified by analyzing CloudTrail logs. `s3:ListBucket` and `s3:GetBucketLocation` are both called on the `elasticbeanstalk-REGION-ACCOUNT_NUMBER` bucket during the Elastic Beanstalk limit checks. The actions are not called directly by awslimitchecker, but by Elastic Beanstalk due to a call awslimitchecker makes to Elastic Beanstalk.

```
"sourceIPAddress": "elasticbeanstalk.amazonaws.com",
"userAgent": "elasticbeanstalk.amazonaws.com",
```

Fixes https://github.com/jantman/awslimitchecker/issues/346.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.
