### PR TITLE
Fixes #346 - add documentation on side-effect API calls made by AWS services

### DIFF
--- a/docs/build_generated_docs.py
+++ b/docs/build_generated_docs.py
@@ -78,7 +78,13 @@ def build_iam_policy(checker):
     ========================
 
     Below is the sample IAM policy from this version of awslimitchecker, listing the IAM
-    permissions required for it to function correctly:
+    permissions required for it to function correctly. Please note that in some cases
+    awslimitchecker may cause AWS services to make additional API calls on your behalf
+    (such as when enumerating ElasticBeanstalk resources, the ElasticBeanstalk service
+    itself will make ``s3:ListBucket`` and ``s3:GetBucketLocation`` calls). The policy
+    below includes only the bare minimum permissions for awslimitchecker to function
+    properly, and does not include permissions for any side-effect calls made by AWS
+    services that do not affect the results of this program.
 
     .. code-block:: json
 


### PR DESCRIPTION
Fixes #346 - add documentation on side-effect API calls made by AWS services