### PR TITLE
Issues/365 - API Gateway limit updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,10 +8,13 @@ This release **requires new IAM permissions**:
 
 * ``lambda:GetAccountSettings``
 
+**Important:** This release removes the ApiGateway ``APIs per account`` limit in favor of more-specific limits; see below.
+
 * `Issue #363 <https://github.com/jantman/awslimitchecker/issues/363>`_ - Add support for the Lambda limits and usages.
 * Clarify support for "unlimited" limits (limits where :py:meth:`awslimitchecker.limit.AwsLimit.get_limit` returns ``None``).
 * Add support for 26 new EC2 instance types.
 * Update default limits for ECS service.
+* ``ApiGateway`` service now has three ReST API limits (``Regional API keys per account``, ``Private API keys per account``, and ``Edge API keys per account``) in place of the previous single ``APIs per account`` to reflect the current documented service limits.
 
 Important Note on Limit Values
 ++++++++++++++++++++++++++++++

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ This release **requires new IAM permissions**:
 * Add support for 26 new EC2 instance types.
 * Update default limits for ECS service.
 * ``ApiGateway`` service now has three ReST API limits (``Regional API keys per account``, ``Private API keys per account``, and ``Edge API keys per account``) in place of the previous single ``APIs per account`` to reflect the current documented service limits.
+* API Gateway service - add support for ``VPC Links per account`` limit.
 
 Important Note on Limit Values
 ++++++++++++++++++++++++++++++

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -3229,6 +3229,35 @@ class ApiGateway(object):
         }
     ]
 
+    vpc_links = [
+        {
+            'items': [
+                {
+                    'id': 'vpcl-1',
+                    'name': 'link1',
+                    'description': 'desc1',
+                    'status': 'AVAILABLE'
+                }
+            ]
+        },
+        {
+            'items': [
+                {
+                    'id': 'vpcl-2',
+                    'name': 'link2',
+                    'description': 'desc2',
+                    'status': 'AVAILABLE'
+                },
+                {
+                    'id': 'vpcl-3',
+                    'name': 'link3',
+                    'description': 'desc3',
+                    'status': 'PENDING'
+                }
+            ]
+        }
+    ]
+
     api_keys = [
         {
             'warnings': [

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -2450,7 +2450,10 @@ class ApiGateway(object):
                     ],
                     'binaryMediaTypes': [
                         'string',
-                    ]
+                    ],
+                    'endpointConfiguration': {
+                        'types': ['PRIVATE']
+                    }
                 },
                 {
                     'id': 'api2',
@@ -2459,7 +2462,10 @@ class ApiGateway(object):
                     'createdDate': datetime(2016, 1, 1),
                     'version': 'api2ver',
                     'warnings': [],
-                    'binaryMediaTypes': []
+                    'binaryMediaTypes': [],
+                    'endpointConfiguration': {
+                        'types': ['REGIONAL']
+                    }
                 }
             ],
             'NextToken': 'string'
@@ -2477,8 +2483,43 @@ class ApiGateway(object):
                     ],
                     'binaryMediaTypes': [
                         'string',
-                    ]
+                    ],
+                    'endpointConfiguration': {
+                        'types': ['REGIONAL']
+                    }
                 },
+                {
+                    'id': 'api4',
+                    'name': 'api4name',
+                    'description': 'api4desc',
+                    'createdDate': datetime(2017, 1, 2),
+                    'version': 'api4ver',
+                    'warnings': [
+                        'string',
+                    ],
+                    'binaryMediaTypes': [
+                        'string',
+                    ],
+                    'endpointConfiguration': {
+                        'types': ['EDGE']
+                    }
+                },
+                {
+                    'id': 'api5',
+                    'name': 'api5name',
+                    'description': 'api5desc',
+                    'createdDate': datetime(2017, 1, 2),
+                    'version': 'api5ver',
+                    'warnings': [
+                        'string',
+                    ],
+                    'binaryMediaTypes': [
+                        'string',
+                    ],
+                    'endpointConfiguration': {
+                        'types': ['EDGE']
+                    }
+                }
             ]
         }
     ]
@@ -2829,10 +2870,16 @@ class ApiGateway(object):
 
     resources_api3 = [{'items': []}]
 
+    resources_api4 = [{'items': []}]
+
+    resources_api5 = [{'items': []}]
+
     get_resources = {
         'api1': resources_api1,
         'api2': resources_api2,
-        'api3': resources_api3
+        'api3': resources_api3,
+        'api4': resources_api4,
+        'api5': resources_api5
     }
 
     doc_parts = {
@@ -2918,7 +2965,33 @@ class ApiGateway(object):
                 },
                 'properties': 'string'
             }
-        ]
+        ],
+        'api4': [
+            {
+                'id': 'string',
+                'location': {
+                    'type': 'API',
+                    'path': 'string',
+                    'method': 'string',
+                    'statusCode': 'string',
+                    'name': 'string'
+                },
+                'properties': 'string'
+            }
+        ],
+        'api5': [
+            {
+                'id': 'string',
+                'location': {
+                    'type': 'API',
+                    'path': 'string',
+                    'method': 'string',
+                    'statusCode': 'string',
+                    'name': 'string'
+                },
+                'properties': 'string'
+            }
+        ],
     }
 
     stages = {
@@ -2968,6 +3041,16 @@ class ApiGateway(object):
             'item': [
                 {'deploymentId': 'blam'},
                 {'deploymentId': 'blarg'}
+            ]
+        },
+        'api4': {
+            'item': [
+                {'deploymentId': 'baz'}
+            ]
+        },
+        'api5': {
+            'item': [
+                {'deploymentId': 'baz'}
             ]
         }
     }
@@ -3019,7 +3102,9 @@ class ApiGateway(object):
                 'authorizerResultTtlInSeconds': 123
             }
         ],
-        'api3': []
+        'api3': [],
+        'api4': [],
+        'api5': []
     }
 
     plans = [

--- a/docs/source/limits.rst
+++ b/docs/source/limits.rst
@@ -36,13 +36,16 @@ ApiGateway
 Limit                           Trusted Advisor API     Default
 =============================== =============== ======= ====
 API keys per account                                    500 
-APIs per account                                        60  
 Client certificates per account                         60  
 Custom authorizers per API                              10  
 Documentation parts per API                             2000
+Edge APIs per account                                   120 
+Private APIs per account                                600 
+Regional APIs per account                               600 
 Resources per API                                       300 
 Stages per API                                          10  
 Usage plans per account                                 300 
+VPC Links per account                                   5   
 =============================== =============== ======= ====
 
 .. _limits.AutoScaling:


### PR DESCRIPTION
This PR fixes the API Gateway limits:

* ``ApiGateway`` service now has three ReST API limits (``Regional API keys per account``, ``Private API keys per account``, and ``Edge API keys per account``) in place of the previous single ``APIs per account`` to reflect the current documented service limits.
* API Gateway service - add support for ``VPC Links per account`` limit.