### PR TITLE
Issues/334 - ALB and NLB limits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,10 @@ This release **requires new IAM permissions**:
 * ``ApiGateway`` service now has three ReST API limits (``Regional API keys per account``, ``Private API keys per account``, and ``Edge API keys per account``) in place of the previous single ``APIs per account`` to reflect the current documented service limits.
 * API Gateway service - add support for ``VPC Links per account`` limit.
 * Add support for Network Load Balancer limits ``Network load balancers`` and ``Listeners per network load balancer``.
+* Add support for Application Load Balancer limits ``Certificates per application load balancer``.
 * Add support for Classic ELB (ELBv1) ``Registered instances per load balancer`` limit.
+
+* Note that I've left out the ``Targets per application load balancer`` and ``Targets per network load balancer`` limits. Checking usage for these requires iterating over ``DescribeTargetHealth`` for each target group, so I've opted to leave it out at this time for performance reasons and because I'd guess that the number of people with 500 or 1000 targets per LB is rather small. Please open an issue if you'd like to see usage calculation for these limits.
 
 Important Note on Limit Values
 ++++++++++++++++++++++++++++++

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ This release **requires new IAM permissions**:
 * ``ApiGateway`` service now has three ReST API limits (``Regional API keys per account``, ``Private API keys per account``, and ``Edge API keys per account``) in place of the previous single ``APIs per account`` to reflect the current documented service limits.
 * API Gateway service - add support for ``VPC Links per account`` limit.
 * Add support for Network Load Balancer limits ``Network load balancers`` and ``Listeners per network load balancer``.
+* Add support for Classic ELB (ELBv1) ``Registered instances per load balancer`` limit.
 
 Important Note on Limit Values
 ++++++++++++++++++++++++++++++

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-5.2.0 (2018-10-04)
+Unreleased Changes
 ------------------
 
 This release **requires new IAM permissions**:
@@ -16,6 +16,7 @@ This release **requires new IAM permissions**:
 * Update default limits for ECS service.
 * ``ApiGateway`` service now has three ReST API limits (``Regional API keys per account``, ``Private API keys per account``, and ``Edge API keys per account``) in place of the previous single ``APIs per account`` to reflect the current documented service limits.
 * API Gateway service - add support for ``VPC Links per account`` limit.
+* Add support for Network Load Balancer limits ``Network load balancers`` and ``Listeners per network load balancer``.
 
 Important Note on Limit Values
 ++++++++++++++++++++++++++++++

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -1195,6 +1195,7 @@ class ELB(object):
                     'ListenerDescriptions': [
                         {'foo': 'bar'},
                     ],
+                    'Instances': []
                 },
                 {
                     'LoadBalancerName': 'elb-2',
@@ -1202,6 +1203,12 @@ class ELB(object):
                         {'foo': 'bar'},
                         {'foo': 'bar'},
                     ],
+                    'Instances': [
+                        {'InstanceId': 'i-1'},
+                        {'InstanceId': 'i-2'},
+                        {'InstanceId': 'i-3'},
+                        {'InstanceId': 'i-4'},
+                    ]
                 },
                 {
                     'LoadBalancerName': 'elb-3',
@@ -1210,6 +1217,7 @@ class ELB(object):
                         {'foo': 'bar'},
                         {'foo': 'bar'},
                     ],
+                    'Instances': [{'InstanceId': 'i-5'}]
                 },
                 {
                     'LoadBalancerName': 'elb-4',
@@ -1221,7 +1229,11 @@ class ELB(object):
                         {'foo': 'bar'},
                         {'foo': 'bar'},
                     ],
-                },
+                    'Instances': [
+                        {'InstanceId': 'i-6'},
+                        {'InstanceId': 'i-7'}
+                    ]
+                }
             ],
         }
 
@@ -1241,7 +1253,8 @@ class ELB(object):
             {'Max': '3', 'Name': 'classic-load-balancers'},
             {'Max': '5', 'Name': 'classic-listeners'},
             {'Name': 'invalid', 'Max': '99'},  # test invalid name
-            {'Name': 'classic-listeners'}  # test no Max
+            {'Name': 'classic-listeners'},  # test no Max
+            {'Name': 'classic-registered-instances', 'Max': '1800'}
         ]
     }
 

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -1280,7 +1280,7 @@ class ELB(object):
             {'Name': 'target-groups'},  # test no Max
             {'Name': 'listeners-per-network-load-balancer', 'Max': '100'},
             {'Name': 'network-load-balancers', 'Max': '40'},
-            {'Name': 'targets-per-network-load-balancer', 'Max': '2'}
+            {'Name': 'targets-per-network-load-balancer', 'Max': '2'},
         ]
     }
 
@@ -1323,9 +1323,44 @@ class ELB(object):
 
     test_usage_alb_listeners = {
         'Listeners': [
-            {'ListenerArn': 'listener1'},
-            {'ListenerArn': 'listener2'},
-            {'ListenerArn': 'listener3'},
+            {
+                'ListenerArn': 'listener1',
+                'Certificates': []
+            },
+            {
+                'ListenerArn': 'listener2',
+                'Certificates': [
+                    {
+                        'CertificateArn': 'cert1',
+                        'IsDefault': True
+                    },
+                    {
+                        'CertificateArn': 'cert2',
+                        'IsDefault': False
+                    },
+                    {
+                        'CertificateArn': 'cert3',
+                        'IsDefault': True
+                    }
+                ]
+            },
+            {
+                'ListenerArn': 'listener3',
+                'Certificates': [
+                    {
+                        'CertificateArn': 'cert4',
+                        'IsDefault': False
+                    },
+                    {
+                        'CertificateArn': 'cert5',
+                        'IsDefault': False
+                    },
+                    {
+                        'CertificateArn': 'cert6',
+                        'IsDefault': True
+                    }
+                ]
+            },
         ]
     }
 

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -1264,7 +1264,10 @@ class ELB(object):
             {'Max': '9', 'Name': 'listeners-per-application-load-balancer'},
             {'Max': '10', 'Name': 'rules-per-application-load-balancer'},
             {'Name': 'invalid', 'Max': '99'},  # test invalid name
-            {'Name': 'target-groups'}  # test no Max
+            {'Name': 'target-groups'},  # test no Max
+            {'Name': 'listeners-per-network-load-balancer', 'Max': '100'},
+            {'Name': 'network-load-balancers', 'Max': '40'},
+            {'Name': 'targets-per-network-load-balancer', 'Max': '2'}
         ]
     }
 
@@ -1272,11 +1275,18 @@ class ELB(object):
         'LoadBalancers': [
             {
                 'LoadBalancerName': 'lb1',
-                'LoadBalancerArn': 'lb-arn1'
+                'LoadBalancerArn': 'lb-arn1',
+                'Type': 'application'
+            },
+            {
+                'LoadBalancerName': 'lb3',
+                'LoadBalancerArn': 'lb-arn3',
+                'Type': 'network'
             },
             {
                 'LoadBalancerName': 'lb2',
-                'LoadBalancerArn': 'lb-arn2'
+                'LoadBalancerArn': 'lb-arn2',
+                'Type': 'application'
             }
         ]
     }
@@ -1298,7 +1308,7 @@ class ELB(object):
         ]
     }
 
-    test_usage_elbv2_listeners = {
+    test_usage_alb_listeners = {
         'Listeners': [
             {'ListenerArn': 'listener1'},
             {'ListenerArn': 'listener2'},
@@ -1306,7 +1316,14 @@ class ELB(object):
         ]
     }
 
-    test_usage_elbv2_rules = [
+    test_usage_nlb_listeners = {
+        'Listeners': [
+            {'ListenerArn': 'listenern1'},
+            {'ListenerArn': 'listenern2'}
+        ]
+    }
+
+    test_usage_alb_rules = [
         {
             'Rules': [
                 {'RuleArn': 'listener1rule1'},

--- a/awslimitchecker/tests/services/test_elb.py
+++ b/awslimitchecker/tests/services/test_elb.py
@@ -72,6 +72,7 @@ class Test_ElbService(object):
         res = cls.get_limits()
         assert sorted(res.keys()) == sorted([
             'Active load balancers',
+            'Certificates per application load balancer',
             'Listeners per application load balancer',
             'Listeners per load balancer',
             'Listeners per network load balancer',
@@ -304,6 +305,13 @@ class Test_ElbService(object):
         assert r[0].get_value() == 7
         assert r[0].aws_type == 'AWS::ElasticLoadBalancingV2::LoadBalancer'
         assert r[0].resource_id == 'albname'
+        certs = cls.limits[
+            'Certificates per application load balancer'
+        ].get_current_usage()
+        assert len(certs) == 1
+        assert certs[0].get_value() == 3
+        assert certs[0].aws_type == 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+        assert certs[0].resource_id == 'albname'
 
     def test_update_usage_for_nlb(self):
         conn = Mock()

--- a/awslimitchecker/tests/services/test_elb.py
+++ b/awslimitchecker/tests/services/test_elb.py
@@ -76,6 +76,7 @@ class Test_ElbService(object):
             'Listeners per load balancer',
             'Listeners per network load balancer',
             'Network load balancers',
+            'Registered instances per load balancer',
             'Rules per application load balancer',
             'Target groups'
         ])
@@ -119,6 +120,8 @@ class Test_ElbService(object):
         ]
         assert cls.limits['Active load balancers'].api_limit == 3
         assert cls.limits['Listeners per load balancer'].api_limit == 5
+        assert cls.limits[
+            'Registered instances per load balancer'].api_limit == 1800
         assert cls.limits['Target groups'].api_limit == 7
         assert cls.limits[
             'Listeners per application load balancer'].api_limit == 9
@@ -164,8 +167,8 @@ class Test_ElbService(object):
                 alc_marker_param='Marker'
             )
         ]
-        entries = sorted(cls.limits['Listeners per load balancer'
-                                    ''].get_current_usage())
+        entries = sorted(cls.limits[
+            'Listeners per load balancer'].get_current_usage())
         assert len(entries) == 4
         assert entries[0].resource_id == 'elb-1'
         assert entries[0].get_value() == 1
@@ -175,6 +178,17 @@ class Test_ElbService(object):
         assert entries[2].get_value() == 3
         assert entries[3].resource_id == 'elb-4'
         assert entries[3].get_value() == 6
+        entries = sorted(cls.limits[
+            'Registered instances per load balancer'].get_current_usage())
+        assert len(entries) == 4
+        assert entries[0].resource_id == 'elb-1'
+        assert entries[0].get_value() == 0
+        assert entries[1].resource_id == 'elb-3'
+        assert entries[1].get_value() == 1
+        assert entries[2].resource_id == 'elb-4'
+        assert entries[2].get_value() == 2
+        assert entries[3].resource_id == 'elb-2'
+        assert entries[3].get_value() == 4
 
     def test_find_usage_elbv2(self):
         lbs_res = result_fixtures.ELB.test_find_usage_elbv2_elbs


### PR DESCRIPTION
This adds support for the NLB limits and some missing ALB and Classic ELB limits, specifically:

* Add support for Network Load Balancer limits ``Network load balancers`` and ``Listeners per network load balancer``.
* Add support for Application Load Balancer limits ``Certificates per application load balancer``.
* Add support for Classic ELB (ELBv1) ``Registered instances per load balancer`` limit

There were some limits mentioned in #334 by @vhartikainen that are available in the DescribeAccountLimits API call that I've left out, specifically Targets per ALB, Targets per NLB, and Targets per Target Group. These limits default to 1000, 500, and 1000, respectively. Because of how the API works calculating usage for these limits would require a ``DescribeTargetHealth`` call for every Target Group in the region. My guess is that the number of users who are approaching 500-1000 targets in a single Target Group is much smaller than the number of users with many target groups with fewer targets, so in the interest of performance, I'm going to leave those limits out for now.

If anyone needs usage calculations for Targets Per (Target Group|ALB|NLB), please open an issue or a PR.