### PR TITLE
Add Network interfaces per Region limit

### DIFF
--- a/awslimitchecker/services/vpc.py
+++ b/awslimitchecker/services/vpc.py
@@ -48,6 +48,8 @@ from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_ENI_LIMIT = 350
+
 
 class _VpcService(_AwsService):
 
@@ -326,13 +328,37 @@ class _VpcService(_AwsService):
         limits['Network interfaces per Region'] = AwsLimit(
             'Network interfaces per Region',
             self,
-            350,
+            DEFAULT_ENI_LIMIT,
             self.warning_threshold,
             self.critical_threshold,
             limit_type='AWS::EC2::NetworkInterface'
         )
         self.limits = limits
         return limits
+
+    def _update_limits_from_api(self):
+        """
+        Query EC2's DescribeAccountAttributes API action and
+        update the network interface limit, as needed. Updates ``self.limits``.
+
+        More info on the network interface limit, from the docs:
+        'This limit is the greater of either the default limit (350) or your
+        On-Demand Instance limit multiplied by 5.
+        The default limit for On-Demand Instances is 20.'
+        """
+        self.connect()
+        self.connect_resource()
+        logger.info("Querying EC2 DescribeAccountAttributes for limits")
+        attribs = self.conn.describe_account_attributes()
+        for attrib in attribs['AccountAttributes']:
+            if attrib['AttributeName'] == 'max-instances':
+                val = attrib['AttributeValues'][0]['AttributeValue']
+                if int(val) * 5 > DEFAULT_ENI_LIMIT:
+                    limit_name = 'Network interfaces per Region'
+                    self.limits[limit_name]._set_api_limit(int(val))
+                else:
+                    continue
+        logger.debug("Done setting limits from API")
 
     def required_iam_permissions(self):
         """

--- a/awslimitchecker/services/vpc.py
+++ b/awslimitchecker/services/vpc.py
@@ -376,4 +376,5 @@ class _VpcService(_AwsService):
             'ec2:DescribeSubnets',
             'ec2:DescribeVpcs',
             'ec2:DescribeVpnGateways',
+            'ec2:DescribeNetworkInterfaces',
         ]

--- a/awslimitchecker/services/vpc.py
+++ b/awslimitchecker/services/vpc.py
@@ -329,7 +329,7 @@ class _VpcService(_AwsService):
             350,
             self.warning_threshold,
             self.critical_threshold,
-            limit_type='AWS::EC2::VPNGateway'
+            limit_type='AWS::EC2::NetworkInterface'
         )
         self.limits = limits
         return limits

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -615,6 +615,40 @@ class VPC(object):
         ]
     }
 
+    test_update_limits_from_api_high_max_instances = {
+        'ResponseMetadata': {
+            'HTTPStatusCode': 200,
+            'RequestId': '16b85906-ab0d-4134-b8bb-df3e6120c6c7'
+        },
+        'AccountAttributes': [
+            {
+                'AttributeName': 'max-instances',
+                'AttributeValues': [
+                    {
+                        'AttributeValue': '400'
+                    }
+                ]
+            }
+        ]
+    }
+
+    test_update_limits_from_api_low_max_instances = {
+        'ResponseMetadata': {
+            'HTTPStatusCode': 200,
+            'RequestId': '16b85906-ab0d-4134-b8bb-df3e6120c6c7'
+        },
+        'AccountAttributes': [
+            {
+                'AttributeName': 'max-instances',
+                'AttributeValues': [
+                    {
+                        'AttributeValue': '50'
+                    }
+                ]
+            }
+        ]
+    }
+
 
 class RDS(object):
     test_find_usage_instances = []

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -551,6 +551,70 @@ class VPC(object):
         ]
     }
 
+    test_find_usage_network_interfaces = {
+        'NetworkInterfaces': [
+            {
+                'Association': {
+                    'AllocationId': 'allocation-123',
+                    'AssociationId': 'association-123',
+                    'IpOwnerId': '123456789012',
+                    'PublicDnsName': 'string',
+                    'PublicIp': '50.0.0.0'
+                },
+                'Attachment': {
+                    'AttachTime': datetime(2015, 1, 1),
+                    'AttachmentId': 'eni-123',
+                    'DeleteOnTermination': True,
+                    'DeviceIndex': 123,
+                    'InstanceId': 'i-123',
+                    'InstanceOwnerId': '123456789012',
+                    'Status': 'attaching'
+                },
+                'AvailabilityZone': 'us-east-2a',
+                'Description': 'NetworkInface',
+                'Groups': [
+                    {
+                        'GroupName': 'groupName',
+                        'GroupId': 'sg-123'
+                    },
+                ],
+                'InterfaceType': 'interface',
+                'Ipv6Addresses': [],
+                'MacAddress': 'address',
+                'NetworkInterfaceId': 'eni-123',
+                'OwnerId': 'string',
+                'PrivateDnsName': 'string',
+                'PrivateIpAddress': 'string',
+                'PrivateIpAddresses': [
+                    {
+                        'Association': {
+                            'AllocationId': 'allocation-123',
+                            'AssociationId': 'association-123',
+                            'IpOwnerId': '123456789012',
+                            'PublicDnsName': 'string',
+                            'PublicIp': '10.0.0.0'
+                        },
+                        'Primary': True,
+                        'PrivateDnsName': 'string',
+                        'PrivateIpAddress': 'string'
+                    },
+                ],
+                'RequesterId': '123456789012',
+                'RequesterManaged': True,
+                'SourceDestCheck': True,
+                'Status': 'available',
+                'SubnetId': 'subnet-123',
+                'TagSet': [
+                    {
+                        'Key': 'tagkey',
+                        'Value': 'tagvalue'
+                    },
+                ],
+                'VpcId': 'string'
+            },
+        ]
+    }
+
 
 class RDS(object):
     test_find_usage_instances = []

--- a/awslimitchecker/tests/services/test_vpc.py
+++ b/awslimitchecker/tests/services/test_vpc.py
@@ -420,4 +420,5 @@ class Test_VpcService(object):
             'ec2:DescribeSubnets',
             'ec2:DescribeVpcs',
             'ec2:DescribeVpnGateways',
+            'ec2:DescribeNetworkInterfaces',
         ]


### PR DESCRIPTION
# Summary
This PR adds the `Network interfaces per Region` limit. This limit is described [here](https://docs.aws.amazon.com/vpc/latest/userguide/amazon-vpc-limits.html) is a bit unusual because the default is:
>This limit is the greater of either the default limit (350) or your On-Demand Instance limit multiplied by 5. 

I used 350 because that is the initial limit a new account will have, given that the default limit for On-Demand Instances is 20.

I had some trouble getting the docs to build so I did not complete that step (it is the only failure in travis). Sorry about that!

# Pull Request Checklist

- [x] All pull requests should be __against the develop branch__, not master.
- [x] All pull requests must include the Contributor License Agreement (see below).
- [ ] Whether or not your PR includes unit tests:
    - [x] Please make sure you have run the exact code contained in the PR locally, and it functions as desired.
    - [ ] Please make sure the TravisCI build passes or, if not, you've corrected any obvious problems identified by the tests.
- [x] Code should conform to the [Development Guidelines](http://awslimitchecker.readthedocs.org/en/latest/development.html#guidelines):
    - [x] pep8 compliant with some exceptions (see pytest.ini)
    - [x] 100% test coverage with pytest (with valid tests). If you have difficulty
      writing tests for the code, that's fine, just mention that in the summary and either
      ask for assistance, or clarify that you'd like someone else to handle the tests. PRs that
      include complete test coverage will usually be merged faster.
    - [x] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [x] documentation has been rebuilt with ``tox -e docs``
    - [x] Connections to the AWS services should only be made by the class's
      ``connect()`` and ``connect_resource()`` methods, inherited from
      [awslimitchecker.connectable.Connectable](http://awslimitchecker.readthedocs.org/en/latest/awslimitchecker.connectable.html)
    - [x] All modules should have (and use) module-level loggers.
    - [x] **Commit messages** should be meaningful, and reference the Issue number
      if you're working on a GitHub issue (i.e. "issue #x - <message>"). Please
      refrain from using the "fixes #x" notation unless you are *sure* that the
      the issue is fixed in that commit.
    - [x] Git history is fully intact; please do not squash or rewrite history.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.
