### PR TITLE
Fix calculation of VPC Network Interfaces limit

### DIFF
--- a/awslimitchecker/services/vpc.py
+++ b/awslimitchecker/services/vpc.py
@@ -355,7 +355,7 @@ class _VpcService(_AwsService):
                 val = attrib['AttributeValues'][0]['AttributeValue']
                 if int(val) * 5 > DEFAULT_ENI_LIMIT:
                     limit_name = 'Network interfaces per Region'
-                    self.limits[limit_name]._set_api_limit(int(val))
+                    self.limits[limit_name]._set_api_limit(int(val) * 5)
         logger.debug("Done setting limits from API")
 
     def required_iam_permissions(self):

--- a/awslimitchecker/tests/services/test_vpc.py
+++ b/awslimitchecker/tests/services/test_vpc.py
@@ -382,8 +382,8 @@ class Test_VpcService(object):
             call.info("Querying EC2 DescribeAccountAttributes for limits"),
             call.debug('Done setting limits from API')
         ]
-        assert cls.limits['Network interfaces per Region'].api_limit == 400
-        assert cls.limits['Network interfaces per Region'].get_limit() == 400
+        assert cls.limits['Network interfaces per Region'].api_limit == 2000
+        assert cls.limits['Network interfaces per Region'].get_limit() == 2000
 
     def test_update_limits_from_api_low_max_instances(self):
         fixtures = result_fixtures.VPC()


### PR DESCRIPTION
# Summary

Fixes calculation for VPC Network Interface limit.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.
