### PR TITLE
Add support for ignoring specific checks based on service and check name

### DIFF
--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -395,7 +395,8 @@ class Runner(object):
             self.checker.remove_services(args.skip_service)
 
         if len(args.skip_check) > 0:
-            self.skip_check = args.skip_check
+            for check in args.skip_check:
+                self.skip_check.append(check)
 
         if len(args.limit) > 0:
             self.set_limit_overrides(args.limit)

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -68,6 +68,7 @@ class Runner(object):
         self.checker = None
         self.skip_ta = False
         self.service_name = None
+        self.skip_check = []
 
     def parse_args(self, argv):
         """
@@ -105,6 +106,10 @@ class Runner(object):
                        dest='skip_service',
                        help='avoid performing actions for the specified service'
                             ' name; see -s|--list-services for valid names')
+        p.add_argument('--skip-check', action='append', default=[],
+                       dest='skip_check',
+                       help='avoid performing actions for the specified check'
+                            ' name')
         p.add_argument('-s', '--list-services', action='store_true',
                        default=False,
                        help='print a list of all AWS service types that '
@@ -311,6 +316,13 @@ class Runner(object):
         columns = {}
         for svc in sorted(problems.keys()):
             for lim_name in sorted(problems[svc].keys()):
+                check_name = "{svc}/{limit}".format(
+                    svc=svc,
+                    limit=lim_name,
+                )
+                if check_name in self.skip_check:
+                    continue
+
                 limit = problems[svc][lim_name]
                 warns = limit.get_warnings()
                 crits = limit.get_criticals()
@@ -381,6 +393,9 @@ class Runner(object):
 
         if len(args.skip_service) > 0:
             self.checker.remove_services(args.skip_service)
+
+        if len(args.skip_check) > 0:
+            self.skip_check = args.skip_check
 
         if len(args.limit) > 0:
             self.set_limit_overrides(args.limit)

--- a/awslimitchecker/tests/test_runner.py
+++ b/awslimitchecker/tests/test_runner.py
@@ -98,6 +98,7 @@ class TestAwsLimitCheckerRunner(object):
         assert self.cls.checker is None
         assert self.cls.skip_ta is False
         assert self.cls.service_name is None
+        assert len(self.cls.skip_check) == 0
 
     def test_parse_args(self):
         argv = ['-V']
@@ -132,6 +133,10 @@ class TestAwsLimitCheckerRunner(object):
                                 help='avoid performing actions for the '
                                      'specified service name; see '
                                      '-s|--list-services for valid names'),
+            call().add_argument('--skip-check', action='append',
+                                dest='skip_check', default=[],
+                                help='avoid performing actions for the '
+                                     'specified check name'),
             call().add_argument('-s', '--list-services',
                                 default=False, action='store_true',
                                 help='print a list of all AWS service types '
@@ -284,6 +289,24 @@ class TestAwsLimitCheckerRunner(object):
         ]
         res = self.cls.parse_args(argv)
         assert res.skip_service == ['foo', 'bar', 'baz']
+
+    def test_parse_args_skip_check(self):
+        argv = [
+            '--skip-check', 'EC2/Running On-Demand x1e.8xlarge instances',
+        ]
+        res = self.cls.parse_args(argv)
+        assert res.skip_check == ['EC2/Running On-Demand x1e.8xlarge instances']
+
+    def test_parse_args_skip_check_multiple(self):
+        argv = [
+            '--skip-check', 'EC2/Running On-Demand x1e.8xlarge instances',
+            '--skip-check', 'EC2/Running On-Demand c5.9xlarge instances',
+        ]
+        res = self.cls.parse_args(argv)
+        assert res.skip_check == [
+            'EC2/Running On-Demand x1e.8xlarge instances',
+            'EC2/Running On-Demand c5.9xlarge instances',
+        ]
 
     def test_entry_version(self, capsys):
         argv = ['awslimitchecker', '-V']
@@ -1050,6 +1073,54 @@ class TestAwsLimitCheckerRunner(object):
             })
         ]
         assert res == 2
+
+    def test_check_thresholds_when_skip_check(self):
+        """lots of problems"""
+        mock_limit1 = Mock(spec_set=AwsLimit)
+        type(mock_limit1).name = 'limit1'
+        mock_w1 = Mock(spec_set=AwsLimitUsage)
+        mock_limit1.get_warnings.return_value = [mock_w1]
+        mock_c1 = Mock(spec_set=AwsLimitUsage)
+        mock_limit1.get_criticals.return_value = [mock_c1]
+
+        mock_limit2 = Mock(spec_set=AwsLimit)
+        type(mock_limit2).name = 'limit2'
+        mock_w2 = Mock(spec_set=AwsLimitUsage)
+        mock_limit2.get_warnings.return_value = [mock_w2]
+        mock_limit2.get_criticals.return_value = []
+
+        mock_checker = Mock(spec_set=AwsLimitChecker)
+        mock_checker.check_thresholds.return_value = {
+            'svc1': {
+                'limit1': mock_limit1,
+                'limit2': mock_limit2,
+            },
+        }
+
+        def se_print(cls, s, l, c, w):
+            return ('{s}/{l}'.format(s=s, l=l.name), '')
+
+        self.cls.checker = mock_checker
+        self.cls.skip_check = ['svc1/limit1']
+        with patch('awslimitchecker.runner.Runner.print_issue',
+                   autospec=True) as mock_print:
+            mock_print.side_effect = se_print
+            with patch('awslimitchecker.runner.dict2cols') as mock_d2c:
+                mock_d2c.return_value = 'd2cval'
+                res = self.cls.check_thresholds()
+
+        assert mock_checker.mock_calls == [
+            call.check_thresholds(use_ta=True, service=None)
+        ]
+        assert mock_print.mock_calls == [
+            call(self.cls, 'svc1', mock_limit2, [], [mock_w2]),
+        ]
+        assert mock_d2c.mock_calls == [
+            call({
+                'svc1/limit2': '',
+            })
+        ]
+        assert res == 1
 
     def test_check_thresholds_warn(self):
         """just warnings"""

--- a/awslimitchecker/tests/test_runner.py
+++ b/awslimitchecker/tests/test_runner.py
@@ -565,6 +565,56 @@ class TestAwsLimitCheckerRunner(object):
             call().remove_services(['foo', 'bar'])
         ]
 
+    def test_entry_skip_check(self):
+        argv = [
+            'awslimitchecker',
+            '--skip-check=EC2/Max launch specifications per spot fleet'
+        ]
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_check:
+                mock_check.return_value = 2
+                with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_c:
+                    with pytest.raises(SystemExit) as excinfo:
+                        self.cls.console_entry_point()
+        assert excinfo.value.code == 2
+        assert mock_c.mock_calls == [
+            call(account_id=None, account_role=None, critical_threshold=99,
+                 external_id=None, mfa_serial_number=None, mfa_token=None,
+                 profile_name=None, region=None, ta_refresh_mode=None,
+                 ta_refresh_timeout=None, warning_threshold=80,
+                 check_version=True),
+        ]
+        assert self.cls.skip_check == [
+            'EC2/Max launch specifications per spot fleet',
+        ]
+
+    def test_entry_skip_check_multi(self):
+        argv = [
+            'awslimitchecker',
+            '--skip-check=EC2/Max launch specifications per spot fleet',
+            '--skip-check', 'EC2/Running On-Demand i3.large instances',
+        ]
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_check:
+                mock_check.return_value = 2
+                with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_c:
+                    with pytest.raises(SystemExit) as excinfo:
+                        self.cls.console_entry_point()
+        assert excinfo.value.code == 2
+        assert mock_c.mock_calls == [
+            call(account_id=None, account_role=None, critical_threshold=99,
+                 external_id=None, mfa_serial_number=None, mfa_token=None,
+                 profile_name=None, region=None, ta_refresh_mode=None,
+                 ta_refresh_timeout=None, warning_threshold=80,
+                 check_version=True),
+        ]
+        assert self.cls.skip_check == [
+            'EC2/Max launch specifications per spot fleet',
+            'EC2/Running On-Demand i3.large instances',
+        ]
+
     def test_entry_limit(self):
         argv = ['awslimitchecker', '-L', 'foo=bar']
         with patch.object(sys, 'argv', argv):

--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -26,6 +26,7 @@ use as a Nagios-compatible plugin).
    (venv)$ awslimitchecker --help
    usage: awslimitchecker [-h] [-S [SERVICE [SERVICE ...]]]
                           [--skip-service SKIP_SERVICE] [-s] [-l]
+                          [--skip-check SKIP_CHECK]
                           [--list-defaults] [-L LIMIT] [-u] [--iam-policy]
                           [-W WARNING_THRESHOLD] [-C CRITICAL_THRESHOLD]
                           [-P PROFILE_NAME] [-A STS_ACCOUNT_ID]
@@ -46,6 +47,8 @@ use as a Nagios-compatible plugin).
      --skip-service SKIP_SERVICE
                            avoid performing actions for the specified service
                            name; see -s|--list-services for valid names
+     --skip-check SKIP_CHECK
+                           avoid performing actions for the specified check
      -s, --list-services   print a list of all AWS service types that
                            awslimitchecker knows how to check
      -l, --list-limits     print all AWS effective limits in
@@ -234,6 +237,28 @@ For example, you can check usage of all services _except_ for ``Firehose`` and
     WARNING:awslimitchecker.checker:Skipping service: Firehose
     WARNING:awslimitchecker.checker:Skipping service: EC2
     ... normal output ...
+
+Disabling Specific Checks
++++++++++++++++++++++++++++
+
+The ``--skip-check`` option can be used to completely disable the specified
+check name(s).
+
+For example, you can run all the EC2 service checks except the ``Max launch specifications per spot fleet`` check with  the following command:
+
+.. code-block:: console
+
+   (venv)$ awslimitchecker --skip-check='EC2/Max launch specifications per spot fleet'
+    ... normal output ...
+    EC2/Max launch specifications per spot fleet  (limit 50) WARNING: sfr-98e516f0-62f8-47ad-ada6-444da23fe6c5=42
+   (venv)$ echo $?
+   2
+
+   # With --skip-check
+   (venv)$ awslimitchecker --skip-check='EC2/Max launch specifications per spot fleet'
+    ... normal output ...
+   (venv)$ echo $?
+   0
 
 Checking Usage
 ++++++++++++++

--- a/docs/source/cli_usage.rst.template
+++ b/docs/source/cli_usage.rst.template
@@ -83,6 +83,28 @@ For example, you can check usage of all services _except_ for ``Firehose`` and
     WARNING:awslimitchecker.checker:Skipping service: EC2
     ... normal output ...
 
+Disabling Specific Checks
++++++++++++++++++++++++++++
+
+The ``--skip-check`` option can be used to completely disable the specified
+check name(s).
+
+For example, you can run all the EC2 service checks except the ``Max launch specifications per spot fleet`` check with  the following command:
+
+.. code-block:: console
+
+   (venv)$ awslimitchecker --skip-check='EC2/Max launch specifications per spot fleet'
+    ... normal output ...
+    EC2/Max launch specifications per spot fleet  (limit 50) WARNING: sfr-98e516f0-62f8-47ad-ada6-444da23fe6c5=42
+   (venv)$ echo $?
+   2
+
+   # With --skip-check
+   (venv)$ awslimitchecker --skip-check='EC2/Max launch specifications per spot fleet'
+    ... normal output ...
+   (venv)$ echo $?
+   0
+
 Checking Usage
 ++++++++++++++
 


### PR DESCRIPTION
Before submitting pull requests, please see the
[Development documentation](http://awslimitchecker.readthedocs.org/en/latest/development.html)
and specifically the [Pull Request Guidelines](http://awslimitchecker.readthedocs.org/en/latest/development.html#pull-requests).

__IMPORTANT:__ Please take note of the below checklist, especially the first three items.

# Summary

This PR adds support for skipping the result of specific checks. See #307 for more details.

# Pull Request Checklist

- [x] All pull requests should be __against the develop branch__, not master.
- [x] All pull requests must include the Contributor License Agreement (see below).
- [x] Whether or not your PR includes unit tests: **My PR includes tests and should have 100% coverage**
    - [x] Please make sure you have run the exact code contained in the PR locally, and it functions as desired. **I ran the code interactively even though my test coverage should be sufficient**

```
ddelnano@10-81-17-110-uswest2adevc:~$ BOTO_CONFIG=/etc/boto_cfg/resource-limit-monitor.cfg awslimitchecker --ta-refresh-wait --no-check-version -r us-west-2 -S EC2 -L 'EC2/Running On-Demand c5.9xlarge instances'=2000 -L 'EC2/Running On-Demand i3.large instances'=16 -L 'EC2/Running On-Demand i3.xlarge instances'=50 -L 'EC2/Running On-Demand m4.16xlarge instances'=16 -L 'EC2/Running On-Demand p3.8xlarge instances'=2 -L 'EC2/Max spot instance requests per region'=2000 -L 'EC2/VPC security groups per elastic network interface'=7 -L 'EC2/Running On-Demand x1e.8xlarge instances'=10
awslimitchecker 6.1.5 is AGPL-licensed free software; all users have a right to the full source code of this version. See <https://github.com/jantman/awslimitchecker>
WARNING:awslimitchecker.trustedadvisor:Polling for TA check eW7HH0l7J9 refresh...
EC2/Max launch specifications per spot fleet  (limit 50) WARNING: sfr-98e516f0-62f8-47ad-ada6-444da23fe6c5=42

ddelnano@10-81-17-110-uswest2adevc:~$ BOTO_CONFIG=/etc/boto_cfg/resource-limit-monitor.cfg awslimitchecker --ta-refresh-wait --no-check-version -r us-west-2 -S EC2 -L 'EC2/Running On-Demand c5.9xlarge instances'=2000 -L 'EC2/Running On-Demand i3.large instances'=16 -L 'EC2/Running On-Demand i3.xlarge instances'=50 -L 'EC2/Running On-Demand m4.16xlarge instances'=16 -L 'EC2/Running On-Demand p3.8xlarge instances'=2 -L 'EC2/Max spot instance requests per region'=2000 -L 'EC2/VPC security groups per elastic network interface'=7 -L 'EC2/Running On-Demand x1e.8xlarge instances'=10 --skip-check 'EC2/Max launch specifications per spot fleet'
awslimitchecker 6.1.5 is AGPL-licensed free software; all users have a right to the full source code of this version. See <https://github.com/jantman/awslimitchecker>
WARNING:awslimitchecker.trustedadvisor:Trusted Advisor check cannot be refreshed for another 253912 milliseconds; skipping refresh and getting check results now

ddelnano@10-81-17-110-uswest2adevc:~$ echo $?
0
```


 - [x] Please make sure the TravisCI build passes or, if not, you've corrected any obvious problems identified by the tests.
- [x] Code should conform to the [Development Guidelines](http://awslimitchecker.readthedocs.org/en/latest/development.html#guidelines):
    - [x] pep8 compliant with some exceptions (see pytest.ini)
    - [x] 100% test coverage with pytest (with valid tests). If you have difficulty
      writing tests for the code, that's fine, just mention that in the summary and either
      ask for assistance, or clarify that you'd like someone else to handle the tests. PRs that
      include complete test coverage will usually be merged faster.
    - [x] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [x] documentation has been rebuilt with ``tox -e docs``
    - [x] Connections to the AWS services should only be made by the class's
      ``connect()`` and ``connect_resource()`` methods, inherited from
      [awslimitchecker.connectable.Connectable](http://awslimitchecker.readthedocs.org/en/latest/awslimitchecker.connectable.html)
    - [x] All modules should have (and use) module-level loggers.
    - [x] **Commit messages** should be meaningful, and reference the Issue number
      if you're working on a GitHub issue (i.e. "issue #x - <message>"). Please
      refrain from using the "fixes #x" notation unless you are *sure* that the
      the issue is fixed in that commit.
    - [x] Git history is fully intact; please do not squash or rewrite history.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.

Here are what the docs look like when rebuilt.

<img width="1680" alt="Screen Shot 2019-04-04 at 4 27 49 PM" src="https://user-images.githubusercontent.com/5855593/55595155-6d2bab00-56f7-11e9-8ffe-47693a9a969d.png">
<img width="1680" alt="Screen Shot 2019-04-04 at 4 27 38 PM" src="https://user-images.githubusercontent.com/5855593/55595157-70269b80-56f7-11e9-9f21-03525ad3fed4.png">

