### PR TITLE
Issue #324 - support setting limit and threshold overrides from local or S3 JSON file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Unreleased Changes
   * Stop referencing deprecated ``botocore.vendored.requests.exceptions.ConnectTimeout`` in favor of new, and higher-level, ``botocore.exceptions.ConnectionError``
   * In :py:meth:`awslimitchecker.utils._get_latest_version`, replace use of ``botocore.vendored.requests`` with ``urllib3``.
 
-* `Issue #324 <https://github.com/jantman/awslimitchecker/issues/324>`__ - Support loading :ref:`limit overrides <cli_usage.limit_overrides>` from a JSON file either stored locally or in S3.
+* `Issue #324 <https://github.com/jantman/awslimitchecker/issues/324>`__ - Support loading :ref:`limit overrides <cli_usage.limit_overrides>` and/or :ref:`threshold overrides <cli_usage.threshold_overrides>` from a JSON file either stored locally or in S3.
 
 7.0.0 (2019-08-13)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased Changes
   * Stop referencing deprecated ``botocore.vendored.requests.exceptions.ConnectTimeout`` in favor of new, and higher-level, ``botocore.exceptions.ConnectionError``
   * In :py:meth:`awslimitchecker.utils._get_latest_version`, replace use of ``botocore.vendored.requests`` with ``urllib3``.
 
+* `Issue #324 <https://github.com/jantman/awslimitchecker/issues/324>`__ - Support loading :ref:`limit overrides <cli_usage.limit_overrides>` from a JSON file either stored locally or in S3.
+
 7.0.0 (2019-08-13)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Unreleased Changes
   * Stop referencing deprecated ``botocore.vendored.requests.exceptions.ConnectTimeout`` in favor of new, and higher-level, ``botocore.exceptions.ConnectionError``
   * In :py:meth:`awslimitchecker.utils._get_latest_version`, replace use of ``botocore.vendored.requests`` with ``urllib3``.
 
-* `Issue #324 <https://github.com/jantman/awslimitchecker/issues/324>`__ - Support loading :ref:`limit overrides <cli_usage.limit_overrides>` and/or :ref:`threshold overrides <cli_usage.threshold_overrides>` from a JSON file either stored locally or in S3.
+* `Issue #324 <https://github.com/jantman/awslimitchecker/issues/324>`__ - Support loading :ref:`limit overrides <cli_usage.limit_overrides>` and/or :ref:`threshold overrides <cli_usage.threshold_overrides>` from a JSON file either stored locally or in S3 via new ``--limit-override-json`` and ``--threshold-override-json`` CLI options.
 
 7.0.0 (2019-08-13)
 ------------------

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -136,6 +136,11 @@ class Runner(object):
                        help='Absolute or relative path, or s3:// URL, to a '
                             'JSON file specifying limit overrides. See docs '
                             'for expected format.')
+        p.add_argument('--threshold-override-json', action='store', type=str,
+                       default=None,
+                       help='Absolute or relative path, or s3:// URL, to a '
+                            'JSON file specifying threshold overrides. See '
+                            'docs for expected format.')
         p.add_argument('-u', '--show-usage', action='store_true',
                        default=False,
                        help='find and print the current usage of all AWS '
@@ -382,10 +387,15 @@ class Runner(object):
 
     def set_limit_overrides_from_json(self, path):
         j = self.load_json(path)
-        for svcname, kv in j.items():
-            for limname, value in kv.items():
-                self.checker.set_limit_override(svcname, limname, value)
+        logger.debug('Limit overrides: %s', j)
+        self.checker.set_limit_overrides(j)
         logger.debug('Done setting limit overrides from JSON.')
+
+    def set_threshold_overrides_from_json(self, path):
+        j = self.load_json(path)
+        logger.debug('Threshold overrides: %s', j)
+        self.checker.set_threshold_overrides(j)
+        logger.debug('Done setting threshold overrides from JSON.')
 
     def console_entry_point(self):
         args = self.parse_args(sys.argv[1:])
@@ -438,6 +448,11 @@ class Runner(object):
 
         if args.limit_override_json is not None:
             self.set_limit_overrides_from_json(args.limit_override_json)
+
+        if args.threshold_override_json is not None:
+            self.set_threshold_overrides_from_json(
+                args.threshold_override_json
+            )
 
         if len(args.limit) > 0:
             self.set_limit_overrides(args.limit)

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -42,10 +42,16 @@ import argparse
 import logging
 import json
 import termcolor
+import boto3
 
 from .checker import AwsLimitChecker
 from .utils import StoreKeyValuePair, dict2cols
 from .limit import SOURCE_TA, SOURCE_API
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger()
@@ -125,6 +131,11 @@ class Runner(object):
                        help='override a single AWS limit, specified in '
                        '"service_name/limit_name=value" format; can be '
                        'specified multiple times.')
+        p.add_argument('--limit-override-json', action='store', type=str,
+                       default=None,
+                       help='Absolute or relative path, or s3:// URL, to a '
+                            'JSON file specifying limit overrides. See docs '
+                            'for expected format.')
         p.add_argument('-u', '--show-usage', action='store_true',
                        default=False,
                        help='find and print the current usage of all AWS '
@@ -349,6 +360,33 @@ class Runner(object):
             svc, limit = key.split('/')
             self.checker.set_limit_override(svc, limit, int(overrides[key]))
 
+    def load_json(self, path):
+        """Load JSON from either a local file or S3"""
+        if path.startswith('s3://'):
+            parsed = urlparse(path)
+            s3key = parsed.path.lstrip('/')
+            logger.debug(
+                'Reading JSON from S3 bucket "%s" key "%s"',
+                parsed.netloc, s3key
+            )
+            client = boto3.client('s3')
+            resp = client.get_object(Bucket=parsed.netloc, Key=s3key)
+            data = resp['Body'].read()
+        else:
+            logger.debug('Reading JSON from: %s', path)
+            with open(path, 'r') as fh:
+                data = fh.read()
+        if isinstance(data, type(b'')):
+            data = data.decode()
+        return json.loads(data)
+
+    def set_limit_overrides_from_json(self, path):
+        j = self.load_json(path)
+        for svcname, kv in j.items():
+            for limname, value in kv.items():
+                self.checker.set_limit_override(svcname, limname, value)
+        logger.debug('Done setting limit overrides from JSON.')
+
     def console_entry_point(self):
         args = self.parse_args(sys.argv[1:])
         self.service_name = args.service
@@ -397,6 +435,9 @@ class Runner(object):
         if len(args.skip_check) > 0:
             for check in args.skip_check:
                 self.skip_check.append(check)
+
+        if args.limit_override_json is not None:
+            self.set_limit_overrides_from_json(args.limit_override_json)
 
         if len(args.limit) > 0:
             self.set_limit_overrides(args.limit)

--- a/awslimitchecker/tests/test_runner.py
+++ b/awslimitchecker/tests/test_runner.py
@@ -73,7 +73,7 @@ def yellow(s):
 pb = 'awslimitchecker.runner'
 
 
-class TestAwsLimitCheckerRunner(object):
+class RunnerTester(object):
 
     def setup(self):
         self.cls = Runner()
@@ -85,6 +85,9 @@ class TestAwsLimitCheckerRunner(object):
             version_str='1.2.3@mytag'
         )
 
+
+class TestModule(RunnerTester):
+
     def test_module_entry_point(self):
         with patch('%s.Runner' % pb) as mock_runner:
             console_entry_point()
@@ -93,6 +96,9 @@ class TestAwsLimitCheckerRunner(object):
             call().console_entry_point(),
         ]
 
+
+class TestInit(RunnerTester):
+
     def test_init(self):
         assert self.cls.colorize is True
         assert self.cls.checker is None
@@ -100,14 +106,17 @@ class TestAwsLimitCheckerRunner(object):
         assert self.cls.service_name is None
         assert len(self.cls.skip_check) == 0
 
-    def test_parse_args(self):
+
+class TestParseArgs(RunnerTester):
+
+    def test_simple(self):
         argv = ['-V']
         res = self.cls.parse_args(argv)
         assert isinstance(res, argparse.Namespace)
         assert res.version is True
         assert res.ta_refresh_mode is None
 
-    def test_parse_args_parser(self):
+    def test_parser(self):
         argv = ['-V']
         desc = 'Report on AWS service limits and usage via boto3, optionally ' \
                'warn about any services with usage nearing or exceeding ' \
@@ -248,40 +257,40 @@ class TestAwsLimitCheckerRunner(object):
             call().parse_args(argv)
         ]
 
-    def test_parse_args_multiple_ta(self):
+    def test_multiple_ta(self):
         argv = ['--ta-refresh-wait', '--ta-refresh-older=100']
         with pytest.raises(SystemExit):
             self.cls.parse_args(argv)
 
-    def test_parse_args_ta_refresh_wait(self):
+    def test_ta_refresh_wait(self):
         argv = ['--ta-refresh-wait']
         res = self.cls.parse_args(argv)
         assert isinstance(res, argparse.Namespace)
         assert res.ta_refresh_mode == 'wait'
 
-    def test_parse_args_ta_refresh_trigger(self):
+    def test_ta_refresh_trigger(self):
         argv = ['--ta-refresh-trigger']
         res = self.cls.parse_args(argv)
         assert isinstance(res, argparse.Namespace)
         assert res.ta_refresh_mode == 'trigger'
 
-    def test_parse_args_ta_refresh_older(self):
+    def test_ta_refresh_older(self):
         argv = ['--ta-refresh-older=123']
         res = self.cls.parse_args(argv)
         assert isinstance(res, argparse.Namespace)
         assert res.ta_refresh_mode == 123
 
-    def test_parse_args_skip_service_none(self):
+    def test_skip_service_none(self):
         argv = []
         res = self.cls.parse_args(argv)
         assert res.skip_service == []
 
-    def test_parse_args_skip_service_one(self):
+    def test_skip_service_one(self):
         argv = ['--skip-service', 'foo']
         res = self.cls.parse_args(argv)
         assert res.skip_service == ['foo']
 
-    def test_parse_args_skip_service_multiple(self):
+    def test_skip_service_multiple(self):
         argv = [
             '--skip-service', 'foo',
             '--skip-service', 'bar',
@@ -290,14 +299,14 @@ class TestAwsLimitCheckerRunner(object):
         res = self.cls.parse_args(argv)
         assert res.skip_service == ['foo', 'bar', 'baz']
 
-    def test_parse_args_skip_check(self):
+    def test_skip_check(self):
         argv = [
             '--skip-check', 'EC2/Running On-Demand x1e.8xlarge instances',
         ]
         res = self.cls.parse_args(argv)
         assert res.skip_check == ['EC2/Running On-Demand x1e.8xlarge instances']
 
-    def test_parse_args_skip_check_multiple(self):
+    def test_skip_check_multiple(self):
         argv = [
             '--skip-check', 'EC2/Running On-Demand x1e.8xlarge instances',
             '--skip-check', 'EC2/Running On-Demand c5.9xlarge instances',
@@ -308,51 +317,10 @@ class TestAwsLimitCheckerRunner(object):
             'EC2/Running On-Demand c5.9xlarge instances',
         ]
 
-    def test_entry_version(self, capsys):
-        argv = ['awslimitchecker', '-V']
-        expected = 'awslimitchecker ver (see <foo> for source code)\n'
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.AwsLimitChecker' % pb,
-                       spec_set=AwsLimitChecker) as mock_alc:
-                mock_alc.return_value.get_project_url.return_value = 'foo'
-                mock_alc.return_value.get_version.return_value = 'ver'
-                with pytest.raises(SystemExit) as excinfo:
-                    self.cls.console_entry_point()
-        out, err = capsys.readouterr()
-        assert out == expected
-        assert excinfo.value.code == 0
-        assert mock_alc.mock_calls == [
-            call(
-                warning_threshold=80,
-                critical_threshold=99,
-                account_id=None,
-                account_role=None,
-                region=None,
-                external_id=None,
-                mfa_serial_number=None,
-                mfa_token=None,
-                profile_name=None,
-                ta_refresh_mode=None,
-                ta_refresh_timeout=None,
-                check_version=True
-            ),
-            call().get_project_url(),
-            call().get_version()
-        ]
 
-    def test_entry_list_services(self):
-        argv = ['awslimitchecker', '-s']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.list_services' % pb,
-                       autospec=True) as mock_list:
-                with pytest.raises(SystemExit) as excinfo:
-                    self.cls.console_entry_point()
-        assert excinfo.value.code == 0
-        assert mock_list.mock_calls == [
-            call(self.cls)
-        ]
+class TestListServices(RunnerTester):
 
-    def test_list_services(self, capsys):
+    def test_happy_path(self, capsys):
         expected = 'Bar\nFoo\n'
         mock_checker = Mock(spec_set=AwsLimitChecker)
         mock_checker.get_service_names.return_value = [
@@ -367,18 +335,10 @@ class TestAwsLimitCheckerRunner(object):
             call.get_service_names()
         ]
 
-    def test_entry_iam_policy(self):
-        argv = ['awslimitchecker', '--iam-policy']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.iam_policy' % pb, autospec=True) as mock_iam:
-                with pytest.raises(SystemExit) as excinfo:
-                    self.cls.console_entry_point()
-        assert excinfo.value.code == 0
-        assert mock_iam.mock_calls == [
-            call(self.cls)
-        ]
 
-    def test_iam_policy(self, capsys):
+class TestIamPolicy(RunnerTester):
+
+    def test_happy_path(self, capsys):
         expected = {"baz": "blam", "foo": "bar"}
         mock_checker = Mock(spec_set=AwsLimitChecker)
         mock_checker.get_required_iam_policy.return_value = {
@@ -393,19 +353,10 @@ class TestAwsLimitCheckerRunner(object):
             call.get_required_iam_policy()
         ]
 
-    def test_entry_list_defaults(self):
-        argv = ['awslimitchecker', '--list-defaults']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.list_defaults' % pb,
-                       autospec=True) as mock_list:
-                with pytest.raises(SystemExit) as excinfo:
-                    self.cls.console_entry_point()
-        assert excinfo.value.code == 0
-        assert mock_list.mock_calls == [
-            call(self.cls)
-        ]
 
-    def test_list_defaults(self, capsys):
+class TestListDefaults(RunnerTester):
+
+    def test_simple(self, capsys):
         mock_checker = Mock(spec_set=AwsLimitChecker)
         mock_checker.get_limits.return_value = sample_limits()
         self.cls.checker = mock_checker
@@ -426,7 +377,7 @@ class TestAwsLimitCheckerRunner(object):
             })
         ]
 
-    def test_list_defaults_one_service(self, capsys):
+    def test_one_service(self, capsys):
         mock_checker = Mock(spec_set=AwsLimitChecker)
         mock_checker.get_limits.return_value = {
             'SvcFoo': sample_limits()['SvcFoo'],
@@ -448,19 +399,10 @@ class TestAwsLimitCheckerRunner(object):
             })
         ]
 
-    def test_entry_list_limits(self):
-        argv = ['awslimitchecker', '-l']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.list_limits' % pb,
-                       autospec=True) as mock_list:
-                with pytest.raises(SystemExit) as excinfo:
-                    self.cls.console_entry_point()
-        assert excinfo.value.code == 0
-        assert mock_list.mock_calls == [
-            call(self.cls)
-        ]
 
-    def test_list_limits(self, capsys):
+class TestListLimits(RunnerTester):
+
+    def test_simple(self, capsys):
         mock_checker = Mock(spec_set=AwsLimitChecker)
         mock_checker.get_limits.return_value = sample_limits_api()
         self.cls.checker = mock_checker
@@ -482,7 +424,7 @@ class TestAwsLimitCheckerRunner(object):
             })
         ]
 
-    def test_list_limits_one_service(self, capsys):
+    def test_one_service(self, capsys):
         mock_checker = Mock(spec_set=AwsLimitChecker)
         mock_checker.get_limits.return_value = {
             'SvcFoo': sample_limits_api()['SvcFoo'],
@@ -505,146 +447,10 @@ class TestAwsLimitCheckerRunner(object):
             })
         ]
 
-    def test_entry_skip_service_none(self):
-        argv = ['awslimitchecker']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_check:
-                mock_check.return_value = 2
-                with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_c:
-                    with pytest.raises(SystemExit) as excinfo:
-                        self.cls.console_entry_point()
-        assert excinfo.value.code == 2
-        assert mock_c.mock_calls == [
-            call(account_id=None, account_role=None, critical_threshold=99,
-                 external_id=None, mfa_serial_number=None, mfa_token=None,
-                 profile_name=None, region=None, ta_refresh_mode=None,
-                 ta_refresh_timeout=None, warning_threshold=80,
-                 check_version=True)
-        ]
 
-    def test_entry_skip_service(self):
-        argv = ['awslimitchecker', '--skip-service=foo']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_check:
-                mock_check.return_value = 2
-                with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_c:
-                    with pytest.raises(SystemExit) as excinfo:
-                        self.cls.console_entry_point()
-        assert excinfo.value.code == 2
-        assert mock_c.mock_calls == [
-            call(account_id=None, account_role=None, critical_threshold=99,
-                 external_id=None, mfa_serial_number=None, mfa_token=None,
-                 profile_name=None, region=None, ta_refresh_mode=None,
-                 ta_refresh_timeout=None, warning_threshold=80,
-                 check_version=True),
-            call().remove_services(['foo'])
-        ]
+class TestSetLimitOverride(RunnerTester):
 
-    def test_entry_skip_service_multi(self):
-        argv = [
-            'awslimitchecker',
-            '--skip-service=foo',
-            '--skip-service', 'bar'
-        ]
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_check:
-                mock_check.return_value = 2
-                with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_c:
-                    with pytest.raises(SystemExit) as excinfo:
-                        self.cls.console_entry_point()
-        assert excinfo.value.code == 2
-        assert mock_c.mock_calls == [
-            call(account_id=None, account_role=None, critical_threshold=99,
-                 external_id=None, mfa_serial_number=None, mfa_token=None,
-                 profile_name=None, region=None, ta_refresh_mode=None,
-                 ta_refresh_timeout=None, warning_threshold=80,
-                 check_version=True),
-            call().remove_services(['foo', 'bar'])
-        ]
-
-    def test_entry_skip_check(self):
-        argv = [
-            'awslimitchecker',
-            '--skip-check=EC2/Max launch specifications per spot fleet'
-        ]
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_check:
-                mock_check.return_value = 2
-                with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_c:
-                    with pytest.raises(SystemExit) as excinfo:
-                        self.cls.console_entry_point()
-        assert excinfo.value.code == 2
-        assert mock_c.mock_calls == [
-            call(account_id=None, account_role=None, critical_threshold=99,
-                 external_id=None, mfa_serial_number=None, mfa_token=None,
-                 profile_name=None, region=None, ta_refresh_mode=None,
-                 ta_refresh_timeout=None, warning_threshold=80,
-                 check_version=True),
-        ]
-        assert self.cls.skip_check == [
-            'EC2/Max launch specifications per spot fleet',
-        ]
-
-    def test_entry_skip_check_multi(self):
-        argv = [
-            'awslimitchecker',
-            '--skip-check=EC2/Max launch specifications per spot fleet',
-            '--skip-check', 'EC2/Running On-Demand i3.large instances',
-        ]
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_check:
-                mock_check.return_value = 2
-                with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_c:
-                    with pytest.raises(SystemExit) as excinfo:
-                        self.cls.console_entry_point()
-        assert excinfo.value.code == 2
-        assert mock_c.mock_calls == [
-            call(account_id=None, account_role=None, critical_threshold=99,
-                 external_id=None, mfa_serial_number=None, mfa_token=None,
-                 profile_name=None, region=None, ta_refresh_mode=None,
-                 ta_refresh_timeout=None, warning_threshold=80,
-                 check_version=True),
-        ]
-        assert self.cls.skip_check == [
-            'EC2/Max launch specifications per spot fleet',
-            'EC2/Running On-Demand i3.large instances',
-        ]
-
-    def test_entry_limit(self):
-        argv = ['awslimitchecker', '-L', 'foo=bar']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb) as mock_ct:
-                with patch('%s.Runner.set_limit_overrides'
-                           '' % pb, autospec=True) as mock_slo:
-                    mock_ct.return_value = 0
-                    with pytest.raises(SystemExit) as excinfo:
-                        self.cls.console_entry_point()
-        assert excinfo.value.code == 0
-        assert mock_slo.mock_calls == [
-            call(self.cls, {'foo': 'bar'})
-        ]
-
-    def test_entry_limit_multi(self):
-        argv = ['awslimitchecker', '--limit=foo=bar', '--limit=baz=blam']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_ct:
-                with patch('%s.Runner.set_limit_overrides'
-                           '' % pb, autospec=True) as mock_slo:
-                    mock_ct.return_value = 0
-                    with pytest.raises(SystemExit) as excinfo:
-                        self.cls.console_entry_point()
-        assert excinfo.value.code == 0
-        assert mock_slo.mock_calls == [
-            call(self.cls, {'foo': 'bar', 'baz': 'blam'})
-        ]
-
-    def test_set_limit_overrides(self):
+    def test_simple(self):
         overrides = {
             'EC2/Foo bar': "2",
             'ElastiCache/Cache cluster subnet groups': "100",
@@ -661,7 +467,7 @@ class TestAwsLimitCheckerRunner(object):
             )
         ]
 
-    def test_set_limit_overrides_error(self):
+    def test_error(self):
         overrides = {
             'EC2': 2,
         }
@@ -677,18 +483,10 @@ class TestAwsLimitCheckerRunner(object):
         assert msg == "Limit names must be in " \
             "'service/limit' format; EC2 is invalid."
 
-    def test_entry_show_usage(self):
-        argv = ['awslimitchecker', '-u']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.show_usage' % pb, autospec=True) as mock_show:
-                with pytest.raises(SystemExit) as excinfo:
-                    self.cls.console_entry_point()
-        assert excinfo.value.code == 0
-        assert mock_show.mock_calls == [
-            call(self.cls)
-        ]
 
-    def test_show_usage(self, capsys):
+class TestShowUsage(RunnerTester):
+
+    def test_default(self, capsys):
         limits = sample_limits()
         limits['SvcFoo']['foo limit3']._add_current_usage(33)
         limits['SvcBar']['bar limit2']._add_current_usage(22)
@@ -713,7 +511,7 @@ class TestAwsLimitCheckerRunner(object):
             })
         ]
 
-    def test_show_usage_one_service(self, capsys):
+    def test_one_service(self, capsys):
         limits = {
             'SvcFoo': sample_limits()['SvcFoo'],
         }
@@ -738,310 +536,10 @@ class TestAwsLimitCheckerRunner(object):
             })
         ]
 
-    def test_entry_skip_ta(self, capsys):
-        argv = ['awslimitchecker', '--skip-ta']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_ct:
-                with pytest.raises(SystemExit) as excinfo:
-                    mock_ct.return_value = 6
-                    self.cls.console_entry_point()
-        out, err = capsys.readouterr()
-        assert out == ''
-        assert excinfo.value.code == 6
-        assert self.cls.skip_ta is True
 
-    def test_entry_service_name(self, capsys):
-        argv = ['awslimitchecker', '-S', 'foo']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_ct:
-                with pytest.raises(SystemExit) as excinfo:
-                    mock_ct.return_value = 6
-                    self.cls.console_entry_point()
-        out, err = capsys.readouterr()
-        assert out == ''
-        assert excinfo.value.code == 6
-        assert self.cls.service_name == ['foo']
+class TestCheckThresholds(RunnerTester):
 
-    def test_entry_no_service_name(self, capsys):
-        argv = ['awslimitchecker']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_ct:
-                with pytest.raises(SystemExit) as excinfo:
-                    mock_ct.return_value = 6
-                    self.cls.console_entry_point()
-        out, err = capsys.readouterr()
-        assert out == ''
-        assert excinfo.value.code == 6
-        assert self.cls.service_name is None
-
-    def test_entry_no_service_name_region(self, capsys):
-        argv = ['awslimitchecker', '-r', 'myregion']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_ct:
-                with patch('%s.AwsLimitChecker' % pb,
-                           spec_set=AwsLimitChecker) as mock_alc:
-                    with pytest.raises(SystemExit) as excinfo:
-                        mock_ct.return_value = 6
-                        self.cls.console_entry_point()
-        out, err = capsys.readouterr()
-        assert out == ''
-        assert excinfo.value.code == 6
-        assert mock_alc.mock_calls == [
-            call(
-                warning_threshold=80,
-                critical_threshold=99,
-                account_id=None,
-                account_role=None,
-                region='myregion',
-                external_id=None,
-                mfa_serial_number=None,
-                mfa_token=None,
-                profile_name=None,
-                ta_refresh_mode=None,
-                ta_refresh_timeout=None,
-                check_version=True
-            )
-        ]
-        assert self.cls.service_name is None
-
-    def test_entry_no_service_name_sts(self, capsys):
-        argv = [
-            'awslimitchecker',
-            '-r',
-            'myregion',
-            '-A',
-            '098765432109',
-            '-R',
-            'myrole'
-        ]
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_ct:
-                with patch('%s.AwsLimitChecker' % pb,
-                           spec_set=AwsLimitChecker) as mock_alc:
-                    with pytest.raises(SystemExit) as excinfo:
-                        mock_ct.return_value = 6
-                        self.cls.console_entry_point()
-        out, err = capsys.readouterr()
-        assert out == ''
-        assert excinfo.value.code == 6
-        assert mock_alc.mock_calls == [
-            call(
-                warning_threshold=80,
-                critical_threshold=99,
-                account_id='098765432109',
-                account_role='myrole',
-                region='myregion',
-                external_id=None,
-                mfa_serial_number=None,
-                mfa_token=None,
-                profile_name=None,
-                ta_refresh_mode=None,
-                ta_refresh_timeout=None,
-                check_version=True
-            )
-        ]
-        assert self.cls.service_name is None
-
-    def test_entry_no_service_name_sts_external_id(self, capsys):
-        argv = [
-            'awslimitchecker',
-            '-r',
-            'myregion',
-            '-A',
-            '098765432109',
-            '-R',
-            'myrole',
-            '-E',
-            'myextid',
-            '--no-check-version'
-        ]
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_ct:
-                with patch('%s.AwsLimitChecker' % pb,
-                           spec_set=AwsLimitChecker) as mock_alc:
-                    with pytest.raises(SystemExit) as excinfo:
-                        mock_ct.return_value = 6
-                        self.cls.console_entry_point()
-        out, err = capsys.readouterr()
-        assert out == ''
-        assert excinfo.value.code == 6
-        assert mock_alc.mock_calls == [
-            call(
-                warning_threshold=80,
-                critical_threshold=99,
-                account_id='098765432109',
-                account_role='myrole',
-                region='myregion',
-                external_id='myextid',
-                mfa_serial_number=None,
-                mfa_token=None,
-                profile_name=None,
-                ta_refresh_mode=None,
-                ta_refresh_timeout=None,
-                check_version=False
-            )
-        ]
-        assert self.cls.service_name is None
-
-    def test_entry_verbose(self, capsys):
-        argv = ['awslimitchecker', '-v']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_ct:
-                with patch('awslimitchecker.runner.logger.setLevel'
-                           '') as mock_set_level:
-                    with pytest.raises(SystemExit) as excinfo:
-                        mock_ct.return_value = 6
-                        self.cls.console_entry_point()
-        out, err = capsys.readouterr()
-        assert out == ''
-        assert excinfo.value.code == 6
-        assert mock_set_level.mock_calls == [call(logging.INFO)]
-
-    def test_entry_debug(self, capsys):
-        argv = ['awslimitchecker', '-vv']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_ct:
-                with patch('awslimitchecker.runner.logger.setLevel'
-                           '') as mock_set_level:
-                    with pytest.raises(SystemExit) as excinfo:
-                        mock_ct.return_value = 7
-                        self.cls.console_entry_point()
-        out, err = capsys.readouterr()
-        assert out == ''
-        assert excinfo.value.args[0] == 7
-        assert mock_set_level.mock_calls == [call(logging.DEBUG)]
-
-    def test_entry_warning(self):
-        argv = ['awslimitchecker', '-W', '50']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_alc:
-                with patch('%s.Runner.check_thresholds' % pb,
-                           autospec=True) as mock_ct:
-                    with pytest.raises(SystemExit) as excinfo:
-                        mock_ct.return_value = 8
-                        self.cls.console_entry_point()
-        assert excinfo.value.code == 8
-        assert mock_alc.mock_calls == [
-            call(
-                warning_threshold=50,
-                critical_threshold=99,
-                account_id=None,
-                account_role=None,
-                region=None,
-                external_id=None,
-                mfa_serial_number=None,
-                mfa_token=None,
-                profile_name=None,
-                ta_refresh_mode=None,
-                ta_refresh_timeout=None,
-                check_version=True
-            )
-        ]
-
-    def test_entry_warning_profile_name(self):
-        argv = ['awslimitchecker', '-W', '50', '-P', 'myprof']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_alc:
-                with patch('%s.Runner.check_thresholds' % pb,
-                           autospec=True) as mock_ct:
-                    with pytest.raises(SystemExit) as excinfo:
-                        mock_ct.return_value = 8
-                        self.cls.console_entry_point()
-        assert excinfo.value.code == 8
-        assert mock_alc.mock_calls == [
-            call(
-                warning_threshold=50,
-                critical_threshold=99,
-                account_id=None,
-                account_role=None,
-                region=None,
-                external_id=None,
-                mfa_serial_number=None,
-                mfa_token=None,
-                profile_name='myprof',
-                ta_refresh_mode=None,
-                ta_refresh_timeout=None,
-                check_version=True
-            )
-        ]
-
-    def test_entry_critical(self):
-        argv = ['awslimitchecker', '-C', '95']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_alc:
-                with patch('%s.Runner.check_thresholds' % pb,
-                           autospec=True) as mock_ct:
-                    with pytest.raises(SystemExit) as excinfo:
-                        mock_ct.return_value = 9
-                        self.cls.console_entry_point()
-        assert excinfo.value.code == 9
-        assert mock_alc.mock_calls == [
-            call(
-                warning_threshold=80,
-                critical_threshold=95,
-                account_id=None,
-                account_role=None,
-                region=None,
-                external_id=None,
-                mfa_serial_number=None,
-                mfa_token=None,
-                profile_name=None,
-                ta_refresh_mode=None,
-                ta_refresh_timeout=None,
-                check_version=True
-            )
-        ]
-
-    def test_entry_critical_ta_refresh(self):
-        argv = ['awslimitchecker', '-C', '95', '--ta-refresh-timeout=123',
-                '--ta-refresh-older=456']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_alc:
-                with patch('%s.Runner.check_thresholds' % pb,
-                           autospec=True) as mock_ct:
-                    with pytest.raises(SystemExit) as excinfo:
-                        mock_ct.return_value = 9
-                        self.cls.console_entry_point()
-        assert excinfo.value.code == 9
-        assert mock_alc.mock_calls == [
-            call(
-                warning_threshold=80,
-                critical_threshold=95,
-                account_id=None,
-                account_role=None,
-                region=None,
-                external_id=None,
-                mfa_serial_number=None,
-                mfa_token=None,
-                profile_name=None,
-                ta_refresh_mode=456,
-                ta_refresh_timeout=123,
-                check_version=True
-            )
-        ]
-
-    def test_entry_check_thresholds(self):
-        argv = ['awslimitchecker']
-        with patch.object(sys, 'argv', argv):
-            with patch('%s.Runner.check_thresholds' % pb,
-                       autospec=True) as mock_ct:
-                with pytest.raises(SystemExit) as excinfo:
-                    mock_ct.return_value = 10
-                    self.cls.console_entry_point()
-        assert excinfo.value.code == 10
-        assert mock_ct.mock_calls == [
-            call(self.cls)
-        ]
-
-    def test_check_thresholds_ok(self, capsys):
+    def test_ok(self, capsys):
         """no problems, return 0 and print nothing"""
         mock_checker = Mock(spec_set=AwsLimitChecker)
         mock_checker.check_thresholds.return_value = {}
@@ -1056,7 +554,7 @@ class TestAwsLimitCheckerRunner(object):
         ]
         assert res == 0
 
-    def test_check_thresholds_many_problems(self):
+    def test_many_problems(self):
         """lots of problems"""
         mock_limit1 = Mock(spec_set=AwsLimit)
         type(mock_limit1).name = 'limit1'
@@ -1124,7 +622,7 @@ class TestAwsLimitCheckerRunner(object):
         ]
         assert res == 2
 
-    def test_check_thresholds_when_skip_check(self):
+    def test_when_skip_check(self):
         """lots of problems"""
         mock_limit1 = Mock(spec_set=AwsLimit)
         type(mock_limit1).name = 'limit1'
@@ -1172,7 +670,7 @@ class TestAwsLimitCheckerRunner(object):
         ]
         assert res == 1
 
-    def test_check_thresholds_warn(self):
+    def test_warn(self):
         """just warnings"""
         mock_limit1 = Mock(spec_set=AwsLimit)
         mock_w1 = Mock(spec_set=AwsLimitUsage)
@@ -1211,7 +709,7 @@ class TestAwsLimitCheckerRunner(object):
         ]
         assert res == 1
 
-    def test_check_thresholds_warn_one_service(self):
+    def test_warn_one_service(self):
         """just warnings"""
         mock_limit1 = Mock(spec_set=AwsLimit)
         mock_w1 = Mock(spec_set=AwsLimitUsage)
@@ -1247,7 +745,7 @@ class TestAwsLimitCheckerRunner(object):
         ]
         assert res == 1
 
-    def test_check_thresholds_crit(self):
+    def test_crit(self):
         """only critical"""
         mock_limit1 = Mock(spec_set=AwsLimit)
         mock_limit1.get_warnings.return_value = []
@@ -1278,7 +776,10 @@ class TestAwsLimitCheckerRunner(object):
         ]
         assert res == 2
 
-    def test_print_issue_crit_one(self):
+
+class TestPrintIssue(RunnerTester):
+
+    def test_crit_one(self):
         mock_limit = Mock(spec_set=AwsLimit)
         type(mock_limit).name = 'limitname'
         mock_limit.get_limit.return_value = 12
@@ -1294,7 +795,7 @@ class TestAwsLimitCheckerRunner(object):
         assert res == ('svcname/limitname',
                        '(limit 12) ' + red('CRITICAL: 56'))
 
-    def test_print_issue_crit_multi(self):
+    def test_crit_multi(self):
         mock_limit = Mock(spec_set=AwsLimit)
         type(mock_limit).name = 'limitname'
         mock_limit.get_limit.return_value = 5
@@ -1312,7 +813,7 @@ class TestAwsLimitCheckerRunner(object):
         assert res == ('svcname/limitname',
                        '(limit 5) ' + red('CRITICAL: 8, 10, c2id=12'))
 
-    def test_print_issue_warn_one(self):
+    def test_warn_one(self):
         mock_limit = Mock(spec_set=AwsLimit)
         type(mock_limit).name = 'limitname'
         mock_limit.get_limit.return_value = 12
@@ -1328,7 +829,7 @@ class TestAwsLimitCheckerRunner(object):
         assert res == ('svcname/limitname', '(limit 12) ' +
                        yellow('WARNING: 11'))
 
-    def test_print_issue_warn_multi(self):
+    def test_warn_multi(self):
         mock_limit = Mock(spec_set=AwsLimit)
         type(mock_limit).name = 'limitname'
         mock_limit.get_limit.return_value = 12
@@ -1347,7 +848,7 @@ class TestAwsLimitCheckerRunner(object):
                        '(limit 12) ' + yellow('WARNING: '
                                               'w2id=10, w3id=10, 11'))
 
-    def test_print_issue_both_one(self):
+    def test_both_one(self):
         mock_limit = Mock(spec_set=AwsLimit)
         type(mock_limit).name = 'limitname'
         mock_limit.get_limit.return_value = 12
@@ -1366,7 +867,7 @@ class TestAwsLimitCheckerRunner(object):
                        red('CRITICAL: 10') + ' ' +
                        yellow('WARNING: w3id=10'))
 
-    def test_print_issue_both_multi(self):
+    def test_both_multi(self):
         mock_limit = Mock(spec_set=AwsLimit)
         type(mock_limit).name = 'limitname'
         mock_limit.get_limit.return_value = 12
@@ -1389,7 +890,549 @@ class TestAwsLimitCheckerRunner(object):
                        red('CRITICAL: 8, 10, c2id=12') + ' ' +
                        yellow('WARNING: w2id=10, w3id=10, 11'))
 
-    def test_entry_no_color(self):
+
+class TestColorOutput(RunnerTester):
+
+    def test_simple(self):
+        assert self.cls.color_output('foo', 'yellow') == termcolor.colored(
+            'foo', 'yellow')
+
+
+class TestConsoleEntryPoint(RunnerTester):
+
+    def test_version(self, capsys):
+        argv = ['awslimitchecker', '-V']
+        expected = 'awslimitchecker ver (see <foo> for source code)\n'
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.AwsLimitChecker' % pb,
+                       spec_set=AwsLimitChecker) as mock_alc:
+                mock_alc.return_value.get_project_url.return_value = 'foo'
+                mock_alc.return_value.get_version.return_value = 'ver'
+                with pytest.raises(SystemExit) as excinfo:
+                    self.cls.console_entry_point()
+        out, err = capsys.readouterr()
+        assert out == expected
+        assert excinfo.value.code == 0
+        assert mock_alc.mock_calls == [
+            call(
+                warning_threshold=80,
+                critical_threshold=99,
+                account_id=None,
+                account_role=None,
+                region=None,
+                external_id=None,
+                mfa_serial_number=None,
+                mfa_token=None,
+                profile_name=None,
+                ta_refresh_mode=None,
+                ta_refresh_timeout=None,
+                check_version=True
+            ),
+            call().get_project_url(),
+            call().get_version()
+        ]
+
+    def test_list_services(self):
+        argv = ['awslimitchecker', '-s']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.list_services' % pb,
+                       autospec=True) as mock_list:
+                with pytest.raises(SystemExit) as excinfo:
+                    self.cls.console_entry_point()
+        assert excinfo.value.code == 0
+        assert mock_list.mock_calls == [
+            call(self.cls)
+        ]
+
+    def test_iam_policy(self):
+        argv = ['awslimitchecker', '--iam-policy']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.iam_policy' % pb, autospec=True) as mock_iam:
+                with pytest.raises(SystemExit) as excinfo:
+                    self.cls.console_entry_point()
+        assert excinfo.value.code == 0
+        assert mock_iam.mock_calls == [
+            call(self.cls)
+        ]
+
+    def test_list_defaults(self):
+        argv = ['awslimitchecker', '--list-defaults']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.list_defaults' % pb,
+                       autospec=True) as mock_list:
+                with pytest.raises(SystemExit) as excinfo:
+                    self.cls.console_entry_point()
+        assert excinfo.value.code == 0
+        assert mock_list.mock_calls == [
+            call(self.cls)
+        ]
+
+    def test_list_limits(self):
+        argv = ['awslimitchecker', '-l']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.list_limits' % pb,
+                       autospec=True) as mock_list:
+                with pytest.raises(SystemExit) as excinfo:
+                    self.cls.console_entry_point()
+        assert excinfo.value.code == 0
+        assert mock_list.mock_calls == [
+            call(self.cls)
+        ]
+
+    def test_skip_service_none(self):
+        argv = ['awslimitchecker']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_check:
+                mock_check.return_value = 2
+                with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_c:
+                    with pytest.raises(SystemExit) as excinfo:
+                        self.cls.console_entry_point()
+        assert excinfo.value.code == 2
+        assert mock_c.mock_calls == [
+            call(account_id=None, account_role=None, critical_threshold=99,
+                 external_id=None, mfa_serial_number=None, mfa_token=None,
+                 profile_name=None, region=None, ta_refresh_mode=None,
+                 ta_refresh_timeout=None, warning_threshold=80,
+                 check_version=True)
+        ]
+
+    def test_skip_service(self):
+        argv = ['awslimitchecker', '--skip-service=foo']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_check:
+                mock_check.return_value = 2
+                with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_c:
+                    with pytest.raises(SystemExit) as excinfo:
+                        self.cls.console_entry_point()
+        assert excinfo.value.code == 2
+        assert mock_c.mock_calls == [
+            call(account_id=None, account_role=None, critical_threshold=99,
+                 external_id=None, mfa_serial_number=None, mfa_token=None,
+                 profile_name=None, region=None, ta_refresh_mode=None,
+                 ta_refresh_timeout=None, warning_threshold=80,
+                 check_version=True),
+            call().remove_services(['foo'])
+        ]
+
+    def test_skip_service_multi(self):
+        argv = [
+            'awslimitchecker',
+            '--skip-service=foo',
+            '--skip-service', 'bar'
+        ]
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_check:
+                mock_check.return_value = 2
+                with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_c:
+                    with pytest.raises(SystemExit) as excinfo:
+                        self.cls.console_entry_point()
+        assert excinfo.value.code == 2
+        assert mock_c.mock_calls == [
+            call(account_id=None, account_role=None, critical_threshold=99,
+                 external_id=None, mfa_serial_number=None, mfa_token=None,
+                 profile_name=None, region=None, ta_refresh_mode=None,
+                 ta_refresh_timeout=None, warning_threshold=80,
+                 check_version=True),
+            call().remove_services(['foo', 'bar'])
+        ]
+
+    def test_skip_check(self):
+        argv = [
+            'awslimitchecker',
+            '--skip-check=EC2/Max launch specifications per spot fleet'
+        ]
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_check:
+                mock_check.return_value = 2
+                with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_c:
+                    with pytest.raises(SystemExit) as excinfo:
+                        self.cls.console_entry_point()
+        assert excinfo.value.code == 2
+        assert mock_c.mock_calls == [
+            call(account_id=None, account_role=None, critical_threshold=99,
+                 external_id=None, mfa_serial_number=None, mfa_token=None,
+                 profile_name=None, region=None, ta_refresh_mode=None,
+                 ta_refresh_timeout=None, warning_threshold=80,
+                 check_version=True),
+        ]
+        assert self.cls.skip_check == [
+            'EC2/Max launch specifications per spot fleet',
+        ]
+
+    def test_skip_check_multi(self):
+        argv = [
+            'awslimitchecker',
+            '--skip-check=EC2/Max launch specifications per spot fleet',
+            '--skip-check', 'EC2/Running On-Demand i3.large instances',
+        ]
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_check:
+                mock_check.return_value = 2
+                with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_c:
+                    with pytest.raises(SystemExit) as excinfo:
+                        self.cls.console_entry_point()
+        assert excinfo.value.code == 2
+        assert mock_c.mock_calls == [
+            call(account_id=None, account_role=None, critical_threshold=99,
+                 external_id=None, mfa_serial_number=None, mfa_token=None,
+                 profile_name=None, region=None, ta_refresh_mode=None,
+                 ta_refresh_timeout=None, warning_threshold=80,
+                 check_version=True),
+        ]
+        assert self.cls.skip_check == [
+            'EC2/Max launch specifications per spot fleet',
+            'EC2/Running On-Demand i3.large instances',
+        ]
+
+    def test_limit(self):
+        argv = ['awslimitchecker', '-L', 'foo=bar']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb) as mock_ct:
+                with patch('%s.Runner.set_limit_overrides'
+                           '' % pb, autospec=True) as mock_slo:
+                    mock_ct.return_value = 0
+                    with pytest.raises(SystemExit) as excinfo:
+                        self.cls.console_entry_point()
+        assert excinfo.value.code == 0
+        assert mock_slo.mock_calls == [
+            call(self.cls, {'foo': 'bar'})
+        ]
+
+    def test_limit_multi(self):
+        argv = ['awslimitchecker', '--limit=foo=bar', '--limit=baz=blam']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_ct:
+                with patch('%s.Runner.set_limit_overrides'
+                           '' % pb, autospec=True) as mock_slo:
+                    mock_ct.return_value = 0
+                    with pytest.raises(SystemExit) as excinfo:
+                        self.cls.console_entry_point()
+        assert excinfo.value.code == 0
+        assert mock_slo.mock_calls == [
+            call(self.cls, {'foo': 'bar', 'baz': 'blam'})
+        ]
+
+    def test_show_usage(self):
+        argv = ['awslimitchecker', '-u']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.show_usage' % pb, autospec=True) as mock_show:
+                with pytest.raises(SystemExit) as excinfo:
+                    self.cls.console_entry_point()
+        assert excinfo.value.code == 0
+        assert mock_show.mock_calls == [
+            call(self.cls)
+        ]
+
+    def test_skip_ta(self, capsys):
+        argv = ['awslimitchecker', '--skip-ta']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_ct:
+                with pytest.raises(SystemExit) as excinfo:
+                    mock_ct.return_value = 6
+                    self.cls.console_entry_point()
+        out, err = capsys.readouterr()
+        assert out == ''
+        assert excinfo.value.code == 6
+        assert self.cls.skip_ta is True
+
+    def test_service_name(self, capsys):
+        argv = ['awslimitchecker', '-S', 'foo']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_ct:
+                with pytest.raises(SystemExit) as excinfo:
+                    mock_ct.return_value = 6
+                    self.cls.console_entry_point()
+        out, err = capsys.readouterr()
+        assert out == ''
+        assert excinfo.value.code == 6
+        assert self.cls.service_name == ['foo']
+
+    def test_no_service_name(self, capsys):
+        argv = ['awslimitchecker']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_ct:
+                with pytest.raises(SystemExit) as excinfo:
+                    mock_ct.return_value = 6
+                    self.cls.console_entry_point()
+        out, err = capsys.readouterr()
+        assert out == ''
+        assert excinfo.value.code == 6
+        assert self.cls.service_name is None
+
+    def test_no_service_name_region(self, capsys):
+        argv = ['awslimitchecker', '-r', 'myregion']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_ct:
+                with patch('%s.AwsLimitChecker' % pb,
+                           spec_set=AwsLimitChecker) as mock_alc:
+                    with pytest.raises(SystemExit) as excinfo:
+                        mock_ct.return_value = 6
+                        self.cls.console_entry_point()
+        out, err = capsys.readouterr()
+        assert out == ''
+        assert excinfo.value.code == 6
+        assert mock_alc.mock_calls == [
+            call(
+                warning_threshold=80,
+                critical_threshold=99,
+                account_id=None,
+                account_role=None,
+                region='myregion',
+                external_id=None,
+                mfa_serial_number=None,
+                mfa_token=None,
+                profile_name=None,
+                ta_refresh_mode=None,
+                ta_refresh_timeout=None,
+                check_version=True
+            )
+        ]
+        assert self.cls.service_name is None
+
+    def test_no_service_name_sts(self, capsys):
+        argv = [
+            'awslimitchecker',
+            '-r',
+            'myregion',
+            '-A',
+            '098765432109',
+            '-R',
+            'myrole'
+        ]
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_ct:
+                with patch('%s.AwsLimitChecker' % pb,
+                           spec_set=AwsLimitChecker) as mock_alc:
+                    with pytest.raises(SystemExit) as excinfo:
+                        mock_ct.return_value = 6
+                        self.cls.console_entry_point()
+        out, err = capsys.readouterr()
+        assert out == ''
+        assert excinfo.value.code == 6
+        assert mock_alc.mock_calls == [
+            call(
+                warning_threshold=80,
+                critical_threshold=99,
+                account_id='098765432109',
+                account_role='myrole',
+                region='myregion',
+                external_id=None,
+                mfa_serial_number=None,
+                mfa_token=None,
+                profile_name=None,
+                ta_refresh_mode=None,
+                ta_refresh_timeout=None,
+                check_version=True
+            )
+        ]
+        assert self.cls.service_name is None
+
+    def test_no_service_name_sts_external_id(self, capsys):
+        argv = [
+            'awslimitchecker',
+            '-r',
+            'myregion',
+            '-A',
+            '098765432109',
+            '-R',
+            'myrole',
+            '-E',
+            'myextid',
+            '--no-check-version'
+        ]
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_ct:
+                with patch('%s.AwsLimitChecker' % pb,
+                           spec_set=AwsLimitChecker) as mock_alc:
+                    with pytest.raises(SystemExit) as excinfo:
+                        mock_ct.return_value = 6
+                        self.cls.console_entry_point()
+        out, err = capsys.readouterr()
+        assert out == ''
+        assert excinfo.value.code == 6
+        assert mock_alc.mock_calls == [
+            call(
+                warning_threshold=80,
+                critical_threshold=99,
+                account_id='098765432109',
+                account_role='myrole',
+                region='myregion',
+                external_id='myextid',
+                mfa_serial_number=None,
+                mfa_token=None,
+                profile_name=None,
+                ta_refresh_mode=None,
+                ta_refresh_timeout=None,
+                check_version=False
+            )
+        ]
+        assert self.cls.service_name is None
+
+    def test_verbose(self, capsys):
+        argv = ['awslimitchecker', '-v']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_ct:
+                with patch('awslimitchecker.runner.logger.setLevel'
+                           '') as mock_set_level:
+                    with pytest.raises(SystemExit) as excinfo:
+                        mock_ct.return_value = 6
+                        self.cls.console_entry_point()
+        out, err = capsys.readouterr()
+        assert out == ''
+        assert excinfo.value.code == 6
+        assert mock_set_level.mock_calls == [call(logging.INFO)]
+
+    def test_debug(self, capsys):
+        argv = ['awslimitchecker', '-vv']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_ct:
+                with patch('awslimitchecker.runner.logger.setLevel'
+                           '') as mock_set_level:
+                    with pytest.raises(SystemExit) as excinfo:
+                        mock_ct.return_value = 7
+                        self.cls.console_entry_point()
+        out, err = capsys.readouterr()
+        assert out == ''
+        assert excinfo.value.args[0] == 7
+        assert mock_set_level.mock_calls == [call(logging.DEBUG)]
+
+    def test_warning(self):
+        argv = ['awslimitchecker', '-W', '50']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_alc:
+                with patch('%s.Runner.check_thresholds' % pb,
+                           autospec=True) as mock_ct:
+                    with pytest.raises(SystemExit) as excinfo:
+                        mock_ct.return_value = 8
+                        self.cls.console_entry_point()
+        assert excinfo.value.code == 8
+        assert mock_alc.mock_calls == [
+            call(
+                warning_threshold=50,
+                critical_threshold=99,
+                account_id=None,
+                account_role=None,
+                region=None,
+                external_id=None,
+                mfa_serial_number=None,
+                mfa_token=None,
+                profile_name=None,
+                ta_refresh_mode=None,
+                ta_refresh_timeout=None,
+                check_version=True
+            )
+        ]
+
+    def test_warning_profile_name(self):
+        argv = ['awslimitchecker', '-W', '50', '-P', 'myprof']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_alc:
+                with patch('%s.Runner.check_thresholds' % pb,
+                           autospec=True) as mock_ct:
+                    with pytest.raises(SystemExit) as excinfo:
+                        mock_ct.return_value = 8
+                        self.cls.console_entry_point()
+        assert excinfo.value.code == 8
+        assert mock_alc.mock_calls == [
+            call(
+                warning_threshold=50,
+                critical_threshold=99,
+                account_id=None,
+                account_role=None,
+                region=None,
+                external_id=None,
+                mfa_serial_number=None,
+                mfa_token=None,
+                profile_name='myprof',
+                ta_refresh_mode=None,
+                ta_refresh_timeout=None,
+                check_version=True
+            )
+        ]
+
+    def test_critical(self):
+        argv = ['awslimitchecker', '-C', '95']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_alc:
+                with patch('%s.Runner.check_thresholds' % pb,
+                           autospec=True) as mock_ct:
+                    with pytest.raises(SystemExit) as excinfo:
+                        mock_ct.return_value = 9
+                        self.cls.console_entry_point()
+        assert excinfo.value.code == 9
+        assert mock_alc.mock_calls == [
+            call(
+                warning_threshold=80,
+                critical_threshold=95,
+                account_id=None,
+                account_role=None,
+                region=None,
+                external_id=None,
+                mfa_serial_number=None,
+                mfa_token=None,
+                profile_name=None,
+                ta_refresh_mode=None,
+                ta_refresh_timeout=None,
+                check_version=True
+            )
+        ]
+
+    def test_critical_ta_refresh(self):
+        argv = ['awslimitchecker', '-C', '95', '--ta-refresh-timeout=123',
+                '--ta-refresh-older=456']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.AwsLimitChecker' % pb, autospec=True) as mock_alc:
+                with patch('%s.Runner.check_thresholds' % pb,
+                           autospec=True) as mock_ct:
+                    with pytest.raises(SystemExit) as excinfo:
+                        mock_ct.return_value = 9
+                        self.cls.console_entry_point()
+        assert excinfo.value.code == 9
+        assert mock_alc.mock_calls == [
+            call(
+                warning_threshold=80,
+                critical_threshold=95,
+                account_id=None,
+                account_role=None,
+                region=None,
+                external_id=None,
+                mfa_serial_number=None,
+                mfa_token=None,
+                profile_name=None,
+                ta_refresh_mode=456,
+                ta_refresh_timeout=123,
+                check_version=True
+            )
+        ]
+
+    def test_check_thresholds(self):
+        argv = ['awslimitchecker']
+        with patch.object(sys, 'argv', argv):
+            with patch('%s.Runner.check_thresholds' % pb,
+                       autospec=True) as mock_ct:
+                with pytest.raises(SystemExit) as excinfo:
+                    mock_ct.return_value = 10
+                    self.cls.console_entry_point()
+        assert excinfo.value.code == 10
+        assert mock_ct.mock_calls == [
+            call(self.cls)
+        ]
+
+    def test_no_color(self):
         argv = ['awslimitchecker', '--no-color']
         with patch.object(sys, 'argv', argv):
             with patch('%s.Runner.check_thresholds' % pb,
@@ -1400,7 +1443,3 @@ class TestAwsLimitCheckerRunner(object):
         assert excinfo.value.code == 0
         assert self.cls.color_output('foo', 'red') == 'foo'
         self.cls.colorize = True
-
-    def test_color_output(self):
-        assert self.cls.color_output('foo', 'yellow') == termcolor.colored(
-            'foo', 'yellow')

--- a/docs/build_generated_docs.py
+++ b/docs/build_generated_docs.py
@@ -282,6 +282,11 @@ def format_cmd_output(cmd, output, name):
     for line in lines:
         if line.strip() == '':
             continue
+        if (
+            name == 'check_thresholds_custom' and
+            'VPC security groups per elastic network interface' in line
+        ):
+            continue
         formatted += '   ' + line + "\n"
     formatted += '\n'
     return formatted

--- a/docs/build_generated_docs.py
+++ b/docs/build_generated_docs.py
@@ -237,6 +237,7 @@ def build_runner_examples():
         except subprocess.CalledProcessError as e:
             output = e.output
         results[name] = format_cmd_output(cmd_str, output, name)
+        results['%s-output-only' % name] = format_cmd_output(None, output, name)
     tmpl = tmpl.format(**results)
 
     # write out the final .rst
@@ -246,8 +247,11 @@ def build_runner_examples():
 
 def format_cmd_output(cmd, output, name):
     """format command output for docs"""
-    formatted = '.. code-block:: console\n\n'
-    formatted += '   (venv)$ {c}\n'.format(c=cmd)
+    if cmd is None:
+        formatted = ''
+    else:
+        formatted = '.. code-block:: console\n\n'
+        formatted += '   (venv)$ {c}\n'.format(c=cmd)
     lines = output.split("\n")
     if name != 'help':
         for idx, line in enumerate(lines):

--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -320,7 +320,7 @@ For example, to override the limits of EC2's "EC2-Classic Elastic IPs" and
 
 This example simply sets the overrides, and then prints the limits for confirmation.
 
-You could also set the same limit overrides using a JSON file stored at ``limit_overrides.json``:
+You could also set the same limit overrides using a JSON file stored at ``limit_overrides.json``, following the format documented for :py:meth:`awslimitchecker.checker.Checker.set_limit_overrides`:
 
 .. code-block:: json
 
@@ -385,7 +385,7 @@ threshold only, and another has crossed the critical threshold):
    VPC/NAT Gateways per AZ                                (limit 5) CRITICAL: us-east-1d=9, us-east-1c= (...)
    VPC/Virtual private gateways                           (limit 5) CRITICAL: 6
 
-
+.. _cli_usage.threshold_overrides:
 
 Set Custom Thresholds
 +++++++++++++++++++++
@@ -405,7 +405,60 @@ To set the warning threshold of 50% and a critical threshold of 75% when checkin
    VPC/NAT Gateways per AZ                                (limit 5) CRITICAL: us-east-1d=7, us-east-1c= (...)
    VPC/Virtual private gateways                           (limit 5) CRITICAL: 5
 
+You can also set custom thresholds on a per-limit basis using the
+``--threshold-override-json`` CLI option, which accepts the path to a JSON file
+(local or an s3:// URL) matching the format described in
+:py:meth:`awslimitchecker.checker.Checker.set_threshold_overrides`, for example:
 
+.. code-block:: json
+
+    {
+        "S3": {
+            "Buckets": {
+                "warning": {
+                    "percent": 97
+                },
+                "critical": {
+                    "percent": 99
+                }
+            }
+        },
+        "EC2": {
+            "Security groups per VPC": {
+                "warning": {
+                    "percent": 80,
+                    "count": 800
+                },
+                "critical": {
+                    "percent": 90,
+                    "count": 900
+                }
+            },
+            "VPC security groups per elastic network interface": {
+                "warning": {
+                    "percent": 101
+                },
+                "critical": {
+                    "percent": 101
+                }
+            }
+        }
+    }
+
+Using a command like:
+
+.. code-block:: console
+
+   (venv)$ awslimitchecker -W 97 --critical=98 --no-color --threshold-overrides-json=s3://bucketname/path/overrides.json
+   ApiGateway/APIs per account                            (limit 60) CRITICAL: 98
+   DynamoDB/Local Secondary Indexes                       (limit 5) CRITICAL: sale_setup_draft_vehicles (...)
+   DynamoDB/Tables Per Region                             (limit 256) WARNING: 250
+   EC2/Security groups per VPC                            (limit 500) CRITICAL: vpc-c89074a9=863
+   EC2/VPC security groups per elastic network interface  (limit 5) CRITICAL: eni-8226ce61=5
+   (...)
+   S3/Buckets                                             (limit 100) CRITICAL: 657
+   VPC/NAT Gateways per AZ                                (limit 5) CRITICAL: us-east-1d=7, us-east-1c= (...)
+   VPC/Virtual private gateways                           (limit 5) CRITICAL: 5
 
 Required IAM Policy
 +++++++++++++++++++
@@ -428,10 +481,11 @@ permissions for it to perform all limit checks. This can be viewed with the
      "Version": "2012-10-17"
    }
 
-
-
 For the current IAM Policy required by this version of awslimitchecker,
 see :ref:`IAM Policy <iam_policy>`.
+
+.. important::
+   The required IAM policy output by awslimitchecker includes only the permissions required to check limits and usage. If you are loading :ref:`limit overrides <cli_usage.limit_overrides>` and/or :ref:`threshold overrides <cli_usage.threshold_overrides>` from S3, you will need to run awslimitchecker with additional permissions to access those objects.
 
 Connect to a Specific Region
 ++++++++++++++++++++++++++++

--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -285,16 +285,20 @@ using their IDs).
 
 
 
+.. _cli_usage.limit_overrides:
+
 Overriding Limits
 +++++++++++++++++
 
 In cases where you've been given a limit increase by AWS Support, you can override
 the default limits with custom ones. Currently, to do this from the command line,
-you must specify each limit that you want to override separately (the
+you can either specify each limit that you want to override separately using the
+``-L`` or ``--limit`` options, or you can specify a JSON file at either a local path
+or an S3 URL using the ``--limit-overrides-json`` option (the
 :py:meth:`~.AwsLimitChecker.set_limit_overrides` Python method accepts a dict for
-easy bulk overrides of limits) using the ``-L`` or ``--limit`` options. Limits are
-specified in a ``service_name/limit_name=value`` format, and must be quoted if the
-limit name contains spaces.
+easy bulk overrides of limits). Limits for the ``-L`` / ``--limit`` option are
+specified in a ``service_name/limit_name=value`` format, and must be quoted if
+the limit name contains spaces.
 
 For example, to override the limits of EC2's "EC2-Classic Elastic IPs" and
 "EC2-VPC Elastic IPs" from their defaults of 5, to 10 and 20, respestively:
@@ -314,9 +318,36 @@ For example, to override the limits of EC2's "EC2-Classic Elastic IPs" and
    VPC/VPCs                                               1000 (TA)
    VPC/Virtual private gateways                           5
 
-
-
 This example simply sets the overrides, and then prints the limits for confirmation.
+
+You could also set the same limit overrides using a JSON file stored at ``limit_overrides.json``:
+
+.. code-block:: json
+
+    {
+        "AutoScaling": {
+            "Auto Scaling groups": 321,
+            "Launch configurations": 456
+        }
+    }
+
+Using a command like:
+
+.. code-block:: console
+
+   (venv)$ awslimitchecker --limit-overrides-json=limit_overrides.json -l
+   ApiGateway/API keys per account                        500
+   ApiGateway/APIs per account                            60
+   ApiGateway/Client certificates per account             60
+   ApiGateway/Custom authorizers per API                  10
+   ApiGateway/Documentation parts per API                 2000
+   (...)
+   CloudFormation/Stacks                                  2500 (API)
+   (...)
+   VPC/Subnets per VPC                                    200
+   VPC/VPCs                                               1000 (TA)
+   VPC/Virtual private gateways                           5
+
 
 Check Limits Against Thresholds
 +++++++++++++++++++++++++++++++

--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -320,7 +320,7 @@ For example, to override the limits of EC2's "EC2-Classic Elastic IPs" and
 
 This example simply sets the overrides, and then prints the limits for confirmation.
 
-You could also set the same limit overrides using a JSON file stored at ``limit_overrides.json``, following the format documented for :py:meth:`awslimitchecker.checker.Checker.set_limit_overrides`:
+You could also set the same limit overrides using a JSON file stored at ``limit_overrides.json``, following the format documented for :py:meth:`awslimitchecker.checker.AwsLimitChecker.set_limit_overrides`:
 
 .. code-block:: json
 
@@ -408,7 +408,7 @@ To set the warning threshold of 50% and a critical threshold of 75% when checkin
 You can also set custom thresholds on a per-limit basis using the
 ``--threshold-override-json`` CLI option, which accepts the path to a JSON file
 (local or an s3:// URL) matching the format described in
-:py:meth:`awslimitchecker.checker.Checker.set_threshold_overrides`, for example:
+:py:meth:`awslimitchecker.checker.AwsLimitChecker.set_threshold_overrides`, for example:
 
 .. code-block:: json
 

--- a/docs/source/cli_usage.rst.template
+++ b/docs/source/cli_usage.rst.template
@@ -118,16 +118,20 @@ using their IDs).
 
 {show_usage}
 
+.. _cli_usage.limit_overrides:
+
 Overriding Limits
 +++++++++++++++++
 
 In cases where you've been given a limit increase by AWS Support, you can override
 the default limits with custom ones. Currently, to do this from the command line,
-you must specify each limit that you want to override separately (the
+you can either specify each limit that you want to override separately using the
+``-L`` or ``--limit`` options, or you can specify a JSON file at either a local path
+or an S3 URL using the ``--limit-overrides-json`` option (the
 :py:meth:`~.AwsLimitChecker.set_limit_overrides` Python method accepts a dict for
-easy bulk overrides of limits) using the ``-L`` or ``--limit`` options. Limits are
-specified in a ``service_name/limit_name=value`` format, and must be quoted if the
-limit name contains spaces.
+easy bulk overrides of limits). Limits for the ``-L`` / ``--limit`` option are
+specified in a ``service_name/limit_name=value`` format, and must be quoted if
+the limit name contains spaces.
 
 For example, to override the limits of EC2's "EC2-Classic Elastic IPs" and
 "EC2-VPC Elastic IPs" from their defaults of 5, to 10 and 20, respestively:
@@ -135,6 +139,24 @@ For example, to override the limits of EC2's "EC2-Classic Elastic IPs" and
 {limit_overrides}
 
 This example simply sets the overrides, and then prints the limits for confirmation.
+
+You could also set the same limit overrides using a JSON file stored at ``limit_overrides.json``:
+
+.. code-block:: json
+
+    {
+        "AutoScaling": {
+            "Auto Scaling groups": 321,
+            "Launch configurations": 456
+        }
+    }
+
+Using a command like:
+
+.. code-block:: console
+
+   (venv)$ awslimitchecker --limit-overrides-json=limit_overrides.json -l
+{limit_overrides-output-only}
 
 Check Limits Against Thresholds
 +++++++++++++++++++++++++++++++

--- a/docs/source/cli_usage.rst.template
+++ b/docs/source/cli_usage.rst.template
@@ -140,7 +140,7 @@ For example, to override the limits of EC2's "EC2-Classic Elastic IPs" and
 
 This example simply sets the overrides, and then prints the limits for confirmation.
 
-You could also set the same limit overrides using a JSON file stored at ``limit_overrides.json``, following the format documented for :py:meth:`awslimitchecker.checker.Checker.set_limit_overrides`:
+You could also set the same limit overrides using a JSON file stored at ``limit_overrides.json``, following the format documented for :py:meth:`awslimitchecker.checker.AwsLimitChecker.set_limit_overrides`:
 
 .. code-block:: json
 
@@ -195,7 +195,7 @@ To set the warning threshold of 50% and a critical threshold of 75% when checkin
 You can also set custom thresholds on a per-limit basis using the
 ``--threshold-override-json`` CLI option, which accepts the path to a JSON file
 (local or an s3:// URL) matching the format described in
-:py:meth:`awslimitchecker.checker.Checker.set_threshold_overrides`, for example:
+:py:meth:`awslimitchecker.checker.AwsLimitChecker.set_threshold_overrides`, for example:
 
 .. code-block:: json
 

--- a/docs/source/cli_usage.rst.template
+++ b/docs/source/cli_usage.rst.template
@@ -140,7 +140,7 @@ For example, to override the limits of EC2's "EC2-Classic Elastic IPs" and
 
 This example simply sets the overrides, and then prints the limits for confirmation.
 
-You could also set the same limit overrides using a JSON file stored at ``limit_overrides.json``:
+You could also set the same limit overrides using a JSON file stored at ``limit_overrides.json``, following the format documented for :py:meth:`awslimitchecker.checker.Checker.set_limit_overrides`:
 
 .. code-block:: json
 
@@ -183,12 +183,61 @@ threshold only, and another has crossed the critical threshold):
 
 {check_thresholds}
 
+.. _cli_usage.threshold_overrides:
+
 Set Custom Thresholds
 +++++++++++++++++++++
 
 To set the warning threshold of 50% and a critical threshold of 75% when checking limits:
 
 {check_thresholds_custom}
+
+You can also set custom thresholds on a per-limit basis using the
+``--threshold-override-json`` CLI option, which accepts the path to a JSON file
+(local or an s3:// URL) matching the format described in
+:py:meth:`awslimitchecker.checker.Checker.set_threshold_overrides`, for example:
+
+.. code-block:: json
+
+    {
+        "S3": {
+            "Buckets": {
+                "warning": {
+                    "percent": 97
+                },
+                "critical": {
+                    "percent": 99
+                }
+            }
+        },
+        "EC2": {
+            "Security groups per VPC": {
+                "warning": {
+                    "percent": 80,
+                    "count": 800
+                },
+                "critical": {
+                    "percent": 90,
+                    "count": 900
+                }
+            },
+            "VPC security groups per elastic network interface": {
+                "warning": {
+                    "percent": 101
+                },
+                "critical": {
+                    "percent": 101
+                }
+            }
+        }
+    }
+
+Using a command like:
+
+.. code-block:: console
+
+   (venv)$ awslimitchecker -W 97 --critical=98 --no-color --threshold-overrides-json=s3://bucketname/path/overrides.json
+{check_thresholds_custom-output-only}
 
 Required IAM Policy
 +++++++++++++++++++
@@ -201,6 +250,9 @@ permissions for it to perform all limit checks. This can be viewed with the
 
 For the current IAM Policy required by this version of awslimitchecker,
 see :ref:`IAM Policy <iam_policy>`.
+
+.. important::
+   The required IAM policy output by awslimitchecker includes only the permissions required to check limits and usage. If you are loading :ref:`limit overrides <cli_usage.limit_overrides>` and/or :ref:`threshold overrides <cli_usage.threshold_overrides>` from S3, you will need to run awslimitchecker with additional permissions to access those objects.
 
 Connect to a Specific Region
 ++++++++++++++++++++++++++++

--- a/docs/source/iam_policy.rst
+++ b/docs/source/iam_policy.rst
@@ -9,6 +9,9 @@
 Required IAM Permissions
 ========================
 
+.. important::
+   The required IAM policy output by awslimitchecker includes only the permissions required to check limits and usage. If you are loading :ref:`limit overrides <cli_usage.limit_overrides>` and/or :ref:`threshold overrides <cli_usage.threshold_overrides>` from S3, you will need to run awslimitchecker with additional permissions to access those objects.
+
 Below is the sample IAM policy from this version of awslimitchecker, listing the IAM
 permissions required for it to function correctly. Please note that in some cases
 awslimitchecker may cause AWS services to make additional API calls on your behalf


### PR DESCRIPTION
# Summary

This PR adds support for command line arguments to set limit overrides and per-limit threshold overrides from a JSON file either on the local filesystem or dynamically retrieved from S3.

This essentially exposes the existing, formerly Python-API-only [awslimitchecker.checker.AwsLimitChecker.set_limit_overrides](https://awslimitchecker.readthedocs.io/en/latest/awslimitchecker.checker.html#awslimitchecker.checker.AwsLimitChecker.set_limit_overrides) and [awslimitchecker.checker.AwsLimitChecker.set_threshold_overrides](https://awslimitchecker.readthedocs.io/en/latest/awslimitchecker.checker.html#awslimitchecker.checker.AwsLimitChecker.set_threshold_overrides) methods via new ``--limit-override-json`` and ``--threshold-override-json`` command line options, which take either a local file path or an S3 URL.

# Pull Request Checklist

- [x] All pull requests should be __against the develop branch__, not master.
- [x] All pull requests must include the Contributor License Agreement (see below).
- [x] Whether or not your PR includes unit tests:
    - [x] Please make sure you have run the exact code contained in the PR locally, and it functions as desired.
    - [x] Please make sure the TravisCI build passes or, if not, you've corrected any obvious problems identified by the tests.
- [x] Code should conform to the [Development Guidelines](http://awslimitchecker.readthedocs.org/en/latest/development.html#guidelines):
    - [x] pep8 compliant with some exceptions (see pytest.ini)
    - [x] 100% test coverage with pytest (with valid tests). If you have difficulty
      writing tests for the code, that's fine, just mention that in the summary and either
      ask for assistance, or clarify that you'd like someone else to handle the tests. PRs that
      include complete test coverage will usually be merged faster.
    - [x] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [x] documentation has been rebuilt with ``tox -e docs``
    - [x] Connections to the AWS services should only be made by the class's
      ``connect()`` and ``connect_resource()`` methods, inherited from
      [awslimitchecker.connectable.Connectable](http://awslimitchecker.readthedocs.org/en/latest/awslimitchecker.connectable.html)
    - [x] All modules should have (and use) module-level loggers.
    - [x] **Commit messages** should be meaningful, and reference the Issue number
      if you're working on a GitHub issue (i.e. "issue #x - <message>"). Please
      refrain from using the "fixes #x" notation unless you are *sure* that the
      the issue is fixed in that commit.
    - [x] Git history is fully intact; please do not squash or rewrite history.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.
