### PR TITLE
Fixes #418 - Metrics Provider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,7 @@ What It Does
   an optional maximum time limit). See
   `Getting Started - Trusted Advisor <http://awslimitchecker.readthedocs.io/en/latest/getting_started.html#trusted-advisor>`_
   for more information.
+- Optionally send current usage and limit metrics to a metrics store, such as Datadog.
 
 Requirements
 ------------

--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -584,3 +584,15 @@ class AwsLimitChecker(object):
             }],
         }
         return policy
+
+    @property
+    def region_name(self):
+        """
+        Return the name of the AWS region that we're checking.
+
+        :return: AWS region name
+        :rtype: str
+        """
+        kwargs = self._boto_conn_kwargs
+        conn = boto3.client('ec2', **kwargs)
+        return conn._client_config.region_name

--- a/awslimitchecker/metrics/__init__.py
+++ b/awslimitchecker/metrics/__init__.py
@@ -39,3 +39,4 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 
 from .base import MetricsProvider
 from .dummy import Dummy
+from .datadog import Datadog

--- a/awslimitchecker/metrics/__init__.py
+++ b/awslimitchecker/metrics/__init__.py
@@ -1,0 +1,41 @@
+"""
+awslimitchecker/metrics/__init__.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2015-2019 Jason Antman <jason@jasonantman.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/awslimitchecker> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+################################################################################
+"""
+
+from .base import MetricsProvider
+from .dummy import Dummy

--- a/awslimitchecker/metrics/base.py
+++ b/awslimitchecker/metrics/base.py
@@ -1,0 +1,121 @@
+"""
+awslimitchecker/metrics/base.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2015-2019 Jason Antman <jason@jasonantman.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/awslimitchecker> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+################################################################################
+"""
+
+import logging
+from abc import ABCMeta, abstractmethod
+
+logger = logging.getLogger(__name__)
+
+
+class MetricsProvider(object):
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self, region_name):
+        """
+        Initialize a MetricsProvider class. This MUST be overridden by
+        subclasses. All configuration must be passed as keyword arguments
+        to the class constructor (these come from ``--metrics-config`` CLI
+        arguments). Any dependency imports must be made in the constructor.
+        The constructor should do as much as possible to validate configuration.
+
+        :param region_name: the name of the region we're connected to
+        :type region_name: str
+        """
+        self._region_name = region_name
+        self._duration = 0.0
+        self._limits = []
+
+    def set_run_duration(self, duration):
+        """
+        Set the duration for the awslimitchecker run (the time taken to check
+        usage against limits).
+
+        :param duration: time taken to check limits
+        :type duration: float
+        """
+        self._duration = duration
+
+    def add_limit(self, limit):
+        """
+        Cache a given limit for later sending to the metrics store.
+
+        :param limit: a limit to cache
+        :type limit: AwsLimit
+        """
+        self._limits.append(limit)
+
+    @abstractmethod
+    def flush(self):
+        """
+        Flush all metrics to the provider. This is the method that actually
+        sends data to your metrics provider/store. It should iterate over
+        ``self._limits`` and send metrics for them, as well as for
+        ``self._duration``.
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def providers_by_name():
+        """
+        Return a dict of available MetricsProvider subclass names to the class
+        objects.
+
+        :return: MetricsProvider class names to classes
+        :rtype: dict
+        """
+        return {x.__name__: x for x in MetricsProvider.__subclasses__()}
+
+    @staticmethod
+    def get_provider_by_name(name):
+        """
+        Get a reference to the provider class with the specified name.
+
+        :param name: name of the MetricsProvider subclass
+        :type name: str
+        :return: MetricsProvider subclass
+        :rtype: ``class``
+        :raises: RuntimeError
+        """
+        try:
+            return MetricsProvider.providers_by_name()[name]
+        except KeyError:
+            raise RuntimeError(
+                'ERROR: "%s" is not a valid MetricsProvider class name' % name
+            )

--- a/awslimitchecker/metrics/datadog.py
+++ b/awslimitchecker/metrics/datadog.py
@@ -1,0 +1,169 @@
+"""
+awslimitchecker/metrics/datadog.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2015-2018 Jason Antman <jason@jasonantman.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/awslimitchecker> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+################################################################################
+"""
+
+import os
+import logging
+import urllib3
+import time
+import re
+import json
+from awslimitchecker.metrics.base import MetricsProvider
+
+logger = logging.getLogger(__name__)
+
+
+class Datadog(MetricsProvider):
+    """Send metrics to Datadog."""
+
+    def __init__(
+        self, region_name, prefix='awslimitchecker.', api_key=None,
+        extra_tags=None
+    ):
+        """
+        Initialize the Datadog metrics provider. This class does not have any
+        additional requirements. You must specify at least the ``api_key``
+        configuration option.
+
+        :param region_name: the name of the region we're connected to. This
+          parameter is automatically passed in by the Runner class.
+        :type region_name: str
+        :param prefix: Datadog metric prefix
+        :type prefix: str
+        :param api_key: Datadog API key. May alternatively be specified by the
+          ``DATADOG_API_KEY`` environment variable.
+        :type api_key: str
+        :param extra_tags: CSV list of additional tags to send with metrics.
+          All metrics will automatically be tagged with ``region:<region name>``
+        :type extra_tags: str
+        """
+        super(Datadog, self).__init__(region_name)
+        self._prefix = prefix
+        self._tags = ['region:%s' % region_name]
+        if extra_tags is not None:
+            self._tags.extend(','.split(extra_tags))
+        self._api_key = os.environ.get('DATADOG_API_KEY')
+        if api_key is not None:
+            self._api_key = api_key
+        if self._api_key is None:
+            raise RuntimeError(
+                'ERROR: Datadog metrics provider requires datadog API key.'
+            )
+        self._http = urllib3.PoolManager()
+        self._validate_auth(self._api_key)
+
+    def _validate_auth(self, api_key):
+        url = 'https://api.datadoghq.com/api/v1/validate?api_key=%s'
+        logger.debug('Validating Datadog API key: GET %s', url)
+        url = url % api_key
+        r = self._http.request('GET', url)
+        if r.status != 200:
+            raise RuntimeError(
+                'ERROR: Datadog API key validation failed with HTTP %s: %s' % (
+                    r.status, r.data
+                )
+            )
+
+    def _name_for_metric(self, service, limit):
+        """
+        Return a metric name that's safe for datadog
+
+        :param service: service name
+        :type service: str
+        :param limit: limit name
+        :type limit: str
+        :return: datadog metric name
+        :rtype: str
+        """
+        return ('%s%s.%s' % (
+            self._prefix,
+            re.sub(r'[^0-9a-zA-Z]+', '_', service),
+            re.sub(r'[^0-9a-zA-Z]+', '_', limit)
+        )).lower()
+
+    def flush(self):
+        ts = int(time.time())
+        logger.debug('Flushing metrics to Datadog.')
+        series = [{
+            'metric': '%sruntime' % self._prefix,
+            'points': [[ts, self._duration]],
+            'type': 'gauge',
+            'tags': self._tags
+        }]
+        for lim in self._limits:
+            u = lim.get_current_usage()
+            if len(u) == 0:
+                max_usage = 0
+            else:
+                max_usage = max(u).get_value()
+            mname = self._name_for_metric(lim.service.service_name, lim.name)
+            series.append({
+                'metric': '%s.max_usage' % mname,
+                'points': [[ts, max_usage]],
+                'type': 'gauge',
+                'tags': self._tags
+            })
+            limit = lim.get_limit()
+            if limit is not None:
+                series.append({
+                    'metric': '%s.limit' % mname,
+                    'points': [[ts, limit]],
+                    'type': 'gauge',
+                    'tags': self._tags
+                })
+        logger.info('POSTing %d metrics to datadog', len(series))
+        data = {'series': series}
+        encoded = json.dumps(data).encode('utf-8')
+        url = 'https://api.datadoghq.com/api/v1/series' \
+              '?api_key=%s' % self._api_key
+        resp = self._http.request(
+            'POST', url,
+            headers={'Content-type': 'application/json'},
+            body=encoded
+        )
+        if resp.status < 300:
+            logger.debug(
+                'Successfully POSTed to Datadog; HTTP %d: %s',
+                resp.status, resp.data
+            )
+            return
+        raise RuntimeError(
+            'ERROR sending metrics to Datadog; API responded HTTP %d: %s' % (
+                resp.status, resp.data
+            )
+        )

--- a/awslimitchecker/metrics/datadog.py
+++ b/awslimitchecker/metrics/datadog.py
@@ -76,7 +76,7 @@ class Datadog(MetricsProvider):
         self._prefix = prefix
         self._tags = ['region:%s' % region_name]
         if extra_tags is not None:
-            self._tags.extend(','.split(extra_tags))
+            self._tags.extend(extra_tags.split(','))
         self._api_key = os.environ.get('DATADOG_API_KEY')
         if api_key is not None:
             self._api_key = api_key

--- a/awslimitchecker/metrics/dummy.py
+++ b/awslimitchecker/metrics/dummy.py
@@ -1,0 +1,71 @@
+"""
+awslimitchecker/metrics/dummy.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2015-2018 Jason Antman <jason@jasonantman.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/awslimitchecker> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+################################################################################
+"""
+
+import logging
+from awslimitchecker.metrics.base import MetricsProvider
+
+logger = logging.getLogger(__name__)
+
+
+class Dummy(MetricsProvider):
+    """Just writes metrics to STDOUT; mainly used for testing."""
+
+    def __init__(self, region_name, **_):
+        super(Dummy, self).__init__(region_name)
+
+    def flush(self):
+        print('DummyMetrics Provider flush for region=%s' % self._region_name)
+        print('Duration: %s' % self._duration)
+        lines = []
+        for lim in self._limits:
+            u = lim.get_current_usage()
+            if len(u) == 0:
+                max_usage = 0
+            else:
+                max_usage = max(u).get_value()
+            limit = lim.get_limit()
+            if limit is None:
+                limit = 'unknown'
+            lines.append(
+                '%s / %s: limit=%s max_usage=%s' % (
+                    lim.service.service_name, lim.name, limit, max_usage
+                )
+            )
+        for l in sorted(lines):
+            print(l)

--- a/awslimitchecker/tests/metrics/__init__.py
+++ b/awslimitchecker/tests/metrics/__init__.py
@@ -1,0 +1,38 @@
+"""
+awslimitchecker/tests/metrics/__init__.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2015-2019 Jason Antman <jason@jasonantman.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/awslimitchecker> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+################################################################################
+"""

--- a/awslimitchecker/tests/metrics/test_base.py
+++ b/awslimitchecker/tests/metrics/test_base.py
@@ -38,7 +38,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 """
 
 from awslimitchecker.metrics.base import MetricsProvider
-from awslimitchecker.metrics import Dummy
+from awslimitchecker.metrics import Dummy, Datadog
 
 import pytest
 
@@ -73,7 +73,8 @@ class TestMetricsProvider(object):
     def test_providers_by_name(self):
         assert MetricsProvider.providers_by_name() == {
             'Dummy': Dummy,
-            'MPTester': MPTester
+            'MPTester': MPTester,
+            'Datadog': Datadog
         }
 
     def test_get_provider_by_name(self):

--- a/awslimitchecker/tests/metrics/test_base.py
+++ b/awslimitchecker/tests/metrics/test_base.py
@@ -1,0 +1,86 @@
+"""
+awslimitchecker/tests/metrics/test_base.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2015-2019 Jason Antman <jason@jasonantman.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/awslimitchecker> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+################################################################################
+"""
+
+from awslimitchecker.metrics.base import MetricsProvider
+from awslimitchecker.metrics import Dummy
+
+import pytest
+
+
+class MPTester(MetricsProvider):
+
+    def flush(self):
+        pass
+
+
+class TestMetricsProvider(object):
+
+    def test_init(self):
+        cls = MPTester('foo')
+        assert cls._region_name == 'foo'
+        assert cls._duration == 0.0
+        assert cls._limits == []
+
+    def test_set_run_duration(self):
+        cls = MPTester('foo')
+        assert cls._duration == 0.0
+        cls.set_run_duration(123.45)
+        assert cls._duration == 123.45
+
+    def test_add_limit(self):
+        cls = MPTester('foo')
+        assert cls._limits == []
+        cls.add_limit(1)
+        cls.add_limit(2)
+        assert cls._limits == [1, 2]
+
+    def test_providers_by_name(self):
+        assert MetricsProvider.providers_by_name() == {
+            'Dummy': Dummy,
+            'MPTester': MPTester
+        }
+
+    def test_get_provider_by_name(self):
+        assert MetricsProvider.get_provider_by_name('Dummy') == Dummy
+
+    def test_get_provider_by_name_exception(self):
+        with pytest.raises(RuntimeError) as exc:
+            MetricsProvider.get_provider_by_name('3993fhej')
+        assert str(exc.value) == 'ERROR: "3993fhej" is not a valid ' \
+                                 'MetricsProvider class name'

--- a/awslimitchecker/tests/metrics/test_datadog.py
+++ b/awslimitchecker/tests/metrics/test_datadog.py
@@ -1,0 +1,305 @@
+"""
+awslimitchecker/tests/metrics/test_datadog.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2015-2019 Jason Antman <jason@jasonantman.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/awslimitchecker> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+################################################################################
+"""
+
+import sys
+import json
+from awslimitchecker.metrics import Datadog
+import pytest
+from freezegun import freeze_time
+
+if (
+        sys.version_info[0] < 3 or
+        sys.version_info[0] == 3 and sys.version_info[1] < 4
+):
+    from mock import Mock, patch, call
+else:
+    from unittest.mock import Mock, patch, call
+
+
+pbm = 'awslimitchecker.metrics.datadog'
+pb = '%s.Datadog' % pbm
+
+
+class TestInit(object):
+
+    @patch.dict('os.environ', {}, clear=True)
+    def test_happy_path(self):
+        mock_http = Mock()
+        with patch('%s.urllib3.PoolManager' % pbm, autospec=True) as m_pm:
+            m_pm.return_value = mock_http
+            with patch('%s._validate_auth' % pb, autospec=True) as m_va:
+                cls = Datadog(
+                    'foo', api_key='1234', extra_tags='foo,bar,baz:blam'
+                )
+        assert cls._region_name == 'foo'
+        assert cls._duration == 0.0
+        assert cls._limits == []
+        assert cls._api_key == '1234'
+        assert cls._prefix == 'awslimitchecker.'
+        assert cls._tags == [
+            'region:foo', 'foo', 'bar', 'baz:blam'
+        ]
+        assert cls._http == mock_http
+        assert m_pm.mock_calls == [call()]
+        assert m_va.mock_calls == [call(cls, '1234')]
+
+    @patch.dict('os.environ', {'DATADOG_API_KEY': '5678'}, clear=True)
+    def test_api_key_env_var(self):
+        mock_http = Mock()
+        with patch('%s.urllib3.PoolManager' % pbm, autospec=True) as m_pm:
+            m_pm.return_value = mock_http
+            with patch('%s._validate_auth' % pb, autospec=True) as m_va:
+                cls = Datadog(
+                    'foo', prefix='myprefix.'
+                )
+        assert cls._region_name == 'foo'
+        assert cls._duration == 0.0
+        assert cls._limits == []
+        assert cls._api_key == '5678'
+        assert cls._prefix == 'myprefix.'
+        assert cls._tags == [
+            'region:foo'
+        ]
+        assert cls._http == mock_http
+        assert m_pm.mock_calls == [call()]
+        assert m_va.mock_calls == [call(cls, '5678')]
+
+    @patch.dict('os.environ', {}, clear=True)
+    def test_no_api_key(self):
+        mock_http = Mock()
+        with patch('%s.urllib3.PoolManager' % pbm, autospec=True) as m_pm:
+            m_pm.return_value = mock_http
+            with patch('%s._validate_auth' % pb, autospec=True) as m_va:
+                with pytest.raises(RuntimeError) as exc:
+                    Datadog(
+                        'foo', extra_tags='foo,bar,baz:blam', prefix='myprefix.'
+                    )
+        assert str(exc.value) == 'ERROR: Datadog metrics provider ' \
+                                 'requires datadog API key.'
+        assert m_pm.mock_calls == []
+        assert m_va.mock_calls == []
+
+
+class DatadogTester(object):
+
+    def setup(self):
+        with patch('%s.__init__' % pb) as m_init:
+            m_init.return_value = None
+            self.cls = Datadog()
+
+
+class TestValidateAuth(DatadogTester):
+
+    def test_happy_path(self):
+        mock_http = Mock()
+        mock_resp = Mock(status=200, data=b'{"success": "ok"}')
+        mock_http.request.return_value = mock_resp
+        self.cls._http = mock_http
+        self.cls._validate_auth('1234')
+        assert mock_http.mock_calls == [
+            call.request(
+                'GET',
+                'https://api.datadoghq.com/api/v1/validate?api_key=1234'
+            )
+        ]
+
+    def test_failure(self):
+        mock_http = Mock()
+        mock_resp = Mock(status=401, data='{"success": "NO"}')
+        mock_http.request.return_value = mock_resp
+        self.cls._http = mock_http
+        with pytest.raises(RuntimeError) as exc:
+            self.cls._validate_auth('1234')
+        assert str(exc.value) == 'ERROR: Datadog API key validation failed ' \
+                                 'with HTTP 401: {"success": "NO"}'
+        assert mock_http.mock_calls == [
+            call.request(
+                'GET',
+                'https://api.datadoghq.com/api/v1/validate?api_key=1234'
+            )
+        ]
+
+
+class TestNameForMetric(DatadogTester):
+
+    def test_simple(self):
+        self.cls._prefix = 'foobar.'
+        assert self.cls._name_for_metric(
+            'Service Name*', 'limit NAME .'
+        ) == 'foobar.service_name_.limit_name_'
+
+
+class TestFlush(DatadogTester):
+
+    @freeze_time("2016-12-16 10:40:42", tz_offset=0, auto_tick_seconds=6)
+    def test_happy_path(self):
+        self.cls._prefix = 'prefix.'
+        self.cls._tags = ['tag1', 'tag:2']
+        self.cls._limits = []
+        self.cls._api_key = 'myKey'
+        self.cls.set_run_duration(123.45)
+        limA = Mock(
+            name='limitA', service=Mock(service_name='SVC1')
+        )
+        type(limA).name = 'limitA'
+        limA.get_current_usage.return_value = []
+        limA.get_limit.return_value = None
+        self.cls.add_limit(limA)
+        limB = Mock(
+            name='limitB', service=Mock(service_name='SVC1')
+        )
+        type(limB).name = 'limitB'
+        mocku = Mock()
+        mocku.get_value.return_value = 6
+        limB.get_current_usage.return_value = [mocku]
+        limB.get_limit.return_value = 10
+        self.cls.add_limit(limB)
+        mock_http = Mock()
+        mock_resp = Mock(status=200, data='{"status": "ok"}')
+        mock_http.request.return_value = mock_resp
+        self.cls._http = mock_http
+        self.cls.flush()
+        ts = 1481884842
+        expected = {
+            'series': [
+                {
+                    'metric': 'prefix.runtime',
+                    'points': [[ts, 123.45]],
+                    'type': 'gauge',
+                    'tags': ['tag1', 'tag:2']
+                },
+                {
+                    'metric': 'prefix.svc1.limita.max_usage',
+                    'points': [[ts, 0]],
+                    'type': 'gauge',
+                    'tags': ['tag1', 'tag:2']
+                },
+                {
+                    'metric': 'prefix.svc1.limitb.max_usage',
+                    'points': [[ts, 6]],
+                    'type': 'gauge',
+                    'tags': ['tag1', 'tag:2']
+                },
+                {
+                    'metric': 'prefix.svc1.limitb.limit',
+                    'points': [[ts, 10]],
+                    'type': 'gauge',
+                    'tags': ['tag1', 'tag:2']
+                }
+            ]
+        }
+        assert len(mock_http.mock_calls) == 1
+        c = mock_http.mock_calls[0]
+        assert c[0] == 'request'
+        assert c[1] == (
+            'POST', 'https://api.datadoghq.com/api/v1/series?api_key=myKey'
+        )
+        assert len(c[2]) == 2
+        assert c[2]['headers'] == {'Content-type': 'application/json'}
+        assert json.loads(c[2]['body'].decode()) == expected
+
+    @freeze_time("2016-12-16 10:40:42", tz_offset=0, auto_tick_seconds=6)
+    def test_api_error(self):
+        self.cls._prefix = 'prefix.'
+        self.cls._tags = ['tag1', 'tag:2']
+        self.cls._limits = []
+        self.cls._api_key = 'myKey'
+        self.cls.set_run_duration(123.45)
+        limA = Mock(
+            name='limitA', service=Mock(service_name='SVC1')
+        )
+        type(limA).name = 'limitA'
+        limA.get_current_usage.return_value = []
+        limA.get_limit.return_value = None
+        self.cls.add_limit(limA)
+        limB = Mock(
+            name='limitB', service=Mock(service_name='SVC1')
+        )
+        type(limB).name = 'limitB'
+        mocku = Mock()
+        mocku.get_value.return_value = 6
+        limB.get_current_usage.return_value = [mocku]
+        limB.get_limit.return_value = 10
+        self.cls.add_limit(limB)
+        mock_http = Mock()
+        mock_resp = Mock(status=503, data='{"status": "NG"}')
+        mock_http.request.return_value = mock_resp
+        self.cls._http = mock_http
+        with pytest.raises(RuntimeError) as exc:
+            self.cls.flush()
+        assert str(exc.value) == 'ERROR sending metrics to Datadog; API ' \
+                                 'responded HTTP 503: {"status": "NG"}'
+        ts = 1481884842
+        expected = {
+            'series': [
+                {
+                    'metric': 'prefix.runtime',
+                    'points': [[ts, 123.45]],
+                    'type': 'gauge',
+                    'tags': ['tag1', 'tag:2']
+                },
+                {
+                    'metric': 'prefix.svc1.limita.max_usage',
+                    'points': [[ts, 0]],
+                    'type': 'gauge',
+                    'tags': ['tag1', 'tag:2']
+                },
+                {
+                    'metric': 'prefix.svc1.limitb.max_usage',
+                    'points': [[ts, 6]],
+                    'type': 'gauge',
+                    'tags': ['tag1', 'tag:2']
+                },
+                {
+                    'metric': 'prefix.svc1.limitb.limit',
+                    'points': [[ts, 10]],
+                    'type': 'gauge',
+                    'tags': ['tag1', 'tag:2']
+                }
+            ]
+        }
+        assert len(mock_http.mock_calls) == 1
+        c = mock_http.mock_calls[0]
+        assert c[0] == 'request'
+        assert c[1] == (
+            'POST', 'https://api.datadoghq.com/api/v1/series?api_key=myKey'
+        )
+        assert len(c[2]) == 2
+        assert c[2]['headers'] == {'Content-type': 'application/json'}
+        assert json.loads(c[2]['body'].decode()) == expected

--- a/awslimitchecker/tests/metrics/test_dummy.py
+++ b/awslimitchecker/tests/metrics/test_dummy.py
@@ -1,0 +1,85 @@
+"""
+awslimitchecker/tests/metrics/test_dummy.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2015-2019 Jason Antman <jason@jasonantman.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/awslimitchecker> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+################################################################################
+"""
+
+import sys
+from awslimitchecker.metrics import Dummy
+
+if (
+        sys.version_info[0] < 3 or
+        sys.version_info[0] == 3 and sys.version_info[1] < 4
+):
+    from mock import Mock
+else:
+    from unittest.mock import Mock
+
+
+class TestDummyInit(object):
+
+    def test_happy_path(self):
+        cls = Dummy('foo')
+        assert cls._region_name == 'foo'
+        assert cls._duration == 0.0
+        assert cls._limits == []
+
+    def test_flush(self, capsys):
+        cls = Dummy('foo')
+        cls.set_run_duration(123.45)
+        limA = Mock(
+            name='limitA', service=Mock(service_name='SVC1')
+        )
+        type(limA).name = 'limitA'
+        limA.get_current_usage.return_value = []
+        limA.get_limit.return_value = None
+        cls.add_limit(limA)
+        limB = Mock(
+            name='limitB', service=Mock(service_name='SVC1')
+        )
+        type(limB).name = 'limitB'
+        mocku = Mock()
+        mocku.get_value.return_value = 6
+        limB.get_current_usage.return_value = [mocku]
+        limB.get_limit.return_value = 10
+        cls.add_limit(limB)
+        cls.flush()
+        out, err = capsys.readouterr()
+        assert err == ''
+        assert out == 'DummyMetrics Provider flush for region=foo\n' \
+                      'Duration: 123.45\n' \
+                      'SVC1 / limitA: limit=unknown max_usage=0\n' \
+                      'SVC1 / limitB: limit=10 max_usage=6\n'

--- a/awslimitchecker/tests/test_checker.py
+++ b/awslimitchecker/tests/test_checker.py
@@ -53,9 +53,9 @@ if (
         sys.version_info[0] < 3 or
         sys.version_info[0] == 3 and sys.version_info[1] < 4
 ):
-    from mock import patch, call, Mock, DEFAULT
+    from mock import patch, call, Mock, DEFAULT, PropertyMock
 else:
-    from unittest.mock import patch, call, Mock, DEFAULT
+    from unittest.mock import patch, call, Mock, DEFAULT, PropertyMock
 
 pbm = 'awslimitchecker.checker'  # patch base path - module
 pb = '%s.AwsLimitChecker' % pbm  # patch base path
@@ -868,3 +868,16 @@ class TestAwsLimitChecker(object):
             call._update_limits_from_api(),
             call.check_thresholds()
         ]
+
+    def test_region_name(self):
+        mock_client = Mock(
+            _client_config=Mock(region_name='rname')
+        )
+        with patch(
+            '%s._boto_conn_kwargs' % pb, new_callable=PropertyMock
+        ) as mock_bck:
+            mock_bck.return_value = {'foo': 'bar'}
+            with patch('%s.boto3.client' % pbm) as m_client:
+                m_client.return_value = mock_client
+                res = self.cls.region_name
+        assert res == 'rname'

--- a/docs/source/awslimitchecker.metrics.base.rst
+++ b/docs/source/awslimitchecker.metrics.base.rst
@@ -1,0 +1,7 @@
+awslimitchecker.metrics.base module
+===================================
+
+.. automodule:: awslimitchecker.metrics.base
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/awslimitchecker.metrics.datadog.rst
+++ b/docs/source/awslimitchecker.metrics.datadog.rst
@@ -1,0 +1,7 @@
+awslimitchecker.metrics.datadog module
+======================================
+
+.. automodule:: awslimitchecker.metrics.datadog
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/awslimitchecker.metrics.dummy.rst
+++ b/docs/source/awslimitchecker.metrics.dummy.rst
@@ -1,0 +1,7 @@
+awslimitchecker.metrics.dummy module
+====================================
+
+.. automodule:: awslimitchecker.metrics.dummy
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/awslimitchecker.metrics.rst
+++ b/docs/source/awslimitchecker.metrics.rst
@@ -12,5 +12,6 @@ Submodules
 .. toctree::
 
    awslimitchecker.metrics.base
+   awslimitchecker.metrics.datadog
    awslimitchecker.metrics.dummy
 

--- a/docs/source/awslimitchecker.metrics.rst
+++ b/docs/source/awslimitchecker.metrics.rst
@@ -1,0 +1,16 @@
+awslimitchecker.metrics package
+===============================
+
+.. automodule:: awslimitchecker.metrics
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+
+   awslimitchecker.metrics.base
+   awslimitchecker.metrics.dummy
+

--- a/docs/source/awslimitchecker.rst
+++ b/docs/source/awslimitchecker.rst
@@ -11,6 +11,7 @@ Subpackages
 
 .. toctree::
 
+    awslimitchecker.metrics
     awslimitchecker.services
 
 Submodules

--- a/docs/source/cli_usage.rst.template
+++ b/docs/source/cli_usage.rst.template
@@ -144,12 +144,7 @@ You could also set the same limit overrides using a JSON file stored at ``limit_
 
 .. code-block:: json
 
-    {
-        "AutoScaling": {
-            "Auto Scaling groups": 321,
-            "Launch configurations": 456
-        }
-    }
+{limit-override-json}
 
 Using a command like:
 
@@ -199,38 +194,7 @@ You can also set custom thresholds on a per-limit basis using the
 
 .. code-block:: json
 
-    {
-        "S3": {
-            "Buckets": {
-                "warning": {
-                    "percent": 97
-                },
-                "critical": {
-                    "percent": 99
-                }
-            }
-        },
-        "EC2": {
-            "Security groups per VPC": {
-                "warning": {
-                    "percent": 80,
-                    "count": 800
-                },
-                "critical": {
-                    "percent": 90,
-                    "count": 900
-                }
-            },
-            "VPC security groups per elastic network interface": {
-                "warning": {
-                    "percent": 101
-                },
-                "critical": {
-                    "percent": 101
-                }
-            }
-        }
-    }
+{threshold-override-json}
 
 Using a command like:
 
@@ -238,6 +202,37 @@ Using a command like:
 
    (venv)$ awslimitchecker -W 97 --critical=98 --no-color --threshold-overrides-json=s3://bucketname/path/overrides.json
 {check_thresholds_custom-output-only}
+
+.. _cli_usage.metrics:
+
+Enable Metrics Provider
++++++++++++++++++++++++
+
+awslimitchecker is capable of sending metrics for the overall runtime of checking
+thresholds, as well as the current limit values and current usage, to various metrics
+stores. The list of metrics providers supported by your version of awslimitchecker
+can be seen with the ``--list-metrics-providers`` option:
+
+{list_metrics}
+
+The configuration options required by each metrics provider are specified in the
+providers' documentation:
+
+{metrics-providers}
+
+For example, to use the :py:class:`~awslimitchecker.metrics.datadog.Datadog`
+metrics provider which requires an ``api_key`` paramater (also accepted as an
+environment variable) and an optional ``extra_tags`` parameter:
+
+.. code-block:: console
+
+    (venv)$ awslimitchecker \
+        --metrics-provider=Datadog \
+        --metrics-config=api_key=123456 \
+        --metrics-config=extra_tags=foo,bar,baz:blam
+
+Metrics will be pushed to the provider only when awslimitchecker is done checking
+all limits.
 
 Required IAM Policy
 +++++++++++++++++++

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -204,6 +204,28 @@ are needed to support new limit checks from TA.
 
 For further information, see :ref:`Internals / Trusted Advisor <internals.trusted_advisor>`.
 
+.. _development.metrics_providers:
+
+Adding Metrics Providers
+------------------------
+
+Metrics providers are subclasses of :py:class:`~.MetricsProvider` that take key/value
+configuration items via constructor keyword arguments and implement a
+:py:meth:`~.MetricsProvider.flush` method to send all metrics to the configured provider.
+It is probably easiest to look at the other existing providers for an example of how to
+implement a new one, but there are a few important things to keep in mind:
+
+* All configuration must be able to be bassed as keyword arguments to the class
+  constructor (which come from ``--metrics-config=key=value`` CLI arguments).
+  It is recommended that any secrets/API keys also be able to be set via
+  environment variables, but the CLI arguments should have precedence.
+* All dependency imports must be made inside the constructor, not at the module
+  level.
+* If the provider requires additional dependencies, they should be added as
+  extras but installed in the Docker image.
+* The constructor should do as much validation (i.e. authentication test) as
+  possible.
+
 .. _development.tests:
 
 Unit Testing

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -23,6 +23,7 @@ What It Does
   an optional maximum time limit). See
   :ref:`Getting Started - Trusted Advisor <getting_started.trusted_advisor>`
   for more information.
+- Optionally send current usage and limit metrics to a :ref:`metrics store <cli_usage.metrics>` such as Datadog.
 
 .. _getting_started.nomenclature:
 
@@ -207,6 +208,9 @@ information on the implementation of Trusted Advisor polling.
 
 Required Permissions
 --------------------
+
+.. important::
+   The required IAM policy output by awslimitchecker includes only the permissions required to check limits and usage. If you are loading :ref:`limit overrides <cli_usage.limit_overrides>` and/or :ref:`threshold overrides <cli_usage.threshold_overrides>` from S3, you will need to run awslimitchecker with additional permissions to access those objects.
 
 You can view a sample IAM policy listing the permissions required for awslimitchecker to function properly
 either via the CLI client:

--- a/docs/source/iam_policy.rst
+++ b/docs/source/iam_policy.rst
@@ -10,7 +10,11 @@ Required IAM Permissions
 ========================
 
 .. important::
-   The required IAM policy output by awslimitchecker includes only the permissions required to check limits and usage. If you are loading :ref:`limit overrides <cli_usage.limit_overrides>` and/or :ref:`threshold overrides <cli_usage.threshold_overrides>` from S3, you will need to run awslimitchecker with additional permissions to access those objects.
+   The required IAM policy output by awslimitchecker includes only the permissions
+   required to check limits and usage. If you are loading
+   :ref:`limit overrides <cli_usage.limit_overrides>` and/or
+   :ref:`threshold overrides <cli_usage.threshold_overrides>` from S3, you will
+   need to run awslimitchecker with additional permissions to access those objects.
 
 Below is the sample IAM policy from this version of awslimitchecker, listing the IAM
 permissions required for it to function correctly. Please note that in some cases

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,5 +5,6 @@ pep8ignore =
 pep8maxlinelength = 80
 flakes-ignore =
            awslimitchecker/services/__init__.py UnusedImport
+           awslimitchecker/metrics/__init__.py UnusedImport
 markers =
         integration: actual integration tests that connect to AWS APIs


### PR DESCRIPTION
This PR implements the metrics provider subsystem described in #418, as well as the first two metrics providers: a "Dummy" provider that just outputs metrics to STDOUT for testing, and the Datadog provider.

Both current providers have been tested off of this branch and are functional. The process for adding new providers has been documented.