### PR TITLE
fixes #441 - unhandled exception during TA polling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Unreleased Changes
 
 * `Issue #429 <https://github.com/jantman/awslimitchecker/issues/429>`_ - add 87 missing EC2 instance types. This will now only impact ``cn-*`` and ``us-gov-*`` regions.
 * `Issue #433 <https://github.com/jantman/awslimitchecker/issues/433>`_ - Fix broken links in the docs; waffle.io and landscape.io are both gone, sadly.
+* `Issue #441 <https://github.com/jantman/awslimitchecker/issues/441>`_ - Fix critical bug where awslimitchecker would die with an unhandled ``botocore.exceptions.ParamValidationError`` exception in accounts that have Trusted Advisor but do not have a "Service Limits" check in the "performance" category.
 
 New EC2 vCPU Limits
 +++++++++++++++++++

--- a/awslimitchecker/tests/test_trustedadvisor.py
+++ b/awslimitchecker/tests/test_trustedadvisor.py
@@ -352,10 +352,10 @@ class TestPoll(object):
     def test_none(self):
         tmp = self.mock_conn.describe_trusted_advisor_check_result
         with patch('%s._get_limit_check_id' % pb, autospec=True) as mock_id:
-            mock_id.return_value = None
+            mock_id.return_value = (None, None)
             res = self.cls._poll()
         assert tmp.mock_calls == []
-        assert res is None
+        assert res == {}
 
     def test_basic(self):
         poll_return_val = {

--- a/awslimitchecker/trustedadvisor.py
+++ b/awslimitchecker/trustedadvisor.py
@@ -168,10 +168,10 @@ class TrustedAdvisor(Connectable):
         if not self.have_ta:
             logger.info('TrustedAdvisor.have_ta is False; not polling TA')
             return {}
-        if tmp is None:
+        if tmp[0] is None:
             logger.critical("Unable to find 'Service Limits' Trusted Advisor "
                             "check; not using Trusted Advisor data.")
-            return
+            return {}
         check_id, metadata = tmp
         checks = self._get_refreshed_check_result(check_id)
         region = self.ta_region or self.conn._client_config.region_name


### PR DESCRIPTION
… on accounts that have TA but do not have the performance / Service Limits check

This was a minor logic bug in the ``_poll()`` method, where if the check couldn't be found the method would return ``(None, None)`` but the error handling code in the caller was looking for ``is None``.