### PR TITLE
Fixes #431 - fix major error in calculating 'EC2/Rules per VPC security group' limit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Changelog
 * In following with the above two issues, raise a ``DeprecationWarning`` when running on any Python2 version prior to 2.7 or any Python3 version prior to 3.4, in accorance with the `published end-of-life dates of those versions <https://devguide.python.org/devcycle/#end-of-life-branches>`_.
 * `Issue #436 <https://github.com/jantman/awslimitchecker/issues/436>`_ - Begin testing under Python 3.8 and base our Docker image on ``python:3.8-alpine``.
 * `Issue #435 <https://github.com/jantman/awslimitchecker/issues/435>`_ - Allow configuring the botocore maximum retries for Throttling / RateExceeded errors on a per-AWS-API basis via environment variables. See the relevant sections of the :ref:`CLI Usage <cli_usage.throttling>` or :ref:`Python Usage <python_usage.throttling>` documentation for further details.
+* `Issue #431 <https://github.com/jantman/awslimitchecker/issues/431>`_ - Fix a **major under-calculation** of usage for the EC2 ``Rules per VPC security group`` limit. We were previously calculating the number of "Rules" (from port / to port / protocol combinations) in a Security Group, but the limit is actually based on the number of permissions granted. See `this comment <https://github.com/jantman/awslimitchecker/issues/431#issuecomment-548599785>`_ on the issue for further details.
 
 .. _changelog.8_0_0_vcpu_limits:
 

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -2084,19 +2084,458 @@ class EC2(object):
         type(mock_sg1).ip_permissions_egress = []
         mock_sg2 = Mock(spec_set=SecurityGroup)
         type(mock_sg2).id = 'sg-2'
-        type(mock_sg2).vpc_id = None
-        type(mock_sg2).ip_permissions = [1, 2, 3, 4, 5, 6]
-        type(mock_sg2).ip_permissions_egress = [8, 9, 10]
+        type(mock_sg2).vpc_id = 'vpc-aaa'
+        type(mock_sg2).ip_permissions = [
+            {
+                'FromPort': 1,
+                'ToPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [
+                    {1: 1}, {2: 2}, {3: 3}, {4: 4}
+                ],
+                'Ipv6Ranges': [
+                    {1: 1}, {2: 2}
+                ],
+                'PrefixListIds': [
+                    {'p1': 'p1'},
+                ],
+                'UserIdGroupPairs': [
+                    {'a': 'a'}, {'b': 'b'}
+                ]
+            },
+            {
+                'FromPort': 2,
+                'IpProtocol': 'string',
+                'IpRanges': [
+                    {1: 1},
+                ],
+                'Ipv6Ranges': [],
+                'PrefixListIds': [],
+                'ToPort': 123,
+                'UserIdGroupPairs': []
+            },
+            {
+                'FromPort': 3,
+                'IpProtocol': 'string',
+                'IpRanges': [],
+                'Ipv6Ranges': [
+                    {1: 1},
+                ],
+                'PrefixListIds': [],
+                'ToPort': 123,
+                'UserIdGroupPairs': [
+                    {'a': 'a'},
+                ]
+            },
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [],
+                'Ipv6Ranges': [],
+                'PrefixListIds': [
+                    {'a': 'a'},
+                ],
+                'ToPort': 1,
+                'UserIdGroupPairs': [
+                    {'b': 'b'},
+                ]
+            },
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [
+                    {'c': 'c'},
+                ],
+                'Ipv6Ranges': [
+                    {4: 4},
+                ],
+                'PrefixListIds': [
+                    {5: 5}, {6: 6}
+                ],
+                'ToPort': 2,
+                'UserIdGroupPairs': []
+            },
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [],
+                'Ipv6Ranges': [],
+                'PrefixListIds': [
+                    {2: 2},
+                ],
+                'ToPort': 3,
+                'UserIdGroupPairs': []
+            }
+        ]
+        type(mock_sg2).ip_permissions_egress = [
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [
+                    {1: 1},
+                ],
+                'Ipv6Ranges': [
+                    {2: 2}, {3: 3}, {4: 4}
+                ],
+                'PrefixListIds': [
+                    {5: 5},
+                ],
+                'ToPort': 1,
+                'UserIdGroupPairs': [
+                    {6: 6},
+                ]
+            },
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [],
+                'Ipv6Ranges': [
+                    {7: 7},
+                ],
+                'PrefixListIds': [],
+                'ToPort': 2,
+                'UserIdGroupPairs': []
+            },
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [],
+                'Ipv6Ranges': [
+                    {8: 8},
+                ],
+                'PrefixListIds': [],
+                'ToPort': 3,
+                'UserIdGroupPairs': []
+            }
+        ]
         mock_sg3 = Mock(spec_set=SecurityGroup)
         type(mock_sg3).id = 'sg-3'
         type(mock_sg3).vpc_id = 'vpc-bbb'
-        type(mock_sg3).ip_permissions = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        type(mock_sg3).ip_permissions_egress = [6, 7, 8, 9]
+        type(mock_sg3).ip_permissions = [
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [
+                    {1: 1},
+                ],
+                'Ipv6Ranges': [],
+                'PrefixListIds': [
+                    {'a': 'a'},
+                ],
+                'ToPort': 123,
+                'UserIdGroupPairs': [
+                    {2: 2},
+                ]
+            },
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [],
+                'Ipv6Ranges': [
+                    {3: 3}, {6: 6}
+                ],
+                'PrefixListIds': [
+                    {4: 4},
+                ],
+                'ToPort': 123,
+                'UserIdGroupPairs': []
+            }
+        ]
+        type(mock_sg3).ip_permissions_egress = [
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [
+                    {1: 1},
+                    {2: 2},
+                    {3: 3},
+                    {4: 4},
+                    {5: 5},
+                    {6: 6},
+                ],
+                'Ipv6Ranges': [
+                    {1: 1},
+                    {2: 2},
+                    {3: 3},
+                    {4: 4},
+                    {5: 5},
+                    {6: 6},
+                    {7: 7},
+                    {8: 8},
+                    {9: 9},
+                    {10: 10},
+                    {11: 11},
+                    {12: 12},
+                    {13: 13}
+                ],
+                'PrefixListIds': [
+                    {1: 1},
+                    {2: 2},
+                    {3: 3},
+                    {4: 4},
+                    {5: 5},
+                    {6: 6},
+                    {7: 7},
+                    {8: 8},
+                    {9: 9},
+                    {10: 10}
+                ],
+                'ToPort': 123,
+                'UserIdGroupPairs': [
+                    {1: 1},
+                    {2: 2},
+                    {3: 3},
+                    {4: 4},
+                    {5: 5},
+                    {6: 6},
+                ]
+            }
+        ]
         mock_sg4 = Mock(spec_set=SecurityGroup)
         type(mock_sg4).id = 'sg-4'
-        type(mock_sg4).vpc_id = 'vpc-aaa'
-        type(mock_sg4).ip_permissions = [1, 2, 3]
-        type(mock_sg4).ip_permissions_egress = [21, 22, 23, 24]
+        type(mock_sg4).vpc_id = None
+        type(mock_sg4).ip_permissions = [
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [
+                    {
+                        'CidrIp': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'Ipv6Ranges': [
+                    {
+                        'CidrIpv6': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'PrefixListIds': [
+                    {
+                        'Description': 'string',
+                        'PrefixListId': 'string'
+                    },
+                ],
+                'ToPort': 123,
+                'UserIdGroupPairs': [
+                    {
+                        'Description': 'string',
+                        'GroupId': 'string',
+                        'GroupName': 'string',
+                        'PeeringStatus': 'string',
+                        'UserId': 'string',
+                        'VpcId': 'string',
+                        'VpcPeeringConnectionId': 'string'
+                    },
+                ]
+            },
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [
+                    {
+                        'CidrIp': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'Ipv6Ranges': [
+                    {
+                        'CidrIpv6': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'PrefixListIds': [
+                    {
+                        'Description': 'string',
+                        'PrefixListId': 'string'
+                    },
+                ],
+                'ToPort': 123,
+                'UserIdGroupPairs': [
+                    {
+                        'Description': 'string',
+                        'GroupId': 'string',
+                        'GroupName': 'string',
+                        'PeeringStatus': 'string',
+                        'UserId': 'string',
+                        'VpcId': 'string',
+                        'VpcPeeringConnectionId': 'string'
+                    },
+                ]
+            },
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [
+                    {
+                        'CidrIp': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'Ipv6Ranges': [
+                    {
+                        'CidrIpv6': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'PrefixListIds': [
+                    {
+                        'Description': 'string',
+                        'PrefixListId': 'string'
+                    },
+                ],
+                'ToPort': 123,
+                'UserIdGroupPairs': [
+                    {
+                        'Description': 'string',
+                        'GroupId': 'string',
+                        'GroupName': 'string',
+                        'PeeringStatus': 'string',
+                        'UserId': 'string',
+                        'VpcId': 'string',
+                        'VpcPeeringConnectionId': 'string'
+                    },
+                ]
+            },
+        ]
+        type(mock_sg4).ip_permissions_egress = [
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [
+                    {
+                        'CidrIp': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'Ipv6Ranges': [
+                    {
+                        'CidrIpv6': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'PrefixListIds': [
+                    {
+                        'Description': 'string',
+                        'PrefixListId': 'string'
+                    },
+                ],
+                'ToPort': 123,
+                'UserIdGroupPairs': [
+                    {
+                        'Description': 'string',
+                        'GroupId': 'string',
+                        'GroupName': 'string',
+                        'PeeringStatus': 'string',
+                        'UserId': 'string',
+                        'VpcId': 'string',
+                        'VpcPeeringConnectionId': 'string'
+                    },
+                ]
+            },
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [
+                    {
+                        'CidrIp': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'Ipv6Ranges': [
+                    {
+                        'CidrIpv6': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'PrefixListIds': [
+                    {
+                        'Description': 'string',
+                        'PrefixListId': 'string'
+                    },
+                ],
+                'ToPort': 123,
+                'UserIdGroupPairs': [
+                    {
+                        'Description': 'string',
+                        'GroupId': 'string',
+                        'GroupName': 'string',
+                        'PeeringStatus': 'string',
+                        'UserId': 'string',
+                        'VpcId': 'string',
+                        'VpcPeeringConnectionId': 'string'
+                    },
+                ]
+            },
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [
+                    {
+                        'CidrIp': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'Ipv6Ranges': [
+                    {
+                        'CidrIpv6': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'PrefixListIds': [
+                    {
+                        'Description': 'string',
+                        'PrefixListId': 'string'
+                    },
+                ],
+                'ToPort': 123,
+                'UserIdGroupPairs': [
+                    {
+                        'Description': 'string',
+                        'GroupId': 'string',
+                        'GroupName': 'string',
+                        'PeeringStatus': 'string',
+                        'UserId': 'string',
+                        'VpcId': 'string',
+                        'VpcPeeringConnectionId': 'string'
+                    },
+                ]
+            },
+            {
+                'FromPort': 123,
+                'IpProtocol': 'string',
+                'IpRanges': [
+                    {
+                        'CidrIp': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'Ipv6Ranges': [
+                    {
+                        'CidrIpv6': 'string',
+                        'Description': 'string'
+                    },
+                ],
+                'PrefixListIds': [
+                    {
+                        'Description': 'string',
+                        'PrefixListId': 'string'
+                    },
+                ],
+                'ToPort': 123,
+                'UserIdGroupPairs': [
+                    {
+                        'Description': 'string',
+                        'GroupId': 'string',
+                        'GroupName': 'string',
+                        'PeeringStatus': 'string',
+                        'UserId': 'string',
+                        'VpcId': 'string',
+                        'VpcPeeringConnectionId': 'string'
+                    },
+                ]
+            }
+        ]
 
         return_value = [
             mock_sg1,

--- a/awslimitchecker/tests/services/test_ec2.py
+++ b/awslimitchecker/tests/services/test_ec2.py
@@ -796,11 +796,15 @@ class TestFindUsageNetworkingSgs(object):
         assert sorted_usage[0].resource_id == 'sg-1'
         assert sorted_usage[0].get_value() == 0
         assert sorted_usage[1].limit == limit
-        assert sorted_usage[1].resource_id == 'sg-4'
-        assert sorted_usage[1].get_value() == 3
+        assert sorted_usage[1].resource_id == 'sg-2'
+        # ingress: IPv4 = 15; IPv6 = 13
+        # egress: IPv4 = 5; IPv6 = 7
+        assert sorted_usage[1].get_value() == 15
         assert sorted_usage[2].limit == limit
         assert sorted_usage[2].resource_id == 'sg-3'
-        assert sorted_usage[2].get_value() == 9
+        # ingress: IPv4 = 4; IPv6 = 5
+        # egress: IPv4 = 22; IPv6 = 29
+        assert sorted_usage[2].get_value() == 29
         assert mock_conn.mock_calls == [
             call.security_groups.all()
         ]


### PR DESCRIPTION
This fixes a major error in the calculation. See #431, and specifically [this comment](https://github.com/jantman/awslimitchecker/issues/431#issuecomment-548599785), for the specifics. Put another way (from this code):

            The value for each of ingress and egress is the count of all
            PrefixListIds in all rules, plus the count of all
            UserIdGroupPairs in all rules, plus the maximum of:
              the count of all IpRanges in all rules
                 -or-
              the count of all Ipv6Ranges in all rules

            The limit that we alert on is the maximum of those values for
            ingress and egress.

            In short, behind the scenes, there are four firewall rulesets
            per SG: (IPv4|IPv6) (ingress|egress)
            Each can have a maximum of <limit> entries. PrefixListIds and
            UserIdGroupPairs count towards both IPv4 and IPv6.