### PR TITLE
fixes #451: Updating default rules per VPC security group

### DIFF
--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -726,7 +726,7 @@ class _Ec2Service(_AwsService):
         limits['Rules per VPC security group'] = AwsLimit(
             'Rules per VPC security group',
             self,
-            50,
+            60,
             self.warning_threshold,
             self.critical_threshold,
             limit_type='AWS::EC2::SecurityGroup',


### PR DESCRIPTION
# Summary

Updates the default threshold for "Rules per Security Group" to 60 as per the "Inbound or outbound rules per security group" section [here](https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html).



## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.
