### PR TITLE
fix: avoid division by zero

### DIFF
--- a/awslimitchecker/limit.py
+++ b/awslimitchecker/limit.py
@@ -429,7 +429,7 @@ class AwsLimit(object):
         for u in self._current_usage:
             usage = u.get_value()
             limit = u.get_maximum() or self.get_limit()
-            if limit is None:
+            if limit is None or limit == 0:
                 continue
             pct = (usage / (limit * 1.0)) * 100
             if crit_int is not None and usage >= crit_int:


### PR DESCRIPTION
# Summary

There is a bug with division by zero:

```
awslimitchecker 8.0.1 is AGPL-licensed free software; all users have a right to the full source code of this version. See <https://github.com/jantman/awslimitchecker>
Traceback (most recent call last):
...
  File "/awslimitchecker/limit.py", line 434, in check_thresholds
    pct = (usage / (limit * 1.0)) * 100
ZeroDivisionError: float division by zero
```

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.
