### PR TITLE
Fix Python 2.7 end of support date

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ Requirements
 
 **Either Docker in order to run via the** `docker image <http://awslimitchecker.readthedocs.io/en/latest/docker.html>`__, **or:**
 
-* Python 3.5 or newer. Python 2.7 will not be supported as of January 1, 2010.
+* Python 3.5 or newer. Python 2.7 will not be supported as of January 1, 2020.
 * Python `VirtualEnv <http://www.virtualenv.org/>`_ and ``pip`` (recommended installation method; your OS/distribution should have packages for these)
 * `boto3 <http://boto3.readthedocs.org/>`_ >= 1.4.6 and its dependency `botocore <https://botocore.readthedocs.io/en/latest/>`_ >= 1.6.0.
 


### PR DESCRIPTION

# Summary

This PR fixes the Python 2.7 end of support date in README.

Reference: 
- https://pythonclock.org/

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.
