### PR TITLE
Fixes #463 - ECS and Fargate limit updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 Unreleased Changes
 ------------------
 
-**Important:** This release requires new IAM permissions: ``sts:GetCallerIdentity``
+**Important:** This release requires new IAM permissions: ``sts:GetCallerIdentity`` and ``cloudwatch:GetMetricData``
 
 **Important:** This release includes updates for major changes to ECS limits, which includes the renaming of some existing limits.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@ Unreleased Changes
   * The default of ``Clusters`` has increased from 2,000 to 10,000.
   * The default of ``Services per Cluster`` has increased from 1,000 to 2,000.
   * The ``Fargate Tasks`` limit has been removed.
+  * The ``Fargate On-Demand resource count`` limit has been added, with a default quota value of 500. This limit measures the number of ECS tasks and EKS pods running concurrently on Fargate. The current usage for this metric is obtained from CloudWatch.
+  * The ``Fargate Spot resource count`` limit has been added, with a default quota value of 500. This limit measures the number of ECS tasks running concurrently on Fargate Spot. The current usage for this metric is obtained from CloudWatch.
+
+* Add internal helper method to :py:class:`~._AwsService` to get Service Quotas usage information from CloudWatch.
 
 .. _changelog.8_1_0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,10 @@ Unreleased Changes
 * `Issue #457 <https://github.com/jantman/awslimitchecker/issues/457>`__ - In the required IAM permissions, replace ``support:*`` with the specific permissions that we need.
 * `Issue #463 <https://github.com/jantman/awslimitchecker/issues/463>`__ - Updates for the major changes to ECS limits `in August 2020 <https://github.com/awsdocs/amazon-ecs-developer-guide/commit/3ba9bc24b3f667557f43a49b9001fea3538311ad#diff-d98743b56c4036e0baeb5e15901d2a73>`__
 
-  * The ``EC2 Tasks per Service (desired count)`` has been replaced with ``Tasks per service``, which measures the desired count of tasks of all launch types (EC2 or Fargate). The default value of this limit has increased from 1000 to 2000.
+  * The ``EC2 Tasks per Service (desired count)`` limit has been replaced with ``Tasks per service``, which measures the desired count of tasks of all launch types (EC2 or Fargate). The default value of this limit has increased from 1000 to 2000.
+  * The default of ``Clusters`` has increased from 2,000 to 10,000.
+  * The default of ``Services per Cluster`` has increased from 1,000 to 2,000.
+  * The ``Fargate Tasks`` limit has been removed.
 
 .. _changelog.8_1_0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,11 +6,16 @@ Unreleased Changes
 
 **Important:** This release requires new IAM permissions: ``sts:GetCallerIdentity``
 
+**Important:** This release includes updates for major changes to ECS limits, which includes the renaming of some existing limits.
+
 * `Issue #477 <https://github.com/jantman/awslimitchecker/issues/477>`__ - EC2 instances running on Dedicated Hosts (tenancy "host") or single-tenant hardware (tenancy "dedicated") do not count towards On-Demand Instances limits. They were previously being counted towards these limits; they are now excluded from the count.
 * `Issue #477 <https://github.com/jantman/awslimitchecker/issues/477>`__ - For all VPC resources that support the ``owner-id`` filter, supply that filter when describing them, set to the current account ID. This will prevent shared resources from other accounts from being counted against the limits.
 * `Issue #475 <https://github.com/jantman/awslimitchecker/issues/475>`__ - When an Alert Provider is used, only exit non-zero if an exception is encountered. Exit zero even if there are warnings and/or criticals.
 * `Issue #467 <https://github.com/jantman/awslimitchecker/issues/467>`__ - Fix the Service Quotas quota name for VPC "NAT Gateways per AZ" limit.
 * `Issue #457 <https://github.com/jantman/awslimitchecker/issues/457>`__ - In the required IAM permissions, replace ``support:*`` with the specific permissions that we need.
+* `Issue #463 <https://github.com/jantman/awslimitchecker/issues/463>`__ - Updates for the major changes to ECS limits `in August 2020 <https://github.com/awsdocs/amazon-ecs-developer-guide/commit/3ba9bc24b3f667557f43a49b9001fea3538311ad#diff-d98743b56c4036e0baeb5e15901d2a73>`__
+
+  * The ``EC2 Tasks per Service (desired count)`` has been replaced with ``Tasks per service``, which measures the desired count of tasks of all launch types (EC2 or Fargate). The default value of this limit has increased from 1000 to 2000.
 
 .. _changelog.8_1_0:
 

--- a/awslimitchecker/checker.py
+++ b/awslimitchecker/checker.py
@@ -648,6 +648,7 @@ class AwsLimitChecker(object):
         :rtype: dict
         """
         required_actions = [
+            'cloudwatch:GetMetricData',
             'servicequotas:ListServiceQuotas',
             'support:DescribeTrustedAdvisorCheckRefreshStatuses',
             'support:DescribeTrustedAdvisorCheckResult',

--- a/awslimitchecker/services/base.py
+++ b/awslimitchecker/services/base.py
@@ -40,6 +40,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 import abc
 import logging
 import boto3
+from datetime import datetime, timedelta
 from awslimitchecker.connectable import Connectable
 
 logger = logging.getLogger(__name__)
@@ -92,6 +93,7 @@ class _AwsService(Connectable):
         self.limits = self.get_limits()
         self._have_usage = False
         self._current_account_id = None
+        self._cloudwatch_client = None
 
     @property
     def current_account_id(self):
@@ -300,3 +302,80 @@ class _AwsService(Connectable):
             )
             if val is not None:
                 lim._set_quotas_limit(val)
+
+    def _cloudwatch_connection(self):
+        """
+        Return a connected CloudWatch client instance. ONLY to be used by
+        :py:meth:`_get_cloudwatch_usage_latest`.
+        """
+        if self._cloudwatch_client is not None:
+            return self._cloudwatch_client
+        kwargs = dict(self._boto3_connection_kwargs)
+        if self._max_retries_config is not None:
+            kwargs['config'] = self._max_retries_config
+        self._cloudwatch_client = boto3.client('cloudwatch', **kwargs)
+        logger.info(
+            "Connected to cloudwatch in region %s",
+            self._cloudwatch_client._client_config.region_name
+        )
+        return self._cloudwatch_client
+
+    def _get_cloudwatch_usage_latest(
+        self, dimensions, metric_name='ResourceCount', period=60
+    ):
+        """
+        Given some metric dimensions, return the value of the latest data point
+        for the ``AWS/Usage`` metric specified.
+
+        :param dimensions: list of dicts; dimensions for the metric
+        :type dimensions: list
+        :param metric_name: AWS/Usage metric name to get
+        :type metric_name: str
+        :param period: metric period
+        :type period: int
+        :return: return the metric value (float or int), or None if it cannot
+          be retrieved
+        :rtype: ``float, int or None``
+        """
+        conn = self._cloudwatch_connection()
+        kwargs = dict(
+            MetricDataQueries=[
+                {
+                    'Id': 'id',
+                    'MetricStat': {
+                        'Metric': {
+                            'Namespace': 'AWS/Usage',
+                            'MetricName': metric_name,
+                            'Dimensions': dimensions
+                        },
+                        'Period': period,
+                        'Stat': 'Average'
+                    }
+                }
+            ],
+            StartTime=datetime.utcnow() - timedelta(hours=1),
+            EndTime=datetime.utcnow(),
+            ScanBy='TimestampDescending',
+            MaxDatapoints=1
+        )
+        try:
+            logger.debug('Querying CloudWatch GetMetricData: %s', kwargs)
+            resp = conn.get_metric_data(**kwargs)
+        except Exception as ex:
+            logger.error(
+                'Error querying CloudWatch GetMetricData for AWS/Usage %s: %s',
+                metric_name, ex
+            )
+            return 0
+        results = resp.get('MetricDataResults', [])
+        if len(results) < 1 or len(results[0]['Values']) < 1:
+            logger.warning(
+                'No data points found for AWS/Usage metric %s with dimensions '
+                '%s; using value of zero!', metric_name, dimensions
+            )
+            return 0
+        logger.debug(
+            'CloudWatch metric query returned value of %s with timestamp %s',
+            results[0]['Values'][0], results[0]['Timestamps'][0]
+        )
+        return results[0]['Values'][0]

--- a/awslimitchecker/services/ecs.py
+++ b/awslimitchecker/services/ecs.py
@@ -127,7 +127,7 @@ class _EcsService(_AwsService):
         :param cluster_name: name of the cluster to find usage for
         :type cluster_name: str
         """
-        tps_lim = self.limits['EC2 Tasks per Service (desired count)']
+        tps_lim = self.limits['Tasks per service']
         paginator = self.conn.get_paginator('list_services')
         for page in paginator.paginate(
             cluster=cluster_name, launchType='EC2'
@@ -136,8 +136,6 @@ class _EcsService(_AwsService):
                 svc = self.conn.describe_services(
                     cluster=cluster_name, services=[svc_arn]
                 )['services'][0]
-                if svc['launchType'] != 'EC2':
-                    continue
                 tps_lim._add_current_usage(
                     svc['desiredCount'],
                     aws_type='AWS::ECS::Service',
@@ -181,10 +179,10 @@ class _EcsService(_AwsService):
             self.critical_threshold,
             limit_type='AWS::ECS::Service'
         )
-        limits['EC2 Tasks per Service (desired count)'] = AwsLimit(
-            'EC2 Tasks per Service (desired count)',
+        limits['Tasks per service'] = AwsLimit(
+            'Tasks per service',
             self,
-            1000,
+            2000,
             self.warning_threshold,
             self.critical_threshold,
             limit_type='AWS::ECS::TaskDefinition',

--- a/awslimitchecker/services/ecs.py
+++ b/awslimitchecker/services/ecs.py
@@ -158,7 +158,7 @@ class _EcsService(_AwsService):
         limits['Clusters'] = AwsLimit(
             'Clusters',
             self,
-            2000,
+            10000,
             self.warning_threshold,
             self.critical_threshold,
             limit_type='AWS::ECS::Cluster',
@@ -174,7 +174,7 @@ class _EcsService(_AwsService):
         limits['Services per Cluster'] = AwsLimit(
             'Services per Cluster',
             self,
-            1000,
+            2000,
             self.warning_threshold,
             self.critical_threshold,
             limit_type='AWS::ECS::Service'

--- a/awslimitchecker/services/ecs.py
+++ b/awslimitchecker/services/ecs.py
@@ -71,8 +71,36 @@ class _EcsService(_AwsService):
         for lim in self.limits.values():
             lim._reset_usage()
         self._find_usage_clusters()
+        self._find_usage_fargate()
         self._have_usage = True
         logger.debug("Done checking usage.")
+
+    def _find_usage_fargate(self):
+        """
+        Find the usage for Fargate, via CloudWatch.
+        """
+        self.limits['Fargate On-Demand resource count']._add_current_usage(
+            self._get_cloudwatch_usage_latest(
+                [
+                    {'Name': 'Type', 'Value': 'Resource'},
+                    {'Name': 'Resource', 'Value': 'OnDemand'},
+                    {'Name': 'Service', 'Value': 'Fargate'},
+                    {'Name': 'Class', 'Value': 'None'},
+                ],
+            ),
+            aws_type='AWS::ECS::TaskDefinition'
+        )
+        self.limits['Fargate Spot resource count']._add_current_usage(
+            self._get_cloudwatch_usage_latest(
+                [
+                    {'Name': 'Type', 'Value': 'Resource'},
+                    {'Name': 'Resource', 'Value': 'Spot'},
+                    {'Name': 'Service', 'Value': 'Fargate'},
+                    {'Name': 'Class', 'Value': 'None'},
+                ],
+            ),
+            aws_type='AWS::ECS::TaskDefinition'
+        )
 
     def _find_usage_clusters(self):
         """
@@ -80,7 +108,6 @@ class _EcsService(_AwsService):
         :py:meth:`~._find_usage_one_cluster` for each cluster.
         """
         count = 0
-        fargate_task_count = 0
         paginator = self.conn.get_paginator('list_clusters')
         for page in paginator.paginate():
             for cluster_arn in page['clusterArns']:
@@ -101,21 +128,7 @@ class _EcsService(_AwsService):
                     aws_type='AWS::ECS::Service',
                     resource_id=cluster['clusterName']
                 )
-                # Note: 'statistics' is not always present in API responses,
-                # even if requested. As far as I can tell, it's omitted if
-                # a cluster has no Fargate tasks.
-                for stat in cluster.get('statistics', []):
-                    if stat['name'] != 'runningFargateTasksCount':
-                        continue
-                    logger.debug(
-                        'Found %s Fargate tasks in cluster %s',
-                        stat['value'], cluster_arn
-                    )
-                    fargate_task_count += int(stat['value'])
                 self._find_usage_one_cluster(cluster['clusterName'])
-        self.limits['Fargate Tasks']._add_current_usage(
-            fargate_task_count, aws_type='AWS::ECS::Task'
-        )
         self.limits['Clusters']._add_current_usage(
             count, aws_type='AWS::ECS::Cluster'
         )
@@ -188,14 +201,23 @@ class _EcsService(_AwsService):
             limit_type='AWS::ECS::TaskDefinition',
             limit_subtype='EC2'
         )
-        limits['Fargate Tasks'] = AwsLimit(
-            'Fargate Tasks',
+        limits['Fargate On-Demand resource count'] = AwsLimit(
+            'Fargate On-Demand resource count',
             self,
-            50,
+            500,
             self.warning_threshold,
             self.critical_threshold,
             limit_type='AWS::ECS::TaskDefinition',
             limit_subtype='Fargate'
+        )
+        limits['Fargate Spot resource count'] = AwsLimit(
+            'Fargate Spot resource count',
+            self,
+            500,
+            self.warning_threshold,
+            self.critical_threshold,
+            limit_type='AWS::ECS::TaskDefinition',
+            limit_subtype='FargateSpot'
         )
         self.limits = limits
         return limits

--- a/awslimitchecker/tests/services/test_base.py
+++ b/awslimitchecker/tests/services/test_base.py
@@ -42,6 +42,10 @@ from awslimitchecker.limit import AwsLimit
 from awslimitchecker.quotas import ServiceQuotasClient
 import pytest
 import sys
+from datetime import datetime
+from dateutil.tz import tzutc
+from freezegun import freeze_time
+from botocore.exceptions import ClientError
 
 # https://code.google.com/p/mock/issues/detail?id=249
 # py>=3.4 should use unittest.mock not the mock package on pypi
@@ -103,6 +107,7 @@ class Test_AwsService(object):
         assert cls._boto3_connection_kwargs == {}
         assert cls._quotas_client == m_quota
         assert cls._current_account_id is None
+        assert cls._cloudwatch_client is None
 
     def test_init_subclass_boto_xargs(self):
         boto_args = {'region_name': 'myregion',
@@ -119,6 +124,42 @@ class Test_AwsService(object):
         assert cls._boto3_connection_kwargs == boto_args
         assert cls._quotas_client is None
         assert cls._current_account_id is None
+        assert cls._cloudwatch_client is None
+
+    def test_current_account_id_stored(self):
+        mock_conf = Mock(region_name='foo')
+        mock_sts = Mock(_client_config=mock_conf)
+        mock_sts.get_caller_identity.return_value = {
+            'UserId': 'something',
+            'Account': '123456789',
+            'Arn': 'something'
+        }
+        cls = AwsServiceTester(1, 2, {'foo': 'bar'}, None)
+        cls._current_account_id = '987654321'
+        with patch('awslimitchecker.services.base.boto3.client') as m_boto:
+            m_boto.return_value = mock_sts
+            res = cls.current_account_id
+        assert res == '987654321'
+        assert m_boto.mock_calls == []
+
+    def test_current_account_id_needed(self):
+        mock_conf = Mock(region_name='foo')
+        mock_sts = Mock(_client_config=mock_conf)
+        mock_sts.get_caller_identity.return_value = {
+            'UserId': 'something',
+            'Account': '123456789',
+            'Arn': 'something'
+        }
+        cls = AwsServiceTester(1, 2, {'foo': 'bar'}, None)
+        with patch('awslimitchecker.services.base.boto3.client') as m_boto:
+            m_boto.return_value = mock_sts
+            res = cls.current_account_id
+        assert res == '123456789'
+        assert cls._current_account_id == '123456789'
+        assert m_boto.mock_calls == [
+            call('sts', foo='bar'),
+            call().get_caller_identity()
+        ]
 
     def test_set_limit_override(self):
         mock_limit = Mock(spec_set=AwsLimit)
@@ -376,38 +417,372 @@ class Test_AwsService(object):
         assert mock_limit1.mock_calls == []
         assert mock_limit2.mock_calls == []
 
-    def test_current_account_id_needed(self):
+    def test_cloudwatch_connection_needed(self):
         mock_conf = Mock(region_name='foo')
-        mock_sts = Mock(_client_config=mock_conf)
-        mock_sts.get_caller_identity.return_value = {
-            'UserId': 'something',
-            'Account': '123456789',
-            'Arn': 'something'
-        }
+        mock_cw = Mock(_client_config=mock_conf)
         cls = AwsServiceTester(1, 2, {'foo': 'bar'}, None)
-        cls._current_account_id = '987654321'
+        assert cls._cloudwatch_client is None
         with patch('awslimitchecker.services.base.boto3.client') as m_boto:
-            m_boto.return_value = mock_sts
-            res = cls.current_account_id
-        assert res == '987654321'
+            m_boto.return_value = mock_cw
+            res = cls._cloudwatch_connection()
+        assert res == mock_cw
+        assert cls._cloudwatch_client == mock_cw
+        assert m_boto.mock_calls == [
+            call.client('cloudwatch', foo='bar')
+        ]
+
+    def test_cloudwatch_connection_needed_max_retries(self):
+        mock_conf = Mock(region_name='foo')
+        mock_cw = Mock(_client_config=mock_conf)
+        cls = AwsServiceTester(1, 2, {'foo': 'bar'}, None)
+        assert cls._cloudwatch_client is None
+        with patch('awslimitchecker.services.base.boto3.client') as m_boto:
+            with patch(
+                'awslimitchecker.connectable.Connectable._max_retries_config',
+                new_callable=PropertyMock
+            ) as m_mrc:
+                m_mrc.return_value = {'retries': 5}
+                m_boto.return_value = mock_cw
+                res = cls._cloudwatch_connection()
+        assert res == mock_cw
+        assert cls._cloudwatch_client == mock_cw
+        assert m_boto.mock_calls == [
+            call.client('cloudwatch', foo='bar', config={'retries': 5})
+        ]
+
+    def test_cloudwatch_connection_stored(self):
+        mock_conf = Mock(region_name='foo')
+        mock_cw = Mock(_client_config=mock_conf)
+        cls = AwsServiceTester(1, 2, {'foo': 'bar'}, None)
+        cls._cloudwatch_client = mock_cw
+        with patch('awslimitchecker.services.base.boto3.client') as m_boto:
+            m_boto.return_value = mock_cw
+            res = cls._cloudwatch_connection()
+        assert res == mock_cw
+        assert cls._cloudwatch_client == mock_cw
         assert m_boto.mock_calls == []
 
-    def test_current_account_id_stored(self):
-        mock_conf = Mock(region_name='foo')
-        mock_sts = Mock(_client_config=mock_conf)
-        mock_sts.get_caller_identity.return_value = {
-            'UserId': 'something',
-            'Account': '123456789',
-            'Arn': 'something'
+
+class TestGetCloudwatchUsageLatest:
+
+    @freeze_time("2020-09-22 12:26:00", tz_offset=0)
+    def test_defaults(self):
+        mock_conn = Mock()
+        mock_conn.get_metric_data.return_value = {
+            'MetricDataResults': [
+                {
+                    'Id': 'id',
+                    'Label': 'ResourceCount',
+                    'Timestamps': [
+                        datetime(2020, 9, 22, 12, 25, tzinfo=tzutc())
+                    ],
+                    'Values': [3.0],
+                    'StatusCode': 'PartialData'
+                }
+            ],
+            'NextToken': 'foo',
+            'Messages': [],
+            'ResponseMetadata': {
+                'RequestId': '77a86d3c-16e1-47c5-b2d1-0f7d81d48a05',
+                'HTTPStatusCode': 200,
+                'HTTPHeaders': {
+                    'x-amzn-requestid': '70f7d81d48a05',
+                    'content-type': 'text/xml',
+                    'content-length': '796',
+                    'date': 'Tue, 22 Sep 2020 12:26:36 GMT'
+                },
+                'RetryAttempts': 0
+            }
         }
         cls = AwsServiceTester(1, 2, {'foo': 'bar'}, None)
-        with patch('awslimitchecker.services.base.boto3.client') as m_boto:
-            m_boto.return_value = mock_sts
-            res = cls.current_account_id
-        assert res == '123456789'
-        assert m_boto.mock_calls == [
-            call('sts', foo='bar'),
-            call().get_caller_identity()
+        with patch(
+            'awslimitchecker.services.base._AwsService._cloudwatch_connection',
+            autospec=True
+        ) as m_cw_conn:
+            m_cw_conn.return_value = mock_conn
+            res = cls._get_cloudwatch_usage_latest([
+                {'Name': 'foo', 'Value': 'bar'},
+                {'Name': 'baz', 'Value': 'blam'}
+            ])
+        assert res == 3.0
+        assert m_cw_conn.mock_calls == [
+            call(cls)
+        ]
+        assert mock_conn.mock_calls == [
+            call.get_metric_data(
+                MetricDataQueries=[
+                    {
+                        'Id': 'id',
+                        'MetricStat': {
+                            'Metric': {
+                                'Namespace': 'AWS/Usage',
+                                'MetricName': 'ResourceCount',
+                                'Dimensions': [
+                                    {'Name': 'foo', 'Value': 'bar'},
+                                    {'Name': 'baz', 'Value': 'blam'}
+                                ]
+                            },
+                            'Period': 60,
+                            'Stat': 'Average'
+                        }
+                    }
+                ],
+                StartTime=datetime(2020, 9, 22, 11, 26, 00),
+                EndTime=datetime(2020, 9, 22, 12, 26, 00),
+                ScanBy='TimestampDescending',
+                MaxDatapoints=1
+            )
+        ]
+
+    @freeze_time("2020-09-22 12:26:00", tz_offset=0)
+    def test_non_default(self):
+        mock_conn = Mock()
+        mock_conn.get_metric_data.return_value = {
+            'MetricDataResults': [
+                {
+                    'Id': 'id',
+                    'Label': 'ResourceCount',
+                    'Timestamps': [
+                        datetime(2020, 9, 22, 12, 25, tzinfo=tzutc())
+                    ],
+                    'Values': [3.0],
+                    'StatusCode': 'PartialData'
+                }
+            ],
+            'NextToken': 'foo',
+            'Messages': [],
+            'ResponseMetadata': {
+                'RequestId': '77a86d3c-16e1-47c5-b2d1-0f7d81d48a05',
+                'HTTPStatusCode': 200,
+                'HTTPHeaders': {
+                    'x-amzn-requestid': '70f7d81d48a05',
+                    'content-type': 'text/xml',
+                    'content-length': '796',
+                    'date': 'Tue, 22 Sep 2020 12:26:36 GMT'
+                },
+                'RetryAttempts': 0
+            }
+        }
+        cls = AwsServiceTester(1, 2, {'foo': 'bar'}, None)
+        with patch(
+            'awslimitchecker.services.base._AwsService._cloudwatch_connection',
+            autospec=True
+        ) as m_cw_conn:
+            m_cw_conn.return_value = mock_conn
+            res = cls._get_cloudwatch_usage_latest([
+                {'Name': 'foo', 'Value': 'bar'},
+                {'Name': 'baz', 'Value': 'blam'}
+            ], metric_name='MyMetric', period=3600)
+        assert res == 3.0
+        assert m_cw_conn.mock_calls == [
+            call(cls)
+        ]
+        assert mock_conn.mock_calls == [
+            call.get_metric_data(
+                MetricDataQueries=[
+                    {
+                        'Id': 'id',
+                        'MetricStat': {
+                            'Metric': {
+                                'Namespace': 'AWS/Usage',
+                                'MetricName': 'MyMetric',
+                                'Dimensions': [
+                                    {'Name': 'foo', 'Value': 'bar'},
+                                    {'Name': 'baz', 'Value': 'blam'}
+                                ]
+                            },
+                            'Period': 3600,
+                            'Stat': 'Average'
+                        }
+                    }
+                ],
+                StartTime=datetime(2020, 9, 22, 11, 26, 00),
+                EndTime=datetime(2020, 9, 22, 12, 26, 00),
+                ScanBy='TimestampDescending',
+                MaxDatapoints=1
+            )
+        ]
+
+    @freeze_time("2020-09-22 12:26:00", tz_offset=0)
+    def test_exception(self):
+        mock_conn = Mock()
+        mock_conn.get_metric_data.side_effect = ClientError(
+            {
+                'ResponseMetadata': {
+                    'HTTPStatusCode': 503,
+                    'RequestId': '7d74c6f0-c789-11e5-82fe-a96cdaa6d564'
+                },
+                'Error': {
+                    'Message': 'Service Unavailable',
+                    'Code': '503'
+                }
+            },
+            'GetMetricData'
+        )
+        cls = AwsServiceTester(1, 2, {'foo': 'bar'}, None)
+        with patch(
+            'awslimitchecker.services.base._AwsService._cloudwatch_connection',
+            autospec=True
+        ) as m_cw_conn:
+            m_cw_conn.return_value = mock_conn
+            res = cls._get_cloudwatch_usage_latest([
+                {'Name': 'foo', 'Value': 'bar'},
+                {'Name': 'baz', 'Value': 'blam'}
+            ], metric_name='MyMetric', period=3600)
+        assert res == 0
+        assert m_cw_conn.mock_calls == [
+            call(cls)
+        ]
+        assert mock_conn.mock_calls == [
+            call.get_metric_data(
+                MetricDataQueries=[
+                    {
+                        'Id': 'id',
+                        'MetricStat': {
+                            'Metric': {
+                                'Namespace': 'AWS/Usage',
+                                'MetricName': 'MyMetric',
+                                'Dimensions': [
+                                    {'Name': 'foo', 'Value': 'bar'},
+                                    {'Name': 'baz', 'Value': 'blam'}
+                                ]
+                            },
+                            'Period': 3600,
+                            'Stat': 'Average'
+                        }
+                    }
+                ],
+                StartTime=datetime(2020, 9, 22, 11, 26, 00),
+                EndTime=datetime(2020, 9, 22, 12, 26, 00),
+                ScanBy='TimestampDescending',
+                MaxDatapoints=1
+            )
+        ]
+
+    @freeze_time("2020-09-22 12:26:00", tz_offset=0)
+    def test_no_data(self):
+        mock_conn = Mock()
+        mock_conn.get_metric_data.return_value = {
+            'MetricDataResults': [],
+            'NextToken': 'foo',
+            'Messages': [],
+            'ResponseMetadata': {
+                'RequestId': '77a86d3c-16e1-47c5-b2d1-0f7d81d48a05',
+                'HTTPStatusCode': 200,
+                'HTTPHeaders': {
+                    'x-amzn-requestid': '70f7d81d48a05',
+                    'content-type': 'text/xml',
+                    'content-length': '796',
+                    'date': 'Tue, 22 Sep 2020 12:26:36 GMT'
+                },
+                'RetryAttempts': 0
+            }
+        }
+        cls = AwsServiceTester(1, 2, {'foo': 'bar'}, None)
+        with patch(
+            'awslimitchecker.services.base._AwsService._cloudwatch_connection',
+            autospec=True
+        ) as m_cw_conn:
+            m_cw_conn.return_value = mock_conn
+            res = cls._get_cloudwatch_usage_latest([
+                {'Name': 'foo', 'Value': 'bar'},
+                {'Name': 'baz', 'Value': 'blam'}
+            ], metric_name='MyMetric', period=3600)
+        assert res == 0
+        assert m_cw_conn.mock_calls == [
+            call(cls)
+        ]
+        assert mock_conn.mock_calls == [
+            call.get_metric_data(
+                MetricDataQueries=[
+                    {
+                        'Id': 'id',
+                        'MetricStat': {
+                            'Metric': {
+                                'Namespace': 'AWS/Usage',
+                                'MetricName': 'MyMetric',
+                                'Dimensions': [
+                                    {'Name': 'foo', 'Value': 'bar'},
+                                    {'Name': 'baz', 'Value': 'blam'}
+                                ]
+                            },
+                            'Period': 3600,
+                            'Stat': 'Average'
+                        }
+                    }
+                ],
+                StartTime=datetime(2020, 9, 22, 11, 26, 00),
+                EndTime=datetime(2020, 9, 22, 12, 26, 00),
+                ScanBy='TimestampDescending',
+                MaxDatapoints=1
+            )
+        ]
+
+    @freeze_time("2020-09-22 12:26:00", tz_offset=0)
+    def test_no_values(self):
+        mock_conn = Mock()
+        mock_conn.get_metric_data.return_value = {
+            'MetricDataResults': [
+                {
+                    'Id': 'id',
+                    'Label': 'ResourceCount',
+                    'Timestamps': [],
+                    'Values': [],
+                    'StatusCode': 'PartialData'
+                }
+            ],
+            'NextToken': 'foo',
+            'Messages': [],
+            'ResponseMetadata': {
+                'RequestId': '77a86d3c-16e1-47c5-b2d1-0f7d81d48a05',
+                'HTTPStatusCode': 200,
+                'HTTPHeaders': {
+                    'x-amzn-requestid': '70f7d81d48a05',
+                    'content-type': 'text/xml',
+                    'content-length': '796',
+                    'date': 'Tue, 22 Sep 2020 12:26:36 GMT'
+                },
+                'RetryAttempts': 0
+            }
+        }
+        cls = AwsServiceTester(1, 2, {'foo': 'bar'}, None)
+        with patch(
+            'awslimitchecker.services.base._AwsService._cloudwatch_connection',
+            autospec=True
+        ) as m_cw_conn:
+            m_cw_conn.return_value = mock_conn
+            res = cls._get_cloudwatch_usage_latest([
+                {'Name': 'foo', 'Value': 'bar'},
+                {'Name': 'baz', 'Value': 'blam'}
+            ], metric_name='MyMetric', period=3600)
+        assert res == 0
+        assert m_cw_conn.mock_calls == [
+            call(cls)
+        ]
+        assert mock_conn.mock_calls == [
+            call.get_metric_data(
+                MetricDataQueries=[
+                    {
+                        'Id': 'id',
+                        'MetricStat': {
+                            'Metric': {
+                                'Namespace': 'AWS/Usage',
+                                'MetricName': 'MyMetric',
+                                'Dimensions': [
+                                    {'Name': 'foo', 'Value': 'bar'},
+                                    {'Name': 'baz', 'Value': 'blam'}
+                                ]
+                            },
+                            'Period': 3600,
+                            'Stat': 'Average'
+                        }
+                    }
+                ],
+                StartTime=datetime(2020, 9, 22, 11, 26, 00),
+                EndTime=datetime(2020, 9, 22, 12, 26, 00),
+                ScanBy='TimestampDescending',
+                MaxDatapoints=1
+            )
         ]
 
 
@@ -434,6 +809,7 @@ class Test_AwsServiceSubclasses(object):
         assert inst.critical_threshold == 7
         assert not inst._boto3_connection_kwargs
         assert inst._current_account_id is None
+        assert inst._cloudwatch_client is None
 
         boto_args = dict(region_name='myregion',
                          aws_access_key_id='myaccesskey',

--- a/awslimitchecker/tests/services/test_ecs.py
+++ b/awslimitchecker/tests/services/test_ecs.py
@@ -74,7 +74,7 @@ class Test_EcsService(object):
         assert sorted(res.keys()) == sorted([
             'Clusters',
             'Container Instances per Cluster',
-            'EC2 Tasks per Service (desired count)',
+            'Tasks per service',
             'Fargate Tasks',
             'Services per Cluster',
         ])
@@ -263,15 +263,18 @@ class Test_EcsService(object):
             call.describe_services(cluster='cName', services=['s3arn'])
         ]
         u = cls.limits[
-            'EC2 Tasks per Service (desired count)'
+            'Tasks per service'
         ].get_current_usage()
-        assert len(u) == 2
+        assert len(u) == 3
         assert u[0].get_value() == 4
         assert u[0].resource_id == 'cluster=cName; service=s1'
         assert u[0].aws_type == 'AWS::ECS::Service'
-        assert u[1].get_value() == 8
-        assert u[1].resource_id == 'cluster=cName; service=s3'
+        assert u[1].get_value() == 26
+        assert u[1].resource_id == 'cluster=cName; service=s2'
         assert u[1].aws_type == 'AWS::ECS::Service'
+        assert u[2].get_value() == 8
+        assert u[2].resource_id == 'cluster=cName; service=s3'
+        assert u[2].aws_type == 'AWS::ECS::Service'
 
     def test_required_iam_permissions(self):
         cls = _EcsService(21, 43, {}, None)

--- a/awslimitchecker/tests/services/test_ecs.py
+++ b/awslimitchecker/tests/services/test_ecs.py
@@ -75,7 +75,8 @@ class Test_EcsService(object):
             'Clusters',
             'Container Instances per Cluster',
             'Tasks per service',
-            'Fargate Tasks',
+            'Fargate On-Demand resource count',
+            'Fargate Spot resource count',
             'Services per Cluster',
         ])
         for name, limit in res.items():
@@ -96,7 +97,8 @@ class Test_EcsService(object):
             pb,
             autospec=True,
             connect=DEFAULT,
-            _find_usage_clusters=DEFAULT
+            _find_usage_clusters=DEFAULT,
+            _find_usage_fargate=DEFAULT
         ) as mocks:
             cls = _EcsService(21, 43, {}, None)
             assert cls._have_usage is False
@@ -104,6 +106,35 @@ class Test_EcsService(object):
         assert mocks['connect'].mock_calls == [call(cls)]
         assert cls._have_usage is True
         assert mocks['connect'].return_value.mock_calls == []
+        assert mocks['_find_usage_clusters'].mock_calls == [call(cls)]
+        assert mocks['_find_usage_fargate'].mock_calls == [call(cls)]
+
+    def test_find_usage_fargate(self):
+
+        def se_gcul(klass, dims, metric_name='ResourceCount', period=60):
+            dim_dict = {x['Name']: x['Value'] for x in dims}
+            if dim_dict['Resource'] == 'OnDemand':
+                return 6.0
+            if dim_dict['Resource'] == 'Spot':
+                return 2.0
+            return 0
+
+        with patch(
+            '%s._get_cloudwatch_usage_latest' % pb, autospec=True
+        ) as m_gcul:
+            m_gcul.side_effect = se_gcul
+            cls = _EcsService(21, 43, {}, None)
+            cls._find_usage_fargate()
+        ondemand = cls.limits[
+            'Fargate On-Demand resource count'
+        ].get_current_usage()
+        assert len(ondemand) == 1
+        assert ondemand[0].get_value() == 6.0
+        assert ondemand[0].resource_id is None
+        spot = cls.limits['Fargate Spot resource count'].get_current_usage()
+        assert len(spot) == 1
+        assert spot[0].get_value() == 2.0
+        assert spot[0].resource_id is None
 
     def test_find_usage_clusters(self):
         def se_clusters(*_, **kwargs):
@@ -175,6 +206,10 @@ class Test_EcsService(object):
                 clusters=['c2arn'], include=['STATISTICS']
             )
         ]
+        assert m_fuoc.mock_calls == [
+            call(cls, 'c1name'),
+            call(cls, 'c2name')
+        ]
         c = cls.limits['Container Instances per Cluster'].get_current_usage()
         assert len(c) == 2
         assert c[0].get_value() == 11
@@ -191,14 +226,6 @@ class Test_EcsService(object):
         assert len(u) == 1
         assert u[0].get_value() == 2
         assert u[0].resource_id is None
-        f = cls.limits['Fargate Tasks'].get_current_usage()
-        assert len(f) == 1
-        assert f[0].get_value() == 4
-        assert f[0].resource_id is None
-        assert m_fuoc.mock_calls == [
-            call(cls, 'c1name'),
-            call(cls, 'c2name')
-        ]
 
     def test_find_usage_one_cluster(self):
 

--- a/awslimitchecker/tests/support.py
+++ b/awslimitchecker/tests/support.py
@@ -159,6 +159,12 @@ class LogRecordHelper(object):
                     r.funcName == 'quotas_for_service' and
                     'Attempted to retrieve Service Quotas' in r.msg):
                 continue
+            if (
+                r.levelno == logging.WARNING and r.module == 'base' and
+                r.funcName == '_get_cloudwatch_usage_latest' and
+                'No data points found for AWS/Usage metric' in r.msg
+            ):
+                continue
             res.append('%s:%s.%s (%s:%s) %s - %s %s' % (
                 r.name,
                 r.module,

--- a/awslimitchecker/tests/test_checker.py
+++ b/awslimitchecker/tests/test_checker.py
@@ -846,6 +846,7 @@ class TestAwsLimitChecker(object):
                 'Effect': 'Allow',
                 'Resource': '*',
                 'Action': [
+                    'cloudwatch:GetMetricData',
                     'ec2:bar',
                     'ec2:foo',
                     'foo:perm1',


### PR DESCRIPTION
This PR fixes #463 

-   [Issue \#463][] - Updates for the major changes to ECS limits [in August 2020][]
    -   The `EC2 Tasks per Service (desired count)` limit has been replaced with `Tasks per service`, which measures the desired count of tasks of all launch types (EC2 or Fargate). The default value of this limit has increased from 1000 to 2000.
    -   The default of `Clusters` has increased from 2,000 to 10,000.
    -   The default of `Services per Cluster` has increased from 1,000 to 2,000.
    -   The `Fargate Tasks` limit has been removed.
    -   The `Fargate On-Demand resource count` limit has been added, with a default quota value of 500. This limit measures the number of ECS tasks and EKS pods running concurrently on Fargate. The current usage for this metric is obtained from CloudWatch.
    -   The `Fargate Spot resource count` limit has been added, with a default quota value of 500. This limit measures the number of ECS tasks running concurrently on Fargate Spot. The current usage for this metric is obtained from CloudWatch.
-   Add internal helper method to :py`~._AwsService` to get Service Quotas usage information from CloudWatch.

  [Issue \#463]: https://github.com/jantman/awslimitchecker/issues/463
  [in August 2020]: https://github.com/awsdocs/amazon-ecs-developer-guide/commit/3ba9bc24b3f667557f43a49b9001fea3538311ad#diff-d98743b56c4036e0baeb5e15901d2a73