### PR TITLE
Fixes #466 - Disable TA by default except in China and GovCloud

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+.. _changelog.10_0_0:
+
+10.0.0 (2020-12-07)
+-------------------
+
+**Important:** This release makes significant changes to how Trusted Advisor is used.
+
+* `Issue #466 <https://github.com/jantman/awslimitchecker/issues/466>`__ - **Significant** changes to Trusted Advisor support.
+
+  * In June 2019, AWS `announced <https://aws.amazon.com/about-aws/whats-new/2019/06/introducing-service-quotas-view-and-manage-quotas-for-aws-services-from-one-location/>`__ the new Service Quotas service (great name) that allows us to retrieve limit/quota information from a unified API. In addition, many individual services now provide limit information via their own APIs. At this point (late 2020) all of the limit/quota information that was previously available via Trusted Advisor is now available via a combination of the individual service APIs and Service Quotas.
+  * In February 2020, the layout of Trusted Advisor checks was changed, and the "Performance / Service Limits" check that we previously used to obtain limit information was moved to its own category in Trusted Advisor. While I can't confirm this, as far as I can tell, this change was only made in the standard AWS regions/partitions (i.e. not GovCloud or China).
+  * awslimitchecker still has not been updated for this new Trusted Advisor layout.
+  * This release **disables Trusted Advisor by default outside China and GovCloud**, as it provides no additional information outside of these regions/partitions.
+  * If you are running in China or GovCloud and have issues with awslimitchecker retrieving information from Trusted Advisor, please `open an issue <https://github.com/jantman/awslimitchecker/issues>`__.
+  * My current intent is to leave Trusted Advisor support in this state until Service Quotas is available in China and GovCloud, at which point I plan on completely removing all Trusted Advisor support.
+
 .. _changelog.9_0_0:
 
 9.0.0 (2020-09-22)

--- a/awslimitchecker/tests/test_trustedadvisor.py
+++ b/awslimitchecker/tests/test_trustedadvisor.py
@@ -53,9 +53,9 @@ if (
         sys.version_info[0] < 3 or
         sys.version_info[0] == 3 and sys.version_info[1] < 4
 ):
-    from mock import patch, call, Mock
+    from mock import patch, call, Mock, DEFAULT
 else:
-    from unittest.mock import patch, call, Mock
+    from unittest.mock import patch, call, Mock, DEFAULT
 
 
 pbm = 'awslimitchecker.trustedadvisor'
@@ -163,34 +163,121 @@ class TestUpdateLimits(object):
 
     def test_simple(self):
         mock_results = Mock()
-        with patch('%s.connect' % pb, autospec=True) as mock_connect:
-            with patch('%s._poll' % pb, autospec=True) as mock_poll:
-                with patch('%s._update_services' % pb,
-                           autospec=True) as mock_update_services:
-                    mock_poll.return_value = mock_results
-                    self.cls.update_limits()
-        assert mock_connect.mock_calls == [call(self.cls)]
-        assert mock_poll.mock_calls == [call(self.cls)]
-        assert mock_update_services.mock_calls == [
+        with patch.multiple(
+            pb,
+            connect=DEFAULT,
+            _poll=DEFAULT,
+            _update_services=DEFAULT,
+            _dont_use_ta=DEFAULT,
+            autospec=True
+        ) as mocks:
+            mocks['_poll'].return_value = mock_results
+            mocks['_dont_use_ta'].return_value = False
+            self.cls.update_limits()
+        assert mocks['connect'].mock_calls == [call(self.cls)]
+        assert mocks['_poll'].mock_calls == [call(self.cls)]
+        assert mocks['_update_services'].mock_calls == [
             call(self.cls, mock_results)
         ]
 
     def test_again(self):
         mock_results = Mock()
         self.cls.limits_updated = True
-        with patch('%s.connect' % pb, autospec=True) as mock_connect:
-            with patch('%s._poll' % pb, autospec=True) as mock_poll:
-                with patch('%s._update_services' % pb,
-                           autospec=True) as mock_update_services:
-                    with patch('%s.logger' % pbm) as mock_logger:
-                        mock_poll.return_value = mock_results
-                        self.cls.update_limits()
-        assert mock_connect.mock_calls == []
-        assert mock_poll.mock_calls == []
-        assert mock_update_services.mock_calls == []
+        with patch.multiple(
+            pb,
+            connect=DEFAULT,
+            _poll=DEFAULT,
+            _update_services=DEFAULT,
+            _dont_use_ta=DEFAULT,
+            autospec=True
+        ) as mocks:
+            mocks['_poll'].return_value = mock_results
+            mocks['_dont_use_ta'].return_value = False
+            with patch('%s.logger' % pbm) as mock_logger:
+                self.cls.update_limits()
+        assert mocks['connect'].mock_calls == []
+        assert mocks['_poll'].mock_calls == []
+        assert mocks['_update_services'].mock_calls == []
         assert mock_logger.mock_calls == [
             call.debug('Already polled TA; skipping update')
         ]
+
+    def test_dont_use(self):
+        mock_results = Mock()
+        with patch.multiple(
+            pb,
+            connect=DEFAULT,
+            _poll=DEFAULT,
+            _update_services=DEFAULT,
+            _dont_use_ta=DEFAULT,
+            autospec=True
+        ) as mocks:
+            mocks['_poll'].return_value = mock_results
+            mocks['_dont_use_ta'].return_value = True
+            self.cls.update_limits()
+        assert mocks['connect'].mock_calls == [call(self.cls)]
+        assert mocks['_poll'].mock_calls == []
+        assert mocks['_update_services'].mock_calls == []
+
+
+class TestDontUseTa():
+
+    def setup(self):
+        self.mock_conn = Mock()
+        self.mock_client_config = Mock()
+        type(self.mock_client_config).region_name = 'us-east-1'
+        type(self.mock_conn)._client_config = self.mock_client_config
+        self.cls = TrustedAdvisor({}, {})
+        self.cls.conn = self.mock_conn
+
+        self.mock_svc1 = Mock(spec_set=_AwsService)
+        self.mock_svc2 = Mock(spec_set=_AwsService)
+        self.services = {
+            'SvcFoo': self.mock_svc1,
+            'SvcBar': self.mock_svc2,
+        }
+
+    @patch.dict(
+        'os.environ',
+        {'AWS_REGION': 'us-east-1'},
+        clear=True
+    )
+    def test_simple(self):
+        assert self.cls._dont_use_ta() is True
+
+    @patch.dict(
+        'os.environ',
+        {'AWS_REGION': 'us-east-1', 'FORCE_USE_TA': 'true'},
+        clear=True
+    )
+    def test_env_var(self):
+        assert self.cls._dont_use_ta() is False
+
+    @patch.dict(
+        'os.environ',
+        {'AWS_REGION': 'us-east-1', 'FORCE_USE_TA': 'nottrue'},
+        clear=True
+    )
+    def test_env_var_false(self):
+        assert self.cls._dont_use_ta() is True
+
+    @patch.dict(
+        'os.environ',
+        {'AWS_REGION': 'cn-foo-1'},
+        clear=True
+    )
+    def test_china(self):
+        type(self.mock_client_config).region_name = 'cn-foo-1'
+        assert self.cls._dont_use_ta() is False
+
+    @patch.dict(
+        'os.environ',
+        {'AWS_REGION': 'us-gov-east-1'},
+        clear=True
+    )
+    def test_gov_cloud(self):
+        type(self.mock_client_config).region_name = 'us-gov-east-1'
+        assert self.cls._dont_use_ta() is False
 
 
 class TestGetLimitCheckId(object):

--- a/awslimitchecker/trustedadvisor.py
+++ b/awslimitchecker/trustedadvisor.py
@@ -37,6 +37,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 ################################################################################
 """
 
+import os
 from botocore.exceptions import ClientError
 from dateutil import parser
 import logging
@@ -142,9 +143,38 @@ class TrustedAdvisor(Connectable):
             logger.debug('Already polled TA; skipping update')
             return
         self.connect()
+        if self._dont_use_ta():
+            logger.info(
+                'Not using Trusted Advisor in regions outside of China or '
+                'GovCloud; export FORCE_USE_TA=true to override.'
+            )
+            return
         ta_results = self._poll()
         self._update_services(ta_results)
         self.limits_updated = True
+
+    def _dont_use_ta(self):
+        """
+        If we are connecting to a region outside of China or GovCloud, and do
+        not have the ``FORCE_USE_TA`` environment variable set to ``true``,
+        don't use Trusted Advisor at all.
+
+        :return: whether whether to skip using TA
+        :rtype: bool
+        """
+        if os.environ.get('FORCE_USE_TA', '') == 'true':
+            logger.debug(
+                'Found env var FORCE_USE_TA set to "true"; forcing Trusted '
+                'Advisor polling.'
+            )
+            return False
+        region_name = self.conn._client_config.region_name
+        if region_name.startswith('cn-') or region_name.startswith('us-gov-'):
+            logger.debug(
+                'Using Trusted Advisor in region: %s', region_name
+            )
+            return False
+        return True
 
     def _poll(self):
         """

--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -267,6 +267,9 @@ from the Service Quotas service.
 Disabling Trusted Advisor Checks
 ++++++++++++++++++++++++++++++++
 
+.. attention::
+   Trusted Advisor support in awslimitchecker is deprecated outside of the China and GovCloud regions, and now defaults to disabled/skipped in standard AWS, as the information available from TA can now be retrieved faster and more accurately via other means. See :ref:`changelog.10_0_0` for further information.
+
 Using the ``--skip-ta`` option will disable attempting to query limit information
 from Trusted Advisor for all commands.
 
@@ -683,6 +686,9 @@ between your account and the 123456789012 destination account; see the
 
 Partitions and Trusted Advisor Regions
 ++++++++++++++++++++++++++++++++++++++
+
+.. attention::
+   Trusted Advisor support in awslimitchecker is deprecated outside of the China and GovCloud regions, and now defaults to disabled/skipped in standard AWS, as the information available from TA can now be retrieved faster and more accurately via other means. See :ref:`changelog.10_0_0` for further information.
 
 awslimitchecker currently supports operating against non-standard `partitions <https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html>`_, such as GovCloud and AWS China (Beijing). Partition names, as seen in the ``partition`` field of ARNs, can be specified with the ``--role-partition`` option to awslimitchecker, like ``--role-partition=aws-cn`` for the China (Beijing) partition. Similarly, the region name to use for the ``support`` API for Trusted Advisor can be specified with the ``--ta-api-region`` option, like ``--ta-api-region=us-gov-west-1``.
 

--- a/docs/source/cli_usage.rst.template
+++ b/docs/source/cli_usage.rst.template
@@ -69,6 +69,9 @@ from the Service Quotas service.
 Disabling Trusted Advisor Checks
 ++++++++++++++++++++++++++++++++
 
+.. attention::
+   Trusted Advisor support in awslimitchecker is deprecated outside of the China and GovCloud regions, and now defaults to disabled/skipped in standard AWS, as the information available from TA can now be retrieved faster and more accurately via other means. See :ref:`changelog.10_0_0` for further information.
+
 Using the ``--skip-ta`` option will disable attempting to query limit information
 from Trusted Advisor for all commands.
 
@@ -324,6 +327,9 @@ between your account and the 123456789012 destination account; see the
 
 Partitions and Trusted Advisor Regions
 ++++++++++++++++++++++++++++++++++++++
+
+.. attention::
+   Trusted Advisor support in awslimitchecker is deprecated outside of the China and GovCloud regions, and now defaults to disabled/skipped in standard AWS, as the information available from TA can now be retrieved faster and more accurately via other means. See :ref:`changelog.10_0_0` for further information.
 
 awslimitchecker currently supports operating against non-standard `partitions <https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html>`_, such as GovCloud and AWS China (Beijing). Partition names, as seen in the ``partition`` field of ARNs, can be specified with the ``--role-partition`` option to awslimitchecker, like ``--role-partition=aws-cn`` for the China (Beijing) partition. Similarly, the region name to use for the ``support`` API for Trusted Advisor can be specified with the ``--ta-api-region`` option, like ``--ta-api-region=us-gov-west-1``.
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -206,6 +206,9 @@ include 'NextToken' or another pagination marker, should be called through
 Trusted Advisor Checks
 ----------------------
 
+.. attention::
+   Trusted Advisor support in awslimitchecker is deprecated outside of the China and GovCloud regions, and now defaults to disabled/skipped in standard AWS, as the information available from TA can now be retrieved faster and more accurately via other means. See :ref:`changelog.10_0_0` for further information.
+
 So long as the ``Service`` and ``Limit`` name strings returned by the Trusted Advisor (Support) API exactly match
 how they are set on the corresponding :py:class:`~._AwsService` and :py:class:`~.AwsLimit` objects, no code changes
 are needed to support new limit checks from TA.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -153,6 +153,9 @@ to check limits in multiple regions, simply run the script multiple times, once 
 Trusted Advisor
 ---------------
 
+.. attention::
+   Trusted Advisor support in awslimitchecker is deprecated outside of the China and GovCloud regions, and now defaults to disabled/skipped in standard AWS, as the information available from TA can now be retrieved faster and more accurately via other means. See :ref:`changelog.10_0_0` for further information.
+
 awslimitchecker supports retrieving your current service limits via the
 `Trusted Advisor <https://aws.amazon.com/premiumsupport/trustedadvisor/>`_
 `"Service Limits" performance check <https://aws.amazon.com/premiumsupport/trustedadvisor/best-practices/#Performance>`_

--- a/docs/source/internals.rst
+++ b/docs/source/internals.rst
@@ -40,6 +40,9 @@ to the services and limits without any connection to AWS. This is utilized by th
 Trusted Advisor
 ---------------
 
+.. attention::
+   Trusted Advisor support in awslimitchecker is deprecated outside of the China and GovCloud regions, and now defaults to disabled/skipped in standard AWS, as the information available from TA can now be retrieved faster and more accurately via other means. See :ref:`changelog.10_0_0` for further information.
+
 When :py:class:`~awslimitchecker.checker.AwsLimitChecker` is initialized, it also initializes an instance of
 :py:class:`~awslimitchecker.trustedadvisor.TrustedAdvisor`. In :py:meth:`~.AwsLimitChecker.get_limits`,
 :py:meth:`~.AwsLimitChecker.find_usage` and :py:meth:`~.AwsLimitChecker.check_thresholds`, when called with

--- a/docs/source/python_usage.rst
+++ b/docs/source/python_usage.rst
@@ -56,6 +56,9 @@ parameter to the class constructor:
 Refreshing Trusted Advisor Check Results
 ++++++++++++++++++++++++++++++++++++++++
 
+.. attention::
+   Trusted Advisor support in awslimitchecker is deprecated outside of the China and GovCloud regions, and now defaults to disabled/skipped in standard AWS, as the information available from TA can now be retrieved faster and more accurately via other means. See :ref:`changelog.10_0_0` for further information.
+
 Trusted Advisor check refresh behavior is controlled by the ``ta_refresh_mode``
 and ``ta_refresh_timeout`` parameters on the :py:class:`~awslimitchecker.checker.AwsLimitChecker`
 constructor, which are passed through to the :py:class:`~awslimitchecker.trustedadvisor.TrustedAdvisor`
@@ -235,6 +238,9 @@ crossed the critical threshold:
 Disabling Trusted Advisor
 ++++++++++++++++++++++++++
 
+.. attention::
+   Trusted Advisor support in awslimitchecker is deprecated outside of the China and GovCloud regions, and now defaults to disabled/skipped in standard AWS, as the information available from TA can now be retrieved faster and more accurately via other means. See :ref:`changelog.10_0_0` for further information.
+
 To disable querying Trusted Advisor for limit information, call :py:meth:`~.AwsLimitChecker.get_limits`
 or :py:meth:`~.AwsLimitChecker.check_thresholds` with ``use_ta=False``:
 
@@ -258,6 +264,9 @@ in to the :py:class:`~.AwsLimitChecker` class constructor:
 
 Partitions and Trusted Advisor Regions
 ++++++++++++++++++++++++++++++++++++++
+
+.. attention::
+   Trusted Advisor support in awslimitchecker is deprecated outside of the China and GovCloud regions, and now defaults to disabled/skipped in standard AWS, as the information available from TA can now be retrieved faster and more accurately via other means. See :ref:`changelog.10_0_0` for further information.
 
 awslimitchecker currently supports operating against non-standard `partitions <https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html>`_, such as GovCloud and AWS China (Beijing). Partition names, as seen in the ``partition`` field of ARNs, can be specified with the ``role_partition`` keyword argument to the :py:class:`~.AwsLimitChecker` class. Similarly, the region name to use for the ``support`` API for Trusted Advisor can be specified with the ``ta_api_region`` keyword argument to the :py:class:`~.AwsLimitChecker` class.
 


### PR DESCRIPTION
This PR provides a temporary fix for #466 by disabling Trusted Advisor by default in regions/partitions other than China and GovCloud.