### PR TITLE
Fix #503 - Handle (A|E)LB per Region Service Quota with units Count or None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
   * If you are running in China or GovCloud and have issues with awslimitchecker retrieving information from Trusted Advisor, please `open an issue <https://github.com/jantman/awslimitchecker/issues>`__.
   * My current intent is to leave Trusted Advisor support in this state until Service Quotas is available in China and GovCloud, at which point I plan on completely removing all Trusted Advisor support.
 * Migrate CI builds from travis-ci.org to travis-ci.com.
+* `Issue #503 <https://github.com/jantman/awslimitchecker/issues/503>`__ - Fix ``Units set to "None"`` error when retrieving load balancer data from Service Quotas. We now allow the (A|E)LB per Region quota with a unit of either "Count" (prior to November 2020) or "None" (November 2020 on).
 
 .. _changelog.9_0_0:
 

--- a/awslimitchecker/quotas.py
+++ b/awslimitchecker/quotas.py
@@ -145,10 +145,11 @@ class ServiceQuotasClient(Connectable):
                 return converter(val, svc[quota_name.lower()]['Unit'], units)
             logger.error(
                 'ERROR: Service Quota service_code=%s QuotaName="%s" has '
-                'Units set to "%s"; awslimitchecker does not know how to '
+                'Units set to "%s", but expected units to be "%s"; '
+                'awslimitchecker does not know how to '
                 'handle this. This quota will be ignored. Please open a bug '
                 'report.', service_code, quota_name,
-                svc[quota_name.lower()]['Unit']
+                svc[quota_name.lower()]['Unit'], units
             )
             return None
         return val

--- a/awslimitchecker/tests/test_integration.py
+++ b/awslimitchecker/tests/test_integration.py
@@ -181,8 +181,8 @@ class TestIntegration(object):
         assert len(records) == 0, "awslimitchecker emitted unexpected log " \
             "messages at WARN or higher: \n%s" % "\n".join(records)
         polls = logs.num_ta_polls
-        assert polls == 1, "awslimitchecker should have polled Trusted " \
-            "Advisor once, but polled %s times" % polls
+        assert polls == 0, "awslimitchecker should have polled Trusted " \
+            "Advisor ZERO times, but polled %s times" % polls
 
     @pytest.mark.integration
     @skip_if_pr


### PR DESCRIPTION
This fixes #503 by handling the "Classic Load Balancers per Region" and "Application Load Balancers per Region" Service Quotas with Units set to either "Count" or "None". This bug was caused by yet another unannounced/undocumented change by AWS sometime between November 2 and November 9 of this year. See [this comment on the issue](https://github.com/jantman/awslimitchecker/issues/503#issuecomment-737226772) for details.