### PR TITLE
Fix #501 - update for new calculation of VPC/Network interfaces per Region limit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,8 @@ All Changes
   * Remove the ``EC2/Security groups per VPC`` limit, which no longer exists.
   * Add the new ``EC2/VPC security groups per Region`` limit.
 
+* `Issue #501 <https://github.com/jantman/awslimitchecker/issues/501>`__ - Update ``VPC/Network interfaces per Region`` limit for new calculation method.
+
 .. _changelog.9_0_0:
 
 9.0.0 (2020-09-22)

--- a/awslimitchecker/services/vpc.py
+++ b/awslimitchecker/services/vpc.py
@@ -48,8 +48,6 @@ from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_ENI_LIMIT = 350
-
 
 class _VpcService(_AwsService):
 
@@ -344,35 +342,13 @@ class _VpcService(_AwsService):
         limits['Network interfaces per Region'] = AwsLimit(
             'Network interfaces per Region',
             self,
-            DEFAULT_ENI_LIMIT,
+            5000,
             self.warning_threshold,
             self.critical_threshold,
             limit_type='AWS::EC2::NetworkInterface'
         )
         self.limits = limits
         return limits
-
-    def _update_limits_from_api(self):
-        """
-        Query EC2's DescribeAccountAttributes API action and
-        update the network interface limit, as needed. Updates ``self.limits``.
-
-        More info on the network interface limit, from the docs:
-        'This limit is the greater of either the default limit (350) or your
-        On-Demand Instance limit multiplied by 5.
-        The default limit for On-Demand Instances is 20.'
-        """
-        self.connect()
-        self.connect_resource()
-        logger.info("Querying EC2 DescribeAccountAttributes for limits")
-        attribs = self.conn.describe_account_attributes()
-        for attrib in attribs['AccountAttributes']:
-            if attrib['AttributeName'] == 'max-instances':
-                val = attrib['AttributeValues'][0]['AttributeValue']
-                if int(val) * 5 > DEFAULT_ENI_LIMIT:
-                    limit_name = 'Network interfaces per Region'
-                    self.limits[limit_name]._set_api_limit(int(val) * 5)
-        logger.debug("Done setting limits from API")
 
     def required_iam_permissions(self):
         """

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -221,6 +221,7 @@ class EBS(object):
 
 
 class VPC(object):
+
     test_find_usage_vpcs = {
         'Vpcs': [
             {
@@ -618,48 +619,6 @@ class VPC(object):
             'HTTPStatusCode': 200,
             'RequestId': '9cc96e79-3ace-43c2-8a5f-fa1e41017dc0'
         }
-    }
-
-    test_update_limits_from_api_high_max_instances = {
-        'ResponseMetadata': {
-            'HTTPStatusCode': 200,
-            'RequestId': '16b85906-ab0d-4134-b8bb-df3e6120c6c7'
-        },
-        'AccountAttributes': [
-            {
-                'AttributeName': 'max-instances',
-                'AttributeValues': [
-                    {
-                        'AttributeValue': '400'
-                    }
-                ]
-            }
-        ]
-    }
-
-    test_update_limits_from_api_low_max_instances = {
-        'ResponseMetadata': {
-            'HTTPStatusCode': 200,
-            'RequestId': '16b85906-ab0d-4134-b8bb-df3e6120c6c7'
-        },
-        'AccountAttributes': [
-            {
-                'AttributeName': 'max-instances',
-                'AttributeValues': [
-                    {
-                        'AttributeValue': '50'
-                    }
-                ]
-            },
-            {
-                'AttributeName': 'something-else',
-                'AttributeValues': [
-                    {
-                        'AttributeValue': '1'
-                    }
-                ]
-            }
-        ]
     }
 
 

--- a/awslimitchecker/tests/services/test_vpc.py
+++ b/awslimitchecker/tests/services/test_vpc.py
@@ -39,7 +39,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 
 import sys
 from awslimitchecker.tests.services import result_fixtures
-from awslimitchecker.services.vpc import _VpcService, DEFAULT_ENI_LIMIT
+from awslimitchecker.services.vpc import _VpcService
 
 from botocore.exceptions import ClientError
 
@@ -381,56 +381,6 @@ class Test_VpcService(object):
                 'Name': 'owner-id', 'Values': ['0123456789']
             }]),
         ]
-
-    def test_update_limits_from_api_high_max_instances(self):
-        fixtures = result_fixtures.VPC()
-        response = fixtures.test_update_limits_from_api_high_max_instances
-
-        mock_conn = Mock()
-        mock_client_conn = Mock()
-        mock_client_conn.describe_account_attributes.return_value = response
-
-        cls = _VpcService(21, 43, {}, None)
-        cls.resource_conn = mock_conn
-        cls.conn = mock_client_conn
-        with patch('awslimitchecker.services.vpc.logger') as mock_logger:
-            cls._update_limits_from_api()
-        assert mock_conn.mock_calls == []
-        assert mock_client_conn.mock_calls == [
-            call.describe_account_attributes()
-        ]
-        assert mock_logger.mock_calls == [
-            call.info("Querying EC2 DescribeAccountAttributes for limits"),
-            call.debug('Done setting limits from API')
-        ]
-        assert cls.limits['Network interfaces per Region'].api_limit == 2000
-        assert cls.limits['Network interfaces per Region'].get_limit() == 2000
-
-    def test_update_limits_from_api_low_max_instances(self):
-        fixtures = result_fixtures.VPC()
-        response = fixtures.test_update_limits_from_api_low_max_instances
-
-        mock_conn = Mock()
-        mock_client_conn = Mock()
-        mock_client_conn.describe_account_attributes.return_value = response
-
-        cls = _VpcService(21, 43, {}, None)
-        cls.resource_conn = mock_conn
-        cls.conn = mock_client_conn
-        with patch('awslimitchecker.services.vpc.logger') as mock_logger:
-            cls._update_limits_from_api()
-        assert mock_conn.mock_calls == []
-        assert mock_client_conn.mock_calls == [
-            call.describe_account_attributes()
-        ]
-        assert mock_logger.mock_calls == [
-            call.info("Querying EC2 DescribeAccountAttributes for limits"),
-            call.debug('Done setting limits from API')
-        ]
-
-        limit_name = 'Network interfaces per Region'
-        assert cls.limits[limit_name].api_limit is None
-        assert cls.limits[limit_name].get_limit() == DEFAULT_ENI_LIMIT
 
     def test_required_iam_permissions(self):
         cls = _VpcService(21, 43, {}, None)


### PR DESCRIPTION
This PR fixes #501 to update how the ``VPC/Network interfaces per Region`` limit is calculated.

Per https://docs.aws.amazon.com/vpc/latest/userguide/amazon-vpc-limits.html#vpc-limits-enis this limit is no longer calculated based on the on-demand instance count, but rather has a fixed default of 5000. This limit is also provided by Service Quotas, so in most cases the limit value will come from there.