### PR TITLE
Add gp3 ebs type

### DIFF
--- a/awslimitchecker/services/ebs.py
+++ b/awslimitchecker/services/ebs.py
@@ -83,7 +83,8 @@ class _EbsService(_AwsService):
         vols = 0
         piops = 0
         piops_gb = 0
-        gp_gb = 0
+        gp2_gb = 0
+        gp3_gb = 0
         mag_gb = 0
         st_gb = 0
         sc_gb = 0
@@ -100,7 +101,9 @@ class _EbsService(_AwsService):
                 piops_gb += vol['Size']
                 piops += vol['Iops']
             elif vol['VolumeType'] == 'gp2':
-                gp_gb += vol['Size']
+                gp2_gb += vol['Size']
+            elif vol['VolumeType'] == 'gp3':
+                gp3_gb += vol['Size']
             elif vol['VolumeType'] == 'standard':
                 mag_gb += vol['Size']
             elif vol['VolumeType'] == 'st1':
@@ -124,9 +127,15 @@ class _EbsService(_AwsService):
             aws_type='AWS::EC2::Volume'
         )
         self.limits[
-            'General Purpose (SSD) volume storage (GiB)'
+            'General Purpose (SSD gp2) volume storage (GiB)'
         ]._add_current_usage(
-            gp_gb,
+            gp2_gb,
+            aws_type='AWS::EC2::Volume'
+        )
+        self.limits[
+            'General Purpose (SSD gp3) volume storage (GiB)'
+        ]._add_current_usage(
+            gp3_gb,
             aws_type='AWS::EC2::Volume'
         )
         self.limits[

--- a/awslimitchecker/services/ebs.py
+++ b/awslimitchecker/services/ebs.py
@@ -222,8 +222,8 @@ class _EbsService(_AwsService):
             quotas_unit='GiB',
             quotas_unit_converter=convert_TiB_to_GiB
         )
-        limits['General Purpose (SSD) volume storage (GiB)'] = AwsLimit(
-            'General Purpose (SSD) volume storage (GiB)',
+        limits['General Purpose (SSD gp2) volume storage (GiB)'] = AwsLimit(
+            'General Purpose (SSD gp2) volume storage (GiB)',
             self,
             307200,
             self.warning_threshold,
@@ -231,7 +231,20 @@ class _EbsService(_AwsService):
             limit_type='AWS::EC2::Volume',
             limit_subtype='gp2',
             ta_limit_name='General Purpose SSD (gp2) volume storage (GiB)',
-            quotas_name='General Purpose (SSD) volume storage',
+            quotas_name='Storage for General Purpose SSD (gp2) volumes',
+            quotas_unit='GiB',
+            quotas_unit_converter=convert_TiB_to_GiB
+        )
+        limits['General Purpose (SSD gp3) volume storage (GiB)'] = AwsLimit(
+            'General Purpose (SSD gp3) volume storage (GiB)',
+            self,
+            307200,
+            self.warning_threshold,
+            self.critical_threshold,
+            limit_type='AWS::EC2::Volume',
+            limit_subtype='gp3',
+            ta_limit_name='General Purpose SSD (gp3) volume storage (GiB)',
+            quotas_name='Storage for General Purpose SSD (gp3) volumes',
             quotas_unit='GiB',
             quotas_unit_converter=convert_TiB_to_GiB
         )

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -192,7 +192,7 @@ class EBS(object):
             {
                 'VolumeId': 'vol-3',
                 'Size': 10,
-                'VolumeType': 'gp2',
+                'VolumeType': 'gp3',
                 'Iops': 30,
             },
             # 30G general purpose SSD gp3, 90 IOPS

--- a/awslimitchecker/tests/services/result_fixtures.py
+++ b/awslimitchecker/tests/services/result_fixtures.py
@@ -141,14 +141,14 @@ class EBS(object):
                 'VolumeType': 'standard',
                 'Iops': None,
             },
-            # 15G general purpose SSD, 45 IOPS
+            # 15G general purpose SSD gp2, 45 IOPS
             {
                 'VolumeId': 'vol-3',
                 'Size': 15,
                 'VolumeType': 'gp2',
                 'Iops': 45,
             },
-            # 30G general purpose SSD, 90 IOPS
+            # 30G general purpose SSD gp2, 90 IOPS
             {
                 'VolumeId': 'vol-4',
                 'Size': 30,
@@ -187,6 +187,20 @@ class EBS(object):
                 'Size': 1000,
                 'VolumeType': 'sc1',
                 'Iops': None,
+            },
+            # 10G general purpose SSD gp3, 30 IOPS
+            {
+                'VolumeId': 'vol-3',
+                'Size': 10,
+                'VolumeType': 'gp2',
+                'Iops': 30,
+            },
+            # 30G general purpose SSD gp3, 90 IOPS
+            {
+                'VolumeId': 'vol-4',
+                'Size': 30,
+                'VolumeType': 'gp3',
+                'Iops': 90,
             },
         ]
     }

--- a/awslimitchecker/tests/services/test_ebs.py
+++ b/awslimitchecker/tests/services/test_ebs.py
@@ -101,11 +101,17 @@ class Test_EbsService(object):
         assert piops_tb.limit_type == 'AWS::EC2::Volume'
         assert piops_tb.limit_subtype == 'io1'
         assert piops_tb.default_limit == 307200
-        gp_tb = limits['General Purpose (SSD) volume storage (GiB)']
+        gp2_tb = limits['General Purpose (SSD gp2) volume storage (GiB)']
         assert gp_tb.limit_type == 'AWS::EC2::Volume'
         assert gp_tb.limit_subtype == 'gp2'
         assert gp_tb.default_limit == 307200
         assert gp_tb.ta_limit_name == 'General Purpose SSD (gp2) ' \
+                                      'volume storage (GiB)'
+        gp_tb = limits['General Purpose (SSD gp3) volume storage (GiB)']
+        assert gp_tb.limit_type == 'AWS::EC2::Volume'
+        assert gp_tb.limit_subtype == 'gp3'
+        assert gp_tb.default_limit == 307200
+        assert gp_tb.ta_limit_name == 'General Purpose SSD (gp3) ' \
                                       'volume storage (GiB)'
         mag_tb = limits['Magnetic volume storage (GiB)']
         assert mag_tb.limit_type == 'AWS::EC2::Volume'
@@ -165,7 +171,9 @@ class Test_EbsService(object):
                               '(GiB)'].get_current_usage()) == 1
         assert cls.limits['Provisioned IOPS (SSD) storage '
                           '(GiB)'].get_current_usage()[0].get_value() == 500
-        assert len(cls.limits['General Purpose (SSD) volume storage '
+        assert len(cls.limits['General Purpose (SSD gp2) volume storage '
+                              '(GiB)'].get_current_usage()) == 1
+        assert len(cls.limits['General Purpose (SSD gp3) volume storage '
                               '(GiB)'].get_current_usage()) == 1
         assert cls.limits['General Purpose (SSD) volume storage '
                           '(GiB)'].get_current_usage()[0].get_value() == 45

--- a/awslimitchecker/tests/services/test_ebs.py
+++ b/awslimitchecker/tests/services/test_ebs.py
@@ -173,10 +173,12 @@ class Test_EbsService(object):
                           '(GiB)'].get_current_usage()[0].get_value() == 500
         assert len(cls.limits['General Purpose (SSD gp2) volume storage '
                               '(GiB)'].get_current_usage()) == 1
+        assert cls.limits['General Purpose (SSD gp2) volume storage '
+                          '(GiB)'].get_current_usage()[0].get_value() == 45
         assert len(cls.limits['General Purpose (SSD gp3) volume storage '
                               '(GiB)'].get_current_usage()) == 1
-        assert cls.limits['General Purpose (SSD) volume storage '
-                          '(GiB)'].get_current_usage()[0].get_value() == 45
+        assert cls.limits['General Purpose (SSD gp3) volume storage '
+                          '(GiB)'].get_current_usage()[0].get_value() == 40
         assert len(cls.limits['Magnetic volume storage '
                               '(GiB)'].get_current_usage()) == 1
         assert cls.limits['Magnetic volume storage '

--- a/awslimitchecker/tests/services/test_ebs.py
+++ b/awslimitchecker/tests/services/test_ebs.py
@@ -92,7 +92,7 @@ class Test_EbsService(object):
             assert isinstance(limits[x], AwsLimit)
             assert x == limits[x].name
             assert limits[x].service == cls
-        assert len(limits) == 8
+        assert len(limits) == 9
         piops = limits['Provisioned IOPS']
         assert piops.limit_type == 'AWS::EC2::Volume'
         assert piops.limit_subtype == 'io1'

--- a/awslimitchecker/tests/services/test_ebs.py
+++ b/awslimitchecker/tests/services/test_ebs.py
@@ -102,16 +102,16 @@ class Test_EbsService(object):
         assert piops_tb.limit_subtype == 'io1'
         assert piops_tb.default_limit == 307200
         gp2_tb = limits['General Purpose (SSD gp2) volume storage (GiB)']
-        assert gp_tb.limit_type == 'AWS::EC2::Volume'
-        assert gp_tb.limit_subtype == 'gp2'
-        assert gp_tb.default_limit == 307200
-        assert gp_tb.ta_limit_name == 'General Purpose SSD (gp2) ' \
+        assert gp2_tb.limit_type == 'AWS::EC2::Volume'
+        assert gp2_tb.limit_subtype == 'gp2'
+        assert gp2_tb.default_limit == 307200
+        assert gp2_tb.ta_limit_name == 'General Purpose SSD (gp2) ' \
                                       'volume storage (GiB)'
-        gp_tb = limits['General Purpose (SSD gp3) volume storage (GiB)']
-        assert gp_tb.limit_type == 'AWS::EC2::Volume'
-        assert gp_tb.limit_subtype == 'gp3'
-        assert gp_tb.default_limit == 307200
-        assert gp_tb.ta_limit_name == 'General Purpose SSD (gp3) ' \
+        gp3_tb = limits['General Purpose (SSD gp3) volume storage (GiB)']
+        assert gp3_tb.limit_type == 'AWS::EC2::Volume'
+        assert gp3_tb.limit_subtype == 'gp3'
+        assert gp3_tb.default_limit == 307200
+        assert gp3_tb.ta_limit_name == 'General Purpose SSD (gp3) ' \
                                       'volume storage (GiB)'
         mag_tb = limits['Magnetic volume storage (GiB)']
         assert mag_tb.limit_type == 'AWS::EC2::Volume'

--- a/awslimitchecker/tests/services/test_ebs.py
+++ b/awslimitchecker/tests/services/test_ebs.py
@@ -106,13 +106,13 @@ class Test_EbsService(object):
         assert gp2_tb.limit_subtype == 'gp2'
         assert gp2_tb.default_limit == 307200
         assert gp2_tb.ta_limit_name == 'General Purpose SSD (gp2) ' \
-                                      'volume storage (GiB)'
+                                       'volume storage (GiB)'
         gp3_tb = limits['General Purpose (SSD gp3) volume storage (GiB)']
         assert gp3_tb.limit_type == 'AWS::EC2::Volume'
         assert gp3_tb.limit_subtype == 'gp3'
         assert gp3_tb.default_limit == 307200
         assert gp3_tb.ta_limit_name == 'General Purpose SSD (gp3) ' \
-                                      'volume storage (GiB)'
+                                       'volume storage (GiB)'
         mag_tb = limits['Magnetic volume storage (GiB)']
         assert mag_tb.limit_type == 'AWS::EC2::Volume'
         assert mag_tb.limit_subtype == 'standard'

--- a/awslimitchecker/tests/services/test_ebs.py
+++ b/awslimitchecker/tests/services/test_ebs.py
@@ -194,7 +194,7 @@ class Test_EbsService(object):
 
         assert len(cls.limits['Active volumes'].get_current_usage()) == 1
         assert cls.limits['Active volumes'
-                          ''].get_current_usage()[0].get_value() == 9
+                          ''].get_current_usage()[0].get_value() == 11
         assert mock_conn.mock_calls == []
         assert mock_paginate.mock_calls == [
             call(


### PR DESCRIPTION
# Summary

Add gp3 as an EBS volume type.

We are currently receiving an error: `ERROR - unknown volume type 'gp3' for volume ...`

[AWS docs](https://docs.aws.amazon.com/general/latest/gr/ebs-service.html) show these as two separate limits. Luckily, the limits appear to behave the same as the gp2 limits.

# Pull Request Checklist

- [x] All pull requests should be __against the develop branch__, not master.
- [x] All pull requests must include the Contributor License Agreement (see below).
- [x] Whether or not your PR includes unit tests:
    - [x] Please make sure you have run the exact code contained in the PR locally, and it functions as desired.
    - [x] Please make sure the TravisCI build passes or, if not, you've corrected any obvious problems identified by the tests.
- [x] Code should conform to the [Development Guidelines](http://awslimitchecker.readthedocs.org/en/latest/development.html#guidelines):
    - [x] pep8 compliant with some exceptions (see pytest.ini)
    - [x] 100% test coverage with pytest (with valid tests). If you have difficulty
      writing tests for the code, that's fine, just mention that in the summary and either
      ask for assistance, or clarify that you'd like someone else to handle the tests. PRs that
      include complete test coverage will usually be merged faster.
    - [x] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [x] documentation has been rebuilt with ``tox -e docs``
    - [x] Connections to the AWS services should only be made by the class's
      ``connect()`` and ``connect_resource()`` methods, inherited from
      [awslimitchecker.connectable.Connectable](http://awslimitchecker.readthedocs.org/en/latest/awslimitchecker.connectable.html)
    - [x] All modules should have (and use) module-level loggers.
    - [x] **Commit messages** should be meaningful, and reference the Issue number
      if you're working on a GitHub issue (i.e. "issue #x - <message>"). Please
      refrain from using the "fixes #x" notation unless you are *sure* that the
      the issue is fixed in that commit.
    - [x] Git history is fully intact; please do not squash or rewrite history.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.
