### PR TITLE
use retry mode: standard

### DIFF
--- a/awslimitchecker/connectable.py
+++ b/awslimitchecker/connectable.py
@@ -112,9 +112,13 @@ class Connectable(object):
         """
         if self.conn is not None:
             return
+
+        default_config = Config(retries = {'mode': 'standard'})
         kwargs = dict(self._boto3_connection_kwargs)
+        kwargs['config'] = default_config
+
         if self._max_retries_config is not None:
-            kwargs['config'] = self._max_retries_config
+            kwargs['config'] = default_config.merge(self._max_retries_config)
         self.conn = boto3.client(self.api_name, **kwargs)
         logger.info("Connected to %s in region %s",
                     self.api_name, self.conn._client_config.region_name)
@@ -132,9 +136,14 @@ class Connectable(object):
         """
         if self.resource_conn is not None:
             return
+
+        default_config = Config(retries = {'mode': 'standard'})
         kwargs = dict(self._boto3_connection_kwargs)
+        kwargs['config'] = default_config
+
         if self._max_retries_config is not None:
-            kwargs['config'] = self._max_retries_config
+            kwargs['config'] = default_config.merge(self._max_retries_config)
+
         self.resource_conn = boto3.resource(self.api_name, **kwargs)
         logger.info("Connected to %s (resource) in region %s", self.api_name,
                     self.resource_conn.meta.client._client_config.region_name)

--- a/awslimitchecker/connectable.py
+++ b/awslimitchecker/connectable.py
@@ -113,7 +113,7 @@ class Connectable(object):
         if self.conn is not None:
             return
 
-        default_config = Config(retries={'mode': 'standard'})
+        default_config = Config(retries={'mode': 'adaptive'})
         kwargs = dict(self._boto3_connection_kwargs)
         kwargs['config'] = default_config
 
@@ -137,7 +137,7 @@ class Connectable(object):
         if self.resource_conn is not None:
             return
 
-        default_config = Config(retries={'mode': 'standard'})
+        default_config = Config(retries={'mode': 'adaptive'})
         kwargs = dict(self._boto3_connection_kwargs)
         kwargs['config'] = default_config
 

--- a/awslimitchecker/connectable.py
+++ b/awslimitchecker/connectable.py
@@ -113,7 +113,7 @@ class Connectable(object):
         if self.conn is not None:
             return
 
-        default_config = Config(retries = {'mode': 'standard'})
+        default_config = Config(retries={'mode': 'standard'})
         kwargs = dict(self._boto3_connection_kwargs)
         kwargs['config'] = default_config
 
@@ -137,7 +137,7 @@ class Connectable(object):
         if self.resource_conn is not None:
             return
 
-        default_config = Config(retries = {'mode': 'standard'})
+        default_config = Config(retries={'mode': 'standard'})
         kwargs = dict(self._boto3_connection_kwargs)
         kwargs['config'] = default_config
 

--- a/awslimitchecker/tests/test_connectable.py
+++ b/awslimitchecker/tests/test_connectable.py
@@ -145,9 +145,9 @@ class Test_Connectable(object):
                 with patch('%s.boto3.client' % pbm) as mock_client:
                     with patch('%s.Config' % pbm) as m_conf:
                         with patch(
-                            '%s._max_retries_config' % pb, new_callable=PropertyMock
+                            '%s._max_retries_config' % pb, new_callable=PropertyMock    # noqa - ignore line length
                         ) as m_mrc:
-                            m_conf.return_value.merge.return_value = mock_botoconfig
+                            m_conf.return_value.merge.return_value = mock_botoconfig    # noqa - ignore line length
                             mock_client.return_value = mock_conn
                             cls.connect()
         assert mock_kwargs.mock_calls == [call()]
@@ -188,9 +188,9 @@ class Test_Connectable(object):
                 with patch('%s.boto3.client' % pbm) as mock_client:
                     with patch('%s.Config' % pbm) as m_conf:
                         with patch(
-                            '%s._max_retries_config' % pb, new_callable=PropertyMock
+                            '%s._max_retries_config' % pb, new_callable=PropertyMock    # noqa - ignore line length
                         ) as m_mrc:
-                            m_conf.return_value.merge.return_value = mock_botoconfig
+                            m_conf.return_value.merge.return_value = mock_botoconfig    # noqa - ignore line length
                             m_mrc.return_value = mock_conf
                             mock_client.return_value = mock_conn
                             cls.connect()
@@ -314,7 +314,7 @@ class Test_Connectable(object):
                                 '%s._max_retries_config' % pb,
                                 new_callable=PropertyMock
                         ) as m_mrc:
-                            m_conf.return_value.merge.return_value = mock_botoconfig
+                            m_conf.return_value.merge.return_value = mock_botoconfig    # noqa - ignore line length
                             m_mrc.return_value = mock_conf
                             mock_resource.return_value = mock_conn
                             cls.connect_resource()

--- a/awslimitchecker/tests/test_connectable.py
+++ b/awslimitchecker/tests/test_connectable.py
@@ -129,6 +129,8 @@ class Test_Connectable(object):
     def test_connect(self):
         mock_conn = Mock()
         mock_cc = Mock()
+        mock_botoconfig = Mock()
+
         type(mock_cc).region_name = 'myregion'
         type(mock_conn)._client_config = mock_cc
 
@@ -141,12 +143,13 @@ class Test_Connectable(object):
             mock_kwargs.return_value = kwargs
             with patch('%s.logger' % pbm) as mock_logger:
                 with patch('%s.boto3.client' % pbm) as mock_client:
-                    with patch(
-                        '%s._max_retries_config' % pb, new_callable=PropertyMock
-                    ) as m_mrc:
-                        m_mrc.return_value = None
-                        mock_client.return_value = mock_conn
-                        cls.connect()
+                    with patch('%s.Config' % pbm) as m_conf:
+                        with patch(
+                            '%s._max_retries_config' % pb, new_callable=PropertyMock
+                        ) as m_mrc:
+                            m_conf.return_value.merge.return_value = mock_botoconfig
+                            mock_client.return_value = mock_conn
+                            cls.connect()
         assert mock_kwargs.mock_calls == [call()]
         assert mock_logger.mock_calls == [
             call.info("Connected to %s in region %s",
@@ -157,15 +160,19 @@ class Test_Connectable(object):
             call(
                 'myapi',
                 foo='fooval',
-                bar='barval'
+                bar='barval',
+                config=mock_botoconfig,
             )
         ]
-        assert m_mrc.mock_calls == [call()]
+        assert m_mrc.mock_calls == [call(), call()]
         assert cls.conn == mock_client.return_value
 
     def test_connect_with_retries(self):
         mock_conn = Mock()
         mock_cc = Mock()
+        mock_conf = Mock()
+        mock_botoconfig = Mock()
+
         type(mock_cc).region_name = 'myregion'
         type(mock_conn)._client_config = mock_cc
 
@@ -179,12 +186,14 @@ class Test_Connectable(object):
             mock_kwargs.return_value = kwargs
             with patch('%s.logger' % pbm) as mock_logger:
                 with patch('%s.boto3.client' % pbm) as mock_client:
-                    with patch(
-                        '%s._max_retries_config' % pb, new_callable=PropertyMock
-                    ) as m_mrc:
-                        m_mrc.return_value = mock_conf
-                        mock_client.return_value = mock_conn
-                        cls.connect()
+                    with patch('%s.Config' % pbm) as m_conf:
+                        with patch(
+                            '%s._max_retries_config' % pb, new_callable=PropertyMock
+                        ) as m_mrc:
+                            m_conf.return_value.merge.return_value = mock_botoconfig
+                            m_mrc.return_value = mock_conf
+                            mock_client.return_value = mock_conn
+                            cls.connect()
         assert mock_kwargs.mock_calls == [call()]
         assert mock_logger.mock_calls == [
             call.info("Connected to %s in region %s",
@@ -196,7 +205,7 @@ class Test_Connectable(object):
                 'myapi',
                 foo='fooval',
                 bar='barval',
-                config=mock_conf
+                config=mock_botoconfig
             )
         ]
         assert m_mrc.mock_calls == [call(), call()]
@@ -236,6 +245,8 @@ class Test_Connectable(object):
         mock_meta = Mock()
         mock_client = Mock()
         mock_cc = Mock()
+        mock_botoconfig = Mock()
+
         type(mock_cc).region_name = 'myregion'
         type(mock_client)._client_config = mock_cc
         type(mock_meta).client = mock_client
@@ -250,13 +261,15 @@ class Test_Connectable(object):
             mock_kwargs.return_value = kwargs
             with patch('%s.logger' % pbm) as mock_logger:
                 with patch('%s.boto3.resource' % pbm) as mock_resource:
-                    with patch(
-                            '%s._max_retries_config' % pb,
-                            new_callable=PropertyMock
-                    ) as m_mrc:
-                        m_mrc.return_value = None
-                        mock_resource.return_value = mock_conn
-                        cls.connect_resource()
+                    with patch('%s.Config' % pbm) as m_conf:
+                        with patch(
+                                '%s._max_retries_config' % pb,
+                                new_callable=PropertyMock
+                        ) as m_mrc:
+                            m_conf.return_value = mock_botoconfig
+                            m_mrc.return_value = None
+                            mock_resource.return_value = mock_conn
+                            cls.connect_resource()
         assert mock_kwargs.mock_calls == [call()]
         assert mock_logger.mock_calls == [
             call.info("Connected to %s (resource) in region %s",
@@ -267,7 +280,8 @@ class Test_Connectable(object):
             call(
                 'myapi',
                 foo='fooval',
-                bar='barval'
+                bar='barval',
+                config=mock_botoconfig,
             )
         ]
         assert m_mrc.mock_calls == [call()]
@@ -278,6 +292,8 @@ class Test_Connectable(object):
         mock_meta = Mock()
         mock_client = Mock()
         mock_cc = Mock()
+        mock_botoconfig = Mock()
+
         type(mock_cc).region_name = 'myregion'
         type(mock_client)._client_config = mock_cc
         type(mock_meta).client = mock_client
@@ -293,13 +309,15 @@ class Test_Connectable(object):
             mock_kwargs.return_value = kwargs
             with patch('%s.logger' % pbm) as mock_logger:
                 with patch('%s.boto3.resource' % pbm) as mock_resource:
-                    with patch(
-                            '%s._max_retries_config' % pb,
-                            new_callable=PropertyMock
-                    ) as m_mrc:
-                        m_mrc.return_value = mock_conf
-                        mock_resource.return_value = mock_conn
-                        cls.connect_resource()
+                    with patch('%s.Config' % pbm) as m_conf:
+                        with patch(
+                                '%s._max_retries_config' % pb,
+                                new_callable=PropertyMock
+                        ) as m_mrc:
+                            m_conf.return_value.merge.return_value = mock_botoconfig
+                            m_mrc.return_value = mock_conf
+                            mock_resource.return_value = mock_conn
+                            cls.connect_resource()
         assert mock_kwargs.mock_calls == [call()]
         assert mock_logger.mock_calls == [
             call.info("Connected to %s (resource) in region %s",
@@ -311,7 +329,7 @@ class Test_Connectable(object):
                 'myapi',
                 foo='fooval',
                 bar='barval',
-                config=mock_conf
+                config=mock_botoconfig
             )
         ]
         assert m_mrc.mock_calls == [call(), call()]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal=1
 
 [pycodestyle]
 exclude = lib/*,lib64/*
-max-line-length = 85
+max-line-length = 80
 ignore = E741,W504
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal=1
 
 [pycodestyle]
 exclude = lib/*,lib64/*
-max-line-length = 80
+max-line-length = 85
 ignore = E741,W504
 
 [tool:pytest]


### PR DESCRIPTION
This PR moves the boto config to using retry mode: standard, as the default retry mode is legacy.
https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html

Please let me know your thoughts on this PR.

---

Before submitting pull requests, please see the
[Development documentation](http://awslimitchecker.readthedocs.org/en/latest/development.html)
and specifically the [Pull Request Guidelines](http://awslimitchecker.readthedocs.org/en/latest/development.html#pull-requests).

__IMPORTANT:__ Please take note of the below checklist, especially the first three items.

# Summary

*Add a summary of what your PR does here. This could be as simple as "adds support for X service" or "fixes default limit for Y", or a longer explanation for less straightforward changes.*

# Pull Request Checklist

- [x] All pull requests should be __against the develop branch__, not master.
- [x] All pull requests must include the Contributor License Agreement (see below).
- [x] Whether or not your PR includes unit tests:
    - [x] Please make sure you have run the exact code contained in the PR locally, and it functions as desired.
    - [x] Please make sure the TravisCI build passes or, if not, you've corrected any obvious problems identified by the tests.
- [x] Code should conform to the [Development Guidelines](http://awslimitchecker.readthedocs.org/en/latest/development.html#guidelines):
    - [x] pep8 compliant with some exceptions (see pytest.ini)
    - [x] 100% test coverage with pytest (with valid tests). If you have difficulty
      writing tests for the code, that's fine, just mention that in the summary and either
      ask for assistance, or clarify that you'd like someone else to handle the tests. PRs that
      include complete test coverage will usually be merged faster.
    - [x] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [x] documentation has been rebuilt with ``tox -e docs``
    - [x] Connections to the AWS services should only be made by the class's
      ``connect()`` and ``connect_resource()`` methods, inherited from
      [awslimitchecker.connectable.Connectable](http://awslimitchecker.readthedocs.org/en/latest/awslimitchecker.connectable.html)
    - [x] All modules should have (and use) module-level loggers.
    - [x] **Commit messages** should be meaningful, and reference the Issue number
      if you're working on a GitHub issue (i.e. "issue #x - <message>"). Please
      refrain from using the "fixes #x" notation unless you are *sure* that the
      the issue is fixed in that commit.
    - [x] Git history is fully intact; please do not squash or rewrite history.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.
