### PR TITLE
Replace "Max spot instance requests per region" limit with vCPU-based limits

### DIFF
--- a/awslimitchecker/services/ec2.py
+++ b/awslimitchecker/services/ec2.py
@@ -604,7 +604,7 @@ class _Ec2Service(_AwsService):
         limits['All F Spot Instance Requests'] = AwsLimit(
             'All F Spot Instance Requests',
             self,
-            128,
+            11,
             self.warning_threshold,
             self.critical_threshold,
             limit_subtype='F'
@@ -612,7 +612,7 @@ class _Ec2Service(_AwsService):
         limits['All G Spot Instance Requests'] = AwsLimit(
             'All G Spot Instance Requests',
             self,
-            64,
+            11,
             self.warning_threshold,
             self.critical_threshold,
             limit_subtype='G'
@@ -628,7 +628,7 @@ class _Ec2Service(_AwsService):
         limits['All P Spot Instance Requests'] = AwsLimit(
             'All P Spot Instance Requests',
             self,
-            128,
+            16,
             self.warning_threshold,
             self.critical_threshold,
             limit_subtype='P'
@@ -636,7 +636,7 @@ class _Ec2Service(_AwsService):
         limits['All X Spot Instance Requests'] = AwsLimit(
             'All X Spot Instance Requests',
             self,
-            128,
+            21,
             self.warning_threshold,
             self.critical_threshold,
             limit_subtype='X'
@@ -646,7 +646,7 @@ class _Ec2Service(_AwsService):
         ] = AwsLimit(
             'All Standard (A, C, D, H, I, M, R, T, Z) Spot Instance Requests',
             self,
-            640,
+            1440,
             self.warning_threshold,
             self.critical_threshold,
             limit_subtype='Standard'

--- a/docs/source/iam_policy.rst
+++ b/docs/source/iam_policy.rst
@@ -61,7 +61,6 @@ services that do not affect the results of this program.
             "ec2:DescribeSpotFleetInstances",
             "ec2:DescribeSpotFleetRequestHistory",
             "ec2:DescribeSpotFleetRequests",
-            "ec2:DescribeSpotInstanceRequests",
             "ec2:DescribeSpotPriceHistory",
             "ec2:DescribeSubnets",
             "ec2:DescribeVolumes",

--- a/docs/source/limits.rst
+++ b/docs/source/limits.rst
@@ -176,10 +176,15 @@ type.
 ==================================================================== =============== ======== ======= ====
 Limit                                                                Trusted Advisor Quotas   API     Default
 ==================================================================== =============== ======== ======= ====
+All F Spot Instance Requests                                                         |check|          128 
+All G Spot Instance Requests                                                         |check|          64  
+All Inf Spot Instance Requests                                                       |check|          64  
+All P Spot Instance Requests                                                         |check|          128 
+All Standard (A, C, D, H, I, M, R, T, Z) Spot Instance Requests                      |check|          640 
+All X Spot Instance Requests                                                         |check|          128 
 Elastic IP addresses (EIPs)                                                                   |check| 5   
 Max active spot fleets per region                                                                     1000
 Max launch specifications per spot fleet                                                              50  
-Max spot instance requests per region                                                                 20  
 Max target capacity for all spot fleets in region                                                     5000
 Max target capacity per spot fleet                                                                    3000
 Rules per VPC security group                                                         |check|          60  


### PR DESCRIPTION
# Summary

BREAKING CHANGE

As mentioned in issue #502, the limit "Max spot instance requests per region" was removed from AWS and replaced by the following limits, based on the number of vCPU:
- All F Spot Instance Requests
- All G Spot Instance Requests
- All Inf Spot Instance Requests
- All P Spot Instance Requests
- All Standard (A, C, D, H, I, M, R, T, Z) Spot Instance Requests
- All X Spot Instance Requests

As a result, the usage reported by awslimitchecker is not relevant anymore.

In order to fix this, this commit replaces the call to the EC2 API describe_spot_instance_requests() with a call to the CloudWatch API, since the usage of Spot requests vCPUs is now available as a metric in CloudWatch.

In addition, the applied limits are now retrieved from the Service Quotas service.

# Pull Request Checklist

- [x] All pull requests should be __against the develop branch__, not master.
- [x] All pull requests must include the Contributor License Agreement (see below).
- [ ] Whether or not your PR includes unit tests:
    - [x] Please make sure you have run the exact code contained in the PR locally, and it functions as desired.
    - [ ] Please make sure the TravisCI build passes or, if not, you've corrected any obvious problems identified by the tests.
- [x] Code should conform to the [Development Guidelines](http://awslimitchecker.readthedocs.org/en/latest/development.html#guidelines):
    - [x] pep8 compliant with some exceptions (see pytest.ini)
    - [x] 100% test coverage with pytest (with valid tests). If you have difficulty
      writing tests for the code, that's fine, just mention that in the summary and either
      ask for assistance, or clarify that you'd like someone else to handle the tests. PRs that
      include complete test coverage will usually be merged faster.
    - [x] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [x] documentation has been rebuilt with ``tox -e docs``
    - [x] Connections to the AWS services should only be made by the class's
      ``connect()`` and ``connect_resource()`` methods, inherited from
      [awslimitchecker.connectable.Connectable](http://awslimitchecker.readthedocs.org/en/latest/awslimitchecker.connectable.html)
    - [x] All modules should have (and use) module-level loggers.
    - [x] **Commit messages** should be meaningful, and reference the Issue number
      if you're working on a GitHub issue (i.e. "issue #x - <message>"). Please
      refrain from using the "fixes #x" notation unless you are *sure* that the
      the issue is fixed in that commit.
    - [x] Git history is fully intact; please do not squash or rewrite history.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.
