### PR TITLE
adding an alternative Datadog metric format 'servicetags'

### DIFF
--- a/docs/source/cli_usage.rst
+++ b/docs/source/cli_usage.rst
@@ -222,13 +222,13 @@ and limits followed by ``(API)`` have been obtained from the service's API.
 .. code-block:: console
 
    (venv)$ awslimitchecker -l
-   ApiGateway/API keys per account                                           500.0 (Quotas)
+   ApiGateway/API keys per account                                           10000.0 (Quotas)
    ApiGateway/Client certificates per account                                60.0 (Quotas)
    ApiGateway/Custom authorizers per API                                     10
    ApiGateway/Documentation parts per API                                    2000
    ApiGateway/Edge APIs per account                                          120.0 (Quotas)
    (...)
-   AutoScaling/Auto Scaling groups                                           200 (API)
+   AutoScaling/Auto Scaling groups                                           500 (API)
    (...)
    Lambda/Function Count                                                     None
    (...)
@@ -253,7 +253,7 @@ from the Service Quotas service.
    ApiGateway/Documentation parts per API                                    2000
    ApiGateway/Edge APIs per account                                          120
    (...)
-   AutoScaling/Auto Scaling groups                                           200 (API)
+   AutoScaling/Auto Scaling groups                                           500 (API)
    (...)
    Lambda/Function Count                                                     None
    (...)
@@ -275,13 +275,13 @@ from Trusted Advisor for all commands.
 .. code-block:: console
 
    (venv)$ awslimitchecker -l --skip-ta
-   ApiGateway/API keys per account                                           500.0 (Quotas)
+   ApiGateway/API keys per account                                           10000.0 (Quotas)
    ApiGateway/Client certificates per account                                60.0 (Quotas)
    ApiGateway/Custom authorizers per API                                     10
    ApiGateway/Documentation parts per API                                    2000
    ApiGateway/Edge APIs per account                                          120.0 (Quotas)
    (...)
-   AutoScaling/Auto Scaling groups                                           200 (API)
+   AutoScaling/Auto Scaling groups                                           500 (API)
    (...)
    Lambda/Function Count                                                     None
    (...)
@@ -344,15 +344,15 @@ using their IDs).
 .. code-block:: console
 
    (venv)$ awslimitchecker -u
-   ApiGateway/API keys per account                                           2
+   ApiGateway/API keys per account                                           0
    ApiGateway/Client certificates per account                                0
-   ApiGateway/Custom authorizers per API                                     max: 2d7q4kzcmh=2 (2d7q4kz (...)
-   ApiGateway/Documentation parts per API                                    max: 2d7q4kzcmh=2 (2d7q4kz (...)
-   ApiGateway/Edge APIs per account                                          9
+   ApiGateway/Custom authorizers per API                                     <unknown>
+   ApiGateway/Documentation parts per API                                    <unknown>
+   ApiGateway/Edge APIs per account                                          0
    (...)
-   VPC/Subnets per VPC                                                       max: vpc-f4279a92=6 (vpc-f (...)
+   VPC/Subnets per VPC                                                       max: vpc-02031d86da0b6d120 (...)
    VPC/VPCs                                                                  2
-   VPC/Virtual private gateways                                              1
+   VPC/Virtual private gateways                                              0
 
 
 
@@ -377,7 +377,7 @@ For example, to override the limits of EC2's "EC2-Classic Elastic IPs" and
 .. code-block:: console
 
    (venv)$ awslimitchecker -L "AutoScaling/Auto Scaling groups"=321 --limit="AutoScaling/Launch configurations"=456 -l
-   ApiGateway/API keys per account                                           500.0 (Quotas)
+   ApiGateway/API keys per account                                           10000.0 (Quotas)
    ApiGateway/Client certificates per account                                60.0 (Quotas)
    ApiGateway/Custom authorizers per API                                     10
    ApiGateway/Documentation parts per API                                    2000
@@ -412,7 +412,7 @@ Using a command like:
 .. code-block:: console
 
    (venv)$ awslimitchecker --limit-override-json=limit_overrides.json -l
-   ApiGateway/API keys per account                                           500.0 (Quotas)
+   ApiGateway/API keys per account                                           10000.0 (Quotas)
    ApiGateway/Client certificates per account                                60.0 (Quotas)
    ApiGateway/Custom authorizers per API                                     10
    ApiGateway/Documentation parts per API                                    2000
@@ -573,6 +573,26 @@ environment variable) and an optional ``extra_tags`` parameter:
 
 Metrics will be pushed to the provider only when awslimitchecker is done checking
 all limits.
+
+There is also an alternative metric format for
+:py:class:`~awslimitchecker.metrics.datadog.Datadog` metrics provider which
+uses only two metrics ``awslimitchecker.limit`` and
+``awslimitchecker.max_usage``. All service limits are added as tags to these
+metrics.
+
+To use this alternative format add optional parameter ``metric_format=servicetags``:
+
+.. code-block:: console
+
+    (venv)$ awslimitchecker \
+        --metrics-provider=Datadog \
+        --metrics-config=api_key=123456 \
+        --metrics-config=extra_tags=foo,bar,baz:blam \
+        --metrics-config=metric_format=servicetags
+
+You can use the following query with one Datadog monitor for all service limits.
+``avg(last_4h):avg:awslimitchecker.max_usage{*} by {service_limit} /
+avg:awslimitchecker.limit{*} by {service_limit} * 100 > 95``
 
 .. _cli_usage.alerts:
 

--- a/docs/source/cli_usage.rst.template
+++ b/docs/source/cli_usage.rst.template
@@ -273,6 +273,26 @@ environment variable) and an optional ``extra_tags`` parameter:
 Metrics will be pushed to the provider only when awslimitchecker is done checking
 all limits.
 
+There is also an alternative metric format for
+:py:class:`~awslimitchecker.metrics.datadog.Datadog` metrics provider which
+uses only two metrics ``awslimitchecker.limit`` and
+``awslimitchecker.max_usage``. All service limits are added as tags to these
+metrics.
+
+To use this alternative format add optional parameter ``metric_format=servicetags``:
+
+.. code-block:: console
+
+    (venv)$ awslimitchecker \
+        --metrics-provider=Datadog \
+        --metrics-config=api_key=123456 \
+        --metrics-config=extra_tags=foo,bar,baz:blam \
+        --metrics-config=metric_format=servicetags
+
+You can use the following query with one Datadog monitor for all service limits.
+``avg(last_4h):avg:awslimitchecker.max_usage{*} by {service_limit} /
+avg:awslimitchecker.limit{*} by {service_limit} * 100 > 95``
+
 .. _cli_usage.alerts:
 
 Enable Alerts Provider

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -179,7 +179,7 @@ Trusted Advisor
 
 awslimitchecker supports retrieving your current service limits via the
 `Trusted Advisor <https://aws.amazon.com/premiumsupport/trustedadvisor/>`_
-`"Service Limits" performance check <https://aws.amazon.com/premiumsupport/trustedadvisor/best-practices/#Performance>`_
+`"Service Limits" performance check <https://docs.aws.amazon.com/awssupport/latest/user/performance-checks.html>`_
 , for limits which Trusted Advisor tracks (currently a subset of what awslimitchecker
 knows about). The results of this check may not be available via the API for all
 accounts; as of December 2016, the Trusted Advisor documentation states that while

--- a/docs/source/limits.rst
+++ b/docs/source/limits.rst
@@ -222,7 +222,7 @@ type.
 Limit                                                                Trusted Advisor Quotas   API     Default
 ==================================================================== =============== ======== ======= ====
 All F Spot Instance Requests                                                         |check|          11  
-All G Spot Instance Requests                                                         |check|          11  
+All G Spot Instance Requests                                                                          11  
 All Inf Spot Instance Requests                                                       |check|          64  
 All P Spot Instance Requests                                                         |check|          16  
 All Standard (A, C, D, H, I, M, R, T, Z) Spot Instance Requests                      |check|          1440
@@ -234,7 +234,7 @@ Max target capacity for all spot fleets in region                               
 Max target capacity per spot fleet                                                                    3000
 Rules per VPC security group                                                         |check|          60  
 Running On-Demand All F instances                                                    |check|          128 
-Running On-Demand All G instances                                                    |check|          128 
+Running On-Demand All G instances                                                                     128 
 Running On-Demand All P instances                                                    |check|          128 
 Running On-Demand All Standard (A, C, D, H, I, M, R, T, Z) instances                 |check|          1152
 Running On-Demand All X instances                                                    |check|          128 


### PR DESCRIPTION
# Summary

* adding an alternative Datadog metric format 'servicetags' to limit the number of metrics that are created and make monitoring them easier.

* minor fixes so docs could build

This is a very similar request to [PR 556](https://github.com/jantman/awslimitchecker/pull/556) except this is backward compatible, all changes are optional.

```
awslimitchecker \
     --metrics-provider Datadog \
     --metrics-config=api_key=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
     --metrics-config=metric_format=servicetags
....
    {
      "metric": "awslimitchecker.max_usage",
      "points": [
        [
          12546,
          0
        ]
      ],
      "type": "gauge",
      "tags": [
        "service:apigateway",
        "service_limit:apigateway.api_keys_per_account"
      ]
    },
    {
      "metric": "awslimitchecker.limit",
      "points": [
        [
          12463,
          10
        ]
      ],
      "type": "gauge",
      "tags": [
        "service:apigateway",
        "service_limit:apigateway.api_keys_per_account"
      ]
    },
...
```
<img width="1608" alt="Screen Shot 2022-05-13 at 12 39 43 PM" src="https://user-images.githubusercontent.com/8728145/168338263-3eba29d8-a721-416d-b747-21ce7e21230c.png">



We can use one monitor and one query to track all sevice limits.
```
avg(last_4h):avg:awslimitchecker.max_usage{*} by {service_limit} / avg:awslimitchecker.limit{*} by {service_limit} * 100 > 95
```
<img width="1754" alt="Screen Shot 2022-05-13 at 12 34 53 PM" src="https://user-images.githubusercontent.com/8728145/168338135-8db37af8-76c9-44aa-b9f6-0e3a1835481f.png">



# Pull Request Checklist

- [X] All pull requests should be __against the develop branch__, not master.
- [X] All pull requests must include the Contributor License Agreement (see below).
- [x] Whether or not your PR includes unit tests:
    - [X] Please make sure you have run the exact code contained in the PR locally, and it functions as desired.
    - [] Please make sure the TravisCI build passes or, if not, you've corrected any obvious problems identified by the tests.
- [X] Code should conform to the [Development Guidelines](http://awslimitchecker.readthedocs.org/en/latest/development.html#guidelines):
    - [X] pep8 compliant with some exceptions (see pytest.ini)
    - [X] 100% test coverage with pytest (with valid tests). If you have difficulty
      writing tests for the code, that's fine, just mention that in the summary and either
      ask for assistance, or clarify that you'd like someone else to handle the tests. PRs that
      include complete test coverage will usually be merged faster.
    - [X] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [X] documentation has been rebuilt with ``tox -e docs``
    - [X] Connections to the AWS services should only be made by the class's
      ``connect()`` and ``connect_resource()`` methods, inherited from
      [awslimitchecker.connectable.Connectable](http://awslimitchecker.readthedocs.org/en/latest/awslimitchecker.connectable.html)
    - [X] All modules should have (and use) module-level loggers.
    - [X] **Commit messages** should be meaningful, and reference the Issue number
      if you're working on a GitHub issue (i.e. "issue #x - <message>"). Please
      refrain from using the "fixes #x" notation unless you are *sure* that the
      the issue is fixed in that commit.
    - [X] Git history is fully intact; please do not squash or rewrite history.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.
