### PR TITLE
Fixes #384 - Add a percentage and current limit when running in report mode

### DIFF
--- a/awslimitchecker/__main__.py
+++ b/awslimitchecker/__main__.py
@@ -1,0 +1,20 @@
+# The idea of this file is to enable running the package with
+# `python -m awslimitchecker` or `python -m awslimitchecker [args]`.
+# This enables debugging the package when installed in editable mode
+# (`pip install -e .`) and running the package from the command line.
+
+import sys
+
+from . import runner
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    # Parse arguments and run your package's main functionality
+    print("Running awslimitchecker with arguments:", args)
+    runner.console_entry_point()
+
+
+if __name__ == "__main__":
+    main()

--- a/awslimitchecker/limit.py
+++ b/awslimitchecker/limit.py
@@ -431,9 +431,8 @@ class AwsLimit(object):
             limit = u.get_maximum() or self.get_limit()
             if limit is None or limit == 0:
                 continue
-            pct = (usage / (limit * 1.0)) * 100
+            pct = (usage / limit) * 100
             if crit_int is not None and usage >= crit_int:
-                self._criticals.append(u)
                 all_ok = False
             elif pct >= crit_pct:
                 self._criticals.append(u)

--- a/awslimitchecker/tests/test_limit.py
+++ b/awslimitchecker/tests/test_limit.py
@@ -602,23 +602,33 @@ class TestCheckThresholds(AwsLimitTester):
         assert mock_get_limit.mock_calls == [call(), call(), call()]
 
     def test_int_warn_crit(self):
-        limit = AwsLimit('limitname', self.mock_svc, 100, 1, 2)
-        u1 = AwsLimitUsage(limit, 4, resource_id='foo4bar')
-        u2 = AwsLimitUsage(limit, 1, resource_id='foo3bar')
-        u3 = AwsLimitUsage(limit, 7, resource_id='foo2bar')
+        limit = AwsLimit(
+            name='limitname',
+            service=self.mock_svc,
+            default_limit=10,
+            def_warning_threshold=40,
+            def_critical_threshold=60,
+        )
+        u1 = AwsLimitUsage(
+            limit=limit,
+            value=4,
+            resource_id='foo4bar',
+        )
+        u2 = AwsLimitUsage(
+            limit=limit,
+            value=1,
+            resource_id='foo3bar',
+        )
+        u3 = AwsLimitUsage(
+            limit=limit,
+            value=7,
+            resource_id='foo2bar',
+        )
         limit._current_usage = [u1, u2, u3]
-        with patch('awslimitchecker.limit.AwsLimit.'
-                   '_get_thresholds') as mock_get_thresh:
-            with patch('awslimitchecker.limit.AwsLimit.get_'
-                       'limit') as mock_get_limit:
-                mock_get_thresh.return_value = (4, 40, 6, 80)
-                mock_get_limit.return_value = 100
-                res = limit.check_thresholds()
+        res = limit.check_thresholds()
         assert res is False
         assert limit._warnings == [u1]
         assert limit._criticals == [u3]
-        assert mock_get_thresh.mock_calls == [call()]
-        assert mock_get_limit.mock_calls == [call(), call(), call()]
 
     def test_pct_crit(self):
         limit = AwsLimit('limitname', self.mock_svc, 100, 1, 2)
@@ -640,23 +650,33 @@ class TestCheckThresholds(AwsLimitTester):
         assert mock_get_limit.mock_calls == [call(), call(), call()]
 
     def test_int_crit(self):
-        limit = AwsLimit('limitname', self.mock_svc, 100, 1, 2)
-        u1 = AwsLimitUsage(limit, 9, resource_id='foo4bar')
-        u2 = AwsLimitUsage(limit, 3, resource_id='foo3bar')
-        u3 = AwsLimitUsage(limit, 95, resource_id='foo2bar')
+        limit = AwsLimit(
+            name='limitname',
+            service=self.mock_svc,
+            default_limit=10,
+            def_warning_threshold=60,
+            def_critical_threshold=80,
+        )
+        u1 = AwsLimitUsage(
+            limit=limit,
+            value=9,
+            resource_id='foo4bar',
+        )
+        u2 = AwsLimitUsage(
+            limit=limit,
+            value=3,
+            resource_id='foo3bar',
+        )
+        u3 = AwsLimitUsage(
+            limit=limit,
+            value=95,
+            resource_id='foo2bar',
+        )
         limit._current_usage = [u1, u2, u3]
-        with patch('awslimitchecker.limit.AwsLimit.'
-                   '_get_thresholds') as mock_get_thresh:
-            with patch('awslimitchecker.limit.AwsLimit.get_'
-                       'limit') as mock_get_limit:
-                mock_get_thresh.return_value = (6, 40, 8, 80)
-                mock_get_limit.return_value = 100
-                res = limit.check_thresholds()
+        res = limit.check_thresholds()
         assert res is False
         assert limit._warnings == []
         assert limit._criticals == [u1, u3]
-        assert mock_get_thresh.mock_calls == [call()]
-        assert mock_get_limit.mock_calls == [call(), call(), call()]
 
     def test_pct_warn_crit(self):
         limit = AwsLimit('limitname', self.mock_svc, 100, 1, 2)

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ requires = [
     'python-dateutil',
     'versionfinder>=0.1.1',
     'pytz',
-    'urllib3'
+    'urllib3',
+    'tabulate>=0.9.0',
 ]
 
 classifiers = [


### PR DESCRIPTION
# Summary


Fixes #384

The idea here is to improve the visualization of the reporting
by adding not only the usage, but the limit and how close to the
limit it is.

Also, to make it easier to read, print it all in a table format.

Example before:

```
EC2/All F Spot Instance Requests                                          0
EC2/All G Spot Instance Requests                                          0
EC2/All Inf Spot Instance Requests                                        0
EC2/All P Spot Instance Requests                                          0
EC2/All Standard (A, C, D, H, I, M, R, T, Z) Spot Instance Requests       0
EC2/All X Spot Instance Requests                                          0
EC2/Elastic IP addresses (EIPs)                                           0
EC2/Max active spot fleets per region                                     0
EC2/Max launch specifications per spot fleet                              <unknown>
EC2/Max target capacity for all spot fleets in region                     0
EC2/Max target capacity per spot fleet                                    <unknown>
EC2/Rules per VPC security group                                          max: sg-0648da97fdeebf980=102 (sg-0df2ad106237174ea=1, sg-07e5e4f72cea0dfe5=1, sg-0b9911c871252d8e7=1, sg-0d055747ec7c4140e=1, sg-09551693a5250b7f4=1, sg-0781c381e1b5d378a=1, sg-0fd94d543ec6cf4ee=1, sg-05e714614de7941cd=1, sg-03cc3b695a6366ffd=1, sg-083eae2676c6f8b92=1, sg-0dc2ee2f21505bf2c=1, sg-0e1729f5b07df6416=1, sg-0de5f793ac0da38e7=1, sg-0d79228bbb3f97b6d=1, sg-0c7bcbb474d8afbf5=1, sg-0d6aa6e6209d923b5=1, sg-086b6c19c0860460b=1, sg-0c56e7af849a12622=1, sg-086a3c13d414aef8b=1, sg-0853c55cd9df708de=1, sg-0e1ed9e1ceca720a1=1, sg-099ef683e4d35e2ee=1, sg-0adc28eb7faa40ecf=1, sg-0dabf1e2c30f5998f=1, sg-06aedf016149fbe14=1, sg-0f9148df50a48a291=1, sg-006e95a00de69f1b8=1, sg-0f9f697bf9ef106a5=1,
```

Example after:

```
┌──────────────────────────────────────────────────────────────────────────┬───────────────────────┬───────────┬───────────┬───────────┐
│ Service Limit                                                            │ Resource              │   Usage # │ Usage %   │ Limit     │
├──────────────────────────────────────────────────────────────────────────┼───────────────────────┼───────────┼───────────┼───────────┤
│ EC2/All F Spot Instance Requests                                         │ -                     │         0 │ 0 %       │ 128       │
│ EC2/All G Spot Instance Requests                                         │ -                     │         0 │ -         │ <unknown> │
│ EC2/All Inf Spot Instance Requests                                       │ -                     │         0 │ 0 %       │ 64        │
│ EC2/All P Spot Instance Requests                                         │ -                     │         0 │ -         │ <unknown> │
│ EC2/All Standard (A, C, D, H, I, M, R, T, Z) Spot Instance Requests      │ -                     │         0 │ 0 %       │ 640       │
│ EC2/All X Spot Instance Requests                                         │ -                     │         0 │ 0 %       │ 128       │
│ EC2/Elastic IP addresses (EIPs)                                          │ -                     │         0 │ -         │ <unknown> │
│ EC2/Max active spot fleets per region                                    │ -                     │         0 │ -         │ <unknown> │
│ EC2/Max target capacity for all spot fleets in region                    │ -                     │         0 │ -         │ <unknown> │
│ EC2/Rules per VPC security group                                         │ sg-058d83cc259d4e69c  │         3 │ 2 %       │ 120       │
│ EC2/Rules per VPC security group                                         │ sg-0783065c4d2b78c83  │         3 │ 2 %       │ 120       │
│ EC2/Rules per VPC security group                                         │ sg-0df2ad106237174ea  │         1 │ 1 %       │ 120       │
│ EC2/Rules per VPC security group                                         │ sg-07e5e4f72cea0dfe5  │         1 │ 1 %       │ 120       │
│ EC2/Rules per VPC security group                                         │ sg-0b9911c871252d8e7  │         1 │ 1 %       │ 120       │
│ EC2/Rules per VPC security group                                         │ sg-0229a5ed0b61ce2bd  │         2 │ 2 %       │ 120       │
│ EC2/Rules per VPC security group                                         │ sg-0b25ba5186ce99117  │         2 │ 2 %       │ 120       │
```

# Pull Request Checklist

- [x] All pull requests should be __against the develop branch__, not master.
- [x] All pull requests must include the Contributor License Agreement (see below).
- [x] Whether or not your PR includes unit tests:
    - [x] Please make sure you have run the exact code contained in the PR locally, and it functions as desired.
    - [ ] Please make sure the TravisCI build passes or, if not, you've corrected any obvious problems identified by the tests.
- [x] Code should conform to the [Development Guidelines](http://awslimitchecker.readthedocs.org/en/latest/development.html#guidelines):
    - [x] pep8 compliant with some exceptions (see pytest.ini)
    - [x] 100% test coverage with pytest (with valid tests). If you have difficulty
      writing tests for the code, that's fine, just mention that in the summary and either
      ask for assistance, or clarify that you'd like someone else to handle the tests. PRs that
      include complete test coverage will usually be merged faster.
    - [x] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [x] documentation has been rebuilt with ``tox -e docs``
    - [x] Connections to the AWS services should only be made by the class's
      ``connect()`` and ``connect_resource()`` methods, inherited from
      [awslimitchecker.connectable.Connectable](http://awslimitchecker.readthedocs.org/en/latest/awslimitchecker.connectable.html)
    - [x] All modules should have (and use) module-level loggers.
    - [x] **Commit messages** should be meaningful, and reference the Issue number
      if you're working on a GitHub issue (i.e. "issue #x - <message>"). Please
      refrain from using the "fixes #x" notation unless you are *sure* that the
      the issue is fixed in that commit.
    - [x] Git history is fully intact; please do not squash or rewrite history.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.
