### PR TITLE
Fix RDS storage quota "Units set to None" error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased Changes
+------------------
+
+* Fix ``Units set to "None"`` error when retrieving RDS "Total storage for all DB instances" quota from Service Quotas. AWS changed the quota unit from "Gigabytes" to "None" without announcement. We now allow both unit types (similar to the fix for ELB in Issue #503).
+
 .. _changelog.12_0_0:
 
 12.0.0 (2021-08-04)

--- a/awslimitchecker/services/rds.py
+++ b/awslimitchecker/services/rds.py
@@ -46,6 +46,24 @@ from ..limit import AwsLimit
 logger = logging.getLogger(__name__)
 
 
+def allow_gigabytes_or_none_units(value, in_unit, out_unit):
+    """
+    This is a unit converter for Service Quotas; see
+    :py:meth:`.ServiceQuotasClient.get_quota_value` for details.
+
+    This is a work-around for AWS changing the quota unit for "Total storage
+    for all DB instances" from "Gigabytes" to "None" without announcement.
+    This converter allows both options and treats them identically.
+    """
+    if in_unit not in ['None', 'Gigabytes'] or out_unit != 'Gigabytes':
+        logger.error(
+            'ERROR: cannot convert Service Quotas RDS storage limit value from '
+            'units of "%s" to units of "%s"', in_unit, out_unit
+        )
+        return None
+    return value
+
+
 class _RDSService(_AwsService):
 
     service_name = 'RDS'
@@ -172,7 +190,8 @@ class _RDSService(_AwsService):
             self.critical_threshold,
             limit_type='AWS::RDS::DBInstance',
             quotas_name='Total storage for all DB instances',
-            quotas_unit='Gigabytes'
+            quotas_unit='Gigabytes',
+            quotas_unit_converter=allow_gigabytes_or_none_units
         )
         limits['DB snapshots per user'] = AwsLimit(
             'DB snapshots per user',

--- a/awslimitchecker/tests/services/test_rds.py
+++ b/awslimitchecker/tests/services/test_rds.py
@@ -39,7 +39,7 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 
 import sys
 from awslimitchecker.tests.services import result_fixtures
-from awslimitchecker.services.rds import _RDSService
+from awslimitchecker.services.rds import _RDSService, allow_gigabytes_or_none_units
 
 # https://code.google.com/p/mock/issues/detail?id=249
 # py>=3.4 should use unittest.mock not the mock package on pypi
@@ -50,6 +50,18 @@ if (
     from mock import patch, call, Mock, DEFAULT
 else:
     from unittest.mock import patch, call, Mock, DEFAULT
+
+
+class TestAllowGigabytesOrNoneUnits:
+
+    def test_none(self):
+        assert allow_gigabytes_or_none_units(100, 'None', 'Gigabytes') == 100
+
+    def test_gigabytes(self):
+        assert allow_gigabytes_or_none_units(100, 'Gigabytes', 'Gigabytes') == 100
+
+    def test_other(self):
+        assert allow_gigabytes_or_none_units(100, 'Other', 'Gigabytes') is None
 
 
 class Test_RDSService(object):
@@ -96,6 +108,10 @@ class Test_RDSService(object):
             assert limit.service == cls
             assert limit.def_warning_threshold == 21
             assert limit.def_critical_threshold == 43
+            if name == 'Storage quota (GB)':
+                assert limit.quotas_unit_converter == allow_gigabytes_or_none_units
+            else:
+                assert limit.quotas_unit_converter is None
 
     def test_get_limits_again(self):
         """test that existing limits dict is returned on subsequent calls"""


### PR DESCRIPTION
# Summary

Fix "Units set to "None"" error when retrieving RDS "Total storage for all DB instances" quota from Service Quotas. AWS changed the quota unit from "Gigabytes" to "None" without announcement, similar to the ELB issue fixed in #503. This PR adds a unit converter that accepts both "Gigabytes" and "None" units.

# Pull Request Checklist

- [x] All pull requests should be __against the develop branch__, not master.
- [x] All pull requests must include the Contributor License Agreement (see below).
- [x] Whether or not your PR includes unit tests:
    - [x] Please make sure you have run the exact code contained in the PR locally, and it functions as desired.
    - [x] Please make sure the TravisCI build passes or, if not, you've corrected any obvious problems identified by the tests.
- [x] Code should conform to the Development Guidelines:
    - [x] pep8 compliant with some exceptions (see pytest.ini)
    - [x] 100% test coverage with pytest (with valid tests) - all 12 tests passing
    - [x] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [ ] documentation has been rebuilt with ``tox -e docs`` - unable to run locally due to Python 3.9 vs 3.11 version mismatch, but no documentation structure changes were made
    - [x] Connections to the AWS services use proper methods
    - [x] All modules have module-level loggers.
    - [x] **Commit messages** are meaningful
    - [x] Git history is fully intact; no squashing or rewriting.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.