### PR TITLE
Add Prometheus AlertManager alert provider with full test coverage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased Changes
+------------------
+
+* `PR #515 <https://github.com/jantman/awslimitchecker/pull/515>`__ - Add Prometheus AlertManager alert provider with comprehensive test coverage. Supports sending alerts to AlertManager with configurable endpoints, alert duration, and basic authentication. Example usage: ``--alert-provider=AlertManager --alert-config=endpoints=http://alertmanager1:9093,http://alertmanager2:9093``. Thanks to `varuzam <https://github.com/varuzam>`__ for the original implementation.
+
 .. _changelog.12_0_0:
 
 12.0.0 (2021-08-04)

--- a/awslimitchecker/alerts/__init__.py
+++ b/awslimitchecker/alerts/__init__.py
@@ -40,3 +40,4 @@ Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
 from .base import AlertProvider
 from .dummy import Dummy
 from .pagerdutyv1 import PagerDutyV1
+from .alertmanager import AlertManager

--- a/awslimitchecker/alerts/alertmanager.py
+++ b/awslimitchecker/alerts/alertmanager.py
@@ -1,0 +1,240 @@
+"""
+awslimitchecker/alerts/alertmanager.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2015-2019 Jason Antman <jason@jasonantman.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/awslimitchecker> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+################################################################################
+"""
+import os
+import logging
+import urllib3
+from base64 import b64encode
+from datetime import datetime, timedelta
+
+from .base import AlertProvider
+from awslimitchecker.utils import issue_string_tuple
+
+logger = logging.getLogger(__name__)
+
+
+class AlertManager(AlertProvider):
+    """
+    Alert provider to send notifications to AlertManager.
+    """
+
+    def __init__(
+        self, region_name: str, endpoints: str = None, alert_duration='1800',
+        basic_auth_username: str = None, basic_auth_password: str = None
+    ):
+        """
+        Initialize AlertManager alert provider.
+
+        :param region_name: the name of the region we're connected to
+        :type region_name: str
+        :param endpoints: **Required**; the AlertManager endpoints
+          (ex. endpoints=http://alertmanager1:9093,http://alertmanager2:9093)
+          env: ``ALERTMANAGER_ENDPOINTS``
+        :type endpoints: str
+        :param alert_duration: **Optional**; seconds before AlertManager
+          considers alerts are resolved. Set it more then period between the
+          program runs. env: ALERTMANAGER_ALERT_DURATION
+        :type alert_duration: int
+        :param basic_auth_username: **Optional**; Can also be specified via the
+          ``ALERTMANAGER_BASIC_AUTH_USERNAME`` environment variable.
+        :type basic_auth_username: str
+        :param basic_auth_password: **Optional**; Can also be specified via the
+          ``ALERTMANAGER_BASIC_AUTH_PASSWORD`` environment variable.
+        :type basic_auth_password: str
+        """
+        super().__init__(region_name)
+
+        self._endpoints = os.environ.get('ALERTMANAGER_ENDPOINTS') or endpoints
+        if self._endpoints is None:
+            raise RuntimeError(
+                'ERROR: AlertManager alert provider requires '
+                'endpoints parameter or ALERTMANAGER_ENDPOINTS '
+                'environment variable.'
+            )
+        self._alert_duration = os.environ.get(
+            'ALERTMANAGER_ALERT_DURATION'
+        ) or alert_duration
+        self._basic_auth_username = os.environ.get(
+            'ALERTMANAGER_BASIC_AUTH_USERNAME'
+        ) or basic_auth_username
+        self._basic_auth_password = os.environ.get(
+            'ALERTMANAGER_BASIC_AUTH_PASSWORD'
+        ) or basic_auth_password
+
+    def _send_event(self, severity: str, description: str):
+        """
+        Send an event to AlertManager.
+
+        :param severity: event severity
+        :type severity: str
+        :param description: event description
+        :type description: str
+        """
+        # region in the label 'instance' due to currently awslimitchecker
+        # supports only check per region and grouping by instance is default
+        # behavior in alertmanager.
+        # datetime in UTC format to simplify the code
+        event = '''[{
+                    "labels": {
+                       "alertname": "AWSServiceLimitExceeded",
+                       "instance": "%s",
+                       "severity": "%s"
+                    },
+                    "annotations": {
+                       "description": "%s"
+                    },
+                    "endsAt": "%s"
+                }]''' % (
+            self._region_name,
+            severity,
+            description,
+            (
+                datetime.utcnow() + timedelta(seconds=float(self._alert_duration))
+            ).isoformat() + 'Z'
+        )
+
+        http = urllib3.PoolManager()
+        success = 0
+        for endpoint in self._endpoints.split(","):
+            url = endpoint + '/api/v1/alerts'
+            logger.info(
+                'POSTing to AlertManager API (%s): %s', url, event
+            )
+            try:
+                auth = '%s:%s' % (
+                    self._basic_auth_username, self._basic_auth_password
+                )
+                resp = http.request(
+                    'POST', url,
+                    headers={
+                        'Content-type': 'application/json',
+                        'Authorization': 'Basic %s' % b64encode(
+                            auth.encode()
+                        ).decode()
+                    },
+                    body=event
+                )
+                if resp.status == 200:
+                    logger.debug(
+                        'Successfully POSTed to %s: %s %s',
+                        url, resp.status, resp.data
+                    )
+                    success += 1
+                else:
+                    logger.error(
+                        'Unsuccessfully POSTed to %s: %s %s',
+                        url, resp.status, resp.data
+                    )
+            except urllib3.exceptions.MaxRetryError as e:
+                logger.error(e)
+
+        if success == 0:
+            raise RuntimeError(
+                'Alert was not able to be sent to %s' % self._endpoints
+            )
+
+    def _generate_description(self, problems) -> str:
+        """
+        Generate description from dict of problems for an event
+
+        :param problems: dict of service name to nested dict of limit name to
+          limit, same format as the return value of
+          :py:meth:`~.AwsLimitChecker.check_thresholds`. ``None`` if ``exc`` is
+          specified.
+        :type problems: dict
+        :return: description string for Event
+        :rtype: str
+        """
+        desc = ''
+        for svc in sorted(problems.keys()):
+            for limit_name in sorted(problems[svc].keys()):
+                limit = problems[svc][limit_name]
+                warns = limit.get_warnings()
+                crits = limit.get_criticals()
+                _, v = issue_string_tuple(
+                    svc, limit, crits, warns, colorize=False
+                )
+                desc += f'{svc}/{limit_name} {v}. '
+        return desc
+
+    def on_success(self, duration=None):
+        # AlertManager does not require an event with success
+        pass
+
+    def on_critical(self, problems, problem_str, exc=None, duration=None):
+        """
+        Method called when the run encountered errors, or at least one critical
+        threshold was met or crossed.
+
+        :param problems: dict of service name to nested dict of limit name to
+          limit, same format as the return value of
+          :py:meth:`~.AwsLimitChecker.check_thresholds`. ``None`` if ``exc`` is
+          specified.
+        :type problems: dict or None
+        :param problem_str: String representation of ``problems``, as displayed
+          in ``awslimitchecker`` command line output. ``None`` if ``exc`` is
+          specified.
+        :type problem_str: str or None
+        :param exc: Exception object that was raised during the run (optional)
+        :type exc: Exception
+        :param duration: duration of the run
+        :type duration: float
+        """
+        if exc:
+            # crash if exception arrives. The script health should be monitored from outside
+            raise exc
+        else:
+            description = self._generate_description(problems)
+        self._send_event("critical", description)
+
+    def on_warning(self, problems, problem_str, duration=None):
+        """
+        Method called when one or more warning thresholds were crossed, but no
+        criticals and the run did not encounter any errors.
+
+        :param problems: dict of service name to nested dict of limit name to
+          limit, same format as the return value of
+          :py:meth:`~.AwsLimitChecker.check_thresholds`.
+        :type problems: dict or None
+        :param problem_str: String representation of ``problems``, as displayed
+          in ``awslimitchecker`` command line output.
+        :type problem_str: str or None
+        :param duration: duration of the run
+        :type duration: float
+        """
+        self._send_event("warning", self._generate_description(problems))

--- a/awslimitchecker/tests/alerts/test_alertmanager.py
+++ b/awslimitchecker/tests/alerts/test_alertmanager.py
@@ -1,0 +1,327 @@
+"""
+awslimitchecker/tests/alerts/test_alertmanager.py
+
+The latest version of this package is available at:
+<https://github.com/jantman/awslimitchecker>
+
+################################################################################
+Copyright 2015-2019 Jason Antman <jason@jasonantman.com>
+
+    This file is part of awslimitchecker, also known as awslimitchecker.
+
+    awslimitchecker is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    awslimitchecker is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with awslimitchecker.  If not, see <http://www.gnu.org/licenses/>.
+
+The Copyright and Authors attributions contained herein may not be removed or
+otherwise altered, except to add the Author attribution of a contributor to
+this work. (Additional Terms pursuant to Section 7b of the AGPL v3)
+################################################################################
+While not legally required, I sincerely request that anyone who finds
+bugs please submit them at <https://github.com/jantman/awslimitchecker> or
+to me via email, and that you send any contributions or improvements
+either as a pull request on GitHub, or to me via email.
+################################################################################
+
+AUTHORS:
+Jason Antman <jason@jasonantman.com> <http://www.jasonantman.com>
+################################################################################
+"""
+
+import sys
+from awslimitchecker.alerts.alertmanager import AlertManager
+from awslimitchecker.limit import AwsLimit, AwsLimitUsage
+import pytest
+from datetime import datetime, timedelta
+
+# https://code.google.com/p/mock/issues/detail?id=249
+# py>=3.4 should use unittest.mock not the mock package on pypi
+if (
+        sys.version_info[0] < 3 or
+        sys.version_info[0] == 3 and sys.version_info[1] < 4
+):
+    from mock import patch, call, Mock, DEFAULT
+else:
+    from unittest.mock import patch, call, Mock, DEFAULT
+
+pbm = 'awslimitchecker.alerts.alertmanager'
+pb = '%s.AlertManager' % pbm
+
+
+class TestInit(object):
+
+    @patch.dict(
+        'os.environ',
+        {'ALERTMANAGER_ENDPOINTS': 'http://alertmanager:9093'},
+        clear=True
+    )
+    def test_env_var_only(self):
+        cls = AlertManager('us-east-1')
+        assert cls._region_name == 'us-east-1'
+        assert cls._endpoints == 'http://alertmanager:9093'
+        assert cls._alert_duration == '1800'
+        assert cls._basic_auth_username is None
+        assert cls._basic_auth_password is None
+
+    @patch.dict('os.environ', {}, clear=True)
+    def test_param_only(self):
+        cls = AlertManager('us-west-2', endpoints='http://alertmanager1:9093')
+        assert cls._region_name == 'us-west-2'
+        assert cls._endpoints == 'http://alertmanager1:9093'
+        assert cls._alert_duration == '1800'
+
+    @patch.dict(
+        'os.environ',
+        {
+            'ALERTMANAGER_ENDPOINTS': 'http://alertmanager:9093',
+            'ALERTMANAGER_ALERT_DURATION': '3600',
+            'ALERTMANAGER_BASIC_AUTH_USERNAME': 'user',
+            'ALERTMANAGER_BASIC_AUTH_PASSWORD': 'pass'
+        },
+        clear=True
+    )
+    def test_all_env_vars(self):
+        cls = AlertManager('eu-west-1')
+        assert cls._region_name == 'eu-west-1'
+        assert cls._endpoints == 'http://alertmanager:9093'
+        assert cls._alert_duration == '3600'
+        assert cls._basic_auth_username == 'user'
+        assert cls._basic_auth_password == 'pass'
+
+    @patch.dict('os.environ', {}, clear=True)
+    def test_all_params(self):
+        cls = AlertManager(
+            'us-east-1',
+            endpoints='http://alertmanager1:9093,http://alertmanager2:9093',
+            alert_duration='7200',
+            basic_auth_username='testuser',
+            basic_auth_password='testpass'
+        )
+        assert cls._region_name == 'us-east-1'
+        assert cls._endpoints == 'http://alertmanager1:9093,http://alertmanager2:9093'
+        assert cls._alert_duration == '7200'
+        assert cls._basic_auth_username == 'testuser'
+        assert cls._basic_auth_password == 'testpass'
+
+    @patch.dict('os.environ', {}, clear=True)
+    def test_no_endpoints(self):
+        with pytest.raises(RuntimeError) as exc:
+            AlertManager('us-east-1')
+        assert str(exc.value) == 'ERROR: AlertManager alert provider requires ' \
+                                 'endpoints parameter or ALERTMANAGER_ENDPOINTS ' \
+                                 'environment variable.'
+
+
+class AlertManagerTester(object):
+
+    def setup(self):
+        with patch('%s.__init__' % pb) as m_init:
+            m_init.return_value = None
+            self.cls = AlertManager('us-east-1')
+            self.cls._region_name = 'us-east-1'
+            self.cls._endpoints = 'http://alertmanager:9093'
+            self.cls._alert_duration = '1800'
+            self.cls._basic_auth_username = 'user'
+            self.cls._basic_auth_password = 'pass'
+
+
+class TestSendEvent(AlertManagerTester):
+
+    def test_success_single_endpoint(self):
+        mock_http = Mock()
+        mock_resp = Mock(status=200, data='{"status":"success"}')
+        mock_http.request.return_value = mock_resp
+        
+        with patch('%s.urllib3.PoolManager' % pbm) as mock_pm:
+            with patch('%s.datetime' % pbm) as mock_dt:
+                mock_now = datetime(2025, 1, 15, 12, 0, 0)
+                mock_dt.utcnow.return_value = mock_now
+                mock_pm.return_value = mock_http
+                self.cls._send_event('critical', 'Test alert')
+        
+        # Verify the request was made
+        assert len(mock_http.request.mock_calls) == 1
+        call_args = mock_http.request.mock_calls[0]
+        assert call_args[1][0] == 'POST'
+        assert call_args[1][1] == 'http://alertmanager:9093/api/v1/alerts'
+
+    def test_success_multiple_endpoints(self):
+        self.cls._endpoints = 'http://alertmanager1:9093,http://alertmanager2:9093'
+        mock_http = Mock()
+        mock_resp = Mock(status=200, data='{"status":"success"}')
+        mock_http.request.return_value = mock_resp
+        
+        with patch('%s.urllib3.PoolManager' % pbm) as mock_pm:
+            with patch('%s.datetime' % pbm) as mock_dt:
+                mock_now = datetime(2025, 1, 15, 12, 0, 0)
+                mock_dt.utcnow.return_value = mock_now
+                mock_pm.return_value = mock_http
+                self.cls._send_event('warning', 'Test warning')
+        
+        # Should make 2 requests (one per endpoint)
+        assert len(mock_http.request.mock_calls) == 2
+
+    def test_failure_non_200(self):
+        mock_http = Mock()
+        mock_resp = Mock(status=500, data='{"error":"internal error"}')
+        mock_http.request.return_value = mock_resp
+        
+        with patch('%s.urllib3.PoolManager' % pbm) as mock_pm:
+            with patch('%s.datetime' % pbm) as mock_dt:
+                mock_now = datetime(2025, 1, 15, 12, 0, 0)
+                mock_dt.utcnow.return_value = mock_now
+                mock_pm.return_value = mock_http
+                with pytest.raises(RuntimeError) as exc:
+                    self.cls._send_event('critical', 'Test alert')
+        
+        assert 'Alert was not able to be sent' in str(exc.value)
+
+    def test_failure_max_retry_error(self):
+        import urllib3
+        mock_http = Mock()
+        mock_http.request.side_effect = urllib3.exceptions.MaxRetryError(
+            pool=None, url='http://alertmanager:9093'
+        )
+        
+        with patch('%s.urllib3.PoolManager' % pbm) as mock_pm:
+            with patch('%s.datetime' % pbm) as mock_dt:
+                mock_now = datetime(2025, 1, 15, 12, 0, 0)
+                mock_dt.utcnow.return_value = mock_now
+                mock_pm.return_value = mock_http
+                with pytest.raises(RuntimeError) as exc:
+                    self.cls._send_event('critical', 'Test alert')
+        
+        assert 'Alert was not able to be sent' in str(exc.value)
+
+    def test_partial_success_multiple_endpoints(self):
+        self.cls._endpoints = 'http://alertmanager1:9093,http://alertmanager2:9093'
+        mock_http = Mock()
+        # First succeeds, second fails
+        mock_http.request.side_effect = [
+            Mock(status=200, data='{"status":"success"}'),
+            Mock(status=500, data='{"error":"failed"}')
+        ]
+        
+        with patch('%s.urllib3.PoolManager' % pbm) as mock_pm:
+            with patch('%s.datetime' % pbm) as mock_dt:
+                mock_now = datetime(2025, 1, 15, 12, 0, 0)
+                mock_dt.utcnow.return_value = mock_now
+                mock_pm.return_value = mock_http
+                # Should not raise since at least one succeeded
+                self.cls._send_event('critical', 'Test alert')
+
+
+class TestGenerateDescription(AlertManagerTester):
+
+    def test_single_problem(self):
+        mock_service = Mock()
+        limit = AwsLimit('Test Limit', mock_service, 100, 80, 99)
+        limit._set_api_limit(100)
+        usage = AwsLimitUsage(limit, 95)
+        limit._warnings = [usage]
+        
+        problems = {
+            'EC2': {
+                'Test Limit': limit
+            }
+        }
+        
+        result = self.cls._generate_description(problems)
+        assert 'EC2/Test Limit' in result
+        assert '(limit 100)' in result
+        assert 'WARNING: 95' in result
+
+    def test_multiple_problems(self):
+        mock_service = Mock()
+        limit1 = AwsLimit('Limit 1', mock_service, 100, 80, 99)
+        limit1._set_api_limit(100)
+        usage1 = AwsLimitUsage(limit1, 95)
+        limit1._warnings = [usage1]
+        
+        limit2 = AwsLimit('Limit 2', mock_service, 50, 80, 99)
+        limit2._set_api_limit(50)
+        usage2 = AwsLimitUsage(limit2, 48)
+        limit2._criticals = [usage2]
+        
+        problems = {
+            'EC2': {
+                'Limit 1': limit1,
+                'Limit 2': limit2
+            }
+        }
+        
+        result = self.cls._generate_description(problems)
+        assert 'EC2/Limit 1' in result
+        assert 'EC2/Limit 2' in result
+        assert 'WARNING: 95' in result
+        assert 'CRITICAL: 48' in result
+
+
+class TestOnSuccess(AlertManagerTester):
+
+    def test_on_success(self):
+        # Should do nothing
+        self.cls.on_success(duration=1.23)
+        # No exception means success
+
+
+class TestOnCritical(AlertManagerTester):
+
+    def test_with_exception(self):
+        exc = Exception('Test exception')
+        with pytest.raises(Exception) as raised_exc:
+            self.cls.on_critical(None, None, exc=exc, duration=1.0)
+        assert raised_exc.value == exc
+
+    def test_with_problems(self):
+        mock_service = Mock()
+        limit = AwsLimit('Test Limit', mock_service, 100, 80, 99)
+        limit._set_api_limit(100)
+        usage = AwsLimitUsage(limit, 99)
+        limit._criticals = [usage]
+        
+        problems = {
+            'EC2': {
+                'Test Limit': limit
+            }
+        }
+        
+        with patch.object(self.cls, '_send_event') as mock_send:
+            self.cls.on_critical(problems, 'problem_str', duration=1.0)
+        
+        assert mock_send.call_count == 1
+        assert mock_send.call_args[0][0] == 'critical'
+        assert 'EC2/Test Limit' in mock_send.call_args[0][1]
+
+
+class TestOnWarning(AlertManagerTester):
+
+    def test_on_warning(self):
+        mock_service = Mock()
+        limit = AwsLimit('Test Limit', mock_service, 100, 80, 99)
+        limit._set_api_limit(100)
+        usage = AwsLimitUsage(limit, 85)
+        limit._warnings = [usage]
+        
+        problems = {
+            'RDS': {
+                'Test Limit': limit
+            }
+        }
+        
+        with patch.object(self.cls, '_send_event') as mock_send:
+            self.cls.on_warning(problems, 'problem_str', duration=2.5)
+        
+        assert mock_send.call_count == 1
+        assert mock_send.call_args[0][0] == 'warning'
+        assert 'RDS/Test Limit' in mock_send.call_args[0][1]
+


### PR DESCRIPTION
# Summary

This PR adds comprehensive test coverage to complete PR #515 by @varuzam.

The original PR #515 implements the AlertManager alert provider with support for:
- Single and multiple AlertManager endpoints
- Environment variable and parameter-based configuration
- Basic authentication
- Alert sending with configurable duration

This PR adds the missing unit tests (16 comprehensive tests) to allow the feature to be merged.

Minor fix: `endpoints` parameter was incorrectly required in `__init__` - now properly optional when using environment variables.

# Pull Request Checklist

- [x] All pull requests should be __against the develop branch__, not master.
- [x] All pull requests must include the Contributor License Agreement (see below).
- [x] Whether or not your PR includes unit tests:
    - [x] Please make sure you have run the exact code contained in the PR locally, and it functions as desired.
    - [x] Please make sure the TravisCI build passes or, if not, you've corrected any obvious problems identified by the tests.
- [x] Code should conform to the Development Guidelines:
    - [x] pep8 compliant with some exceptions (see pytest.ini)
    - [x] 100% test coverage with pytest (with valid tests) - 16 tests covering all AlertManager functionality
    - [x] Complete, correctly-formatted documentation for all classes, functions and methods.
    - [ ] documentation has been rebuilt with ``tox -e docs`` (requires Python 3.9, will be handled by CI)
    - [x] Connections to the AWS services - N/A (AlertManager is an alert provider, not AWS service)
    - [x] All modules should have (and use) module-level loggers.
    - [x] **Commit messages** should be meaningful, and reference the Issue number
    - [x] Git history is fully intact; please do not squash or rewrite history.

## Contributor License Agreement

By submitting this work for inclusion in awslimitchecker, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the awslimitchecker project (the Affero GPL v3,
  or any subsequent version of that license if adopted by awslimitchecker).
* My contribution may perpetually be included in and distributed with awslimitchecker; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of awslimitchecker's license.
* I have the legal power and rights to agree to these terms.